### PR TITLE
langchain_oci bugfix: include ToolMessages in chat history

### DIFF
--- a/libs/oci/langchain_oci/__init__.py
+++ b/libs/oci/langchain_oci/__init__.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
 from langchain_oci.chat_models.oci_data_science import (
     ChatOCIModelDeployment,
     ChatOCIModelDeploymentTGI,
-    ChatOCIModelDeploymentVLLM
+    ChatOCIModelDeploymentVLLM,
+)
+from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
+from langchain_oci.embeddings.oci_data_science_model_deployment_endpoint import (
+    OCIModelDeploymentEndpointEmbeddings,
 )
 from langchain_oci.embeddings.oci_generative_ai import OCIGenAIEmbeddings
-from langchain_oci.embeddings.oci_data_science_model_deployment_endpoint import OCIModelDeploymentEndpointEmbeddings
 from langchain_oci.llms.oci_data_science_model_deployment_endpoint import (
     BaseOCIModelDeployment,
     OCIModelDeploymentLLM,

--- a/libs/oci/langchain_oci/chat_models/__init__.py
+++ b/libs/oci/langchain_oci/chat_models/__init__.py
@@ -4,8 +4,13 @@
 from langchain_oci.chat_models.oci_data_science import (
     ChatOCIModelDeployment,
     ChatOCIModelDeploymentTGI,
-    ChatOCIModelDeploymentVLLM
+    ChatOCIModelDeploymentVLLM,
 )
 from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
 
-__all__ = ["ChatOCIGenAI", "ChatOCIModelDeployment", "ChatOCIModelDeploymentTGI", "ChatOCIModelDeploymentVLLM"]
+__all__ = [
+    "ChatOCIGenAI",
+    "ChatOCIModelDeployment",
+    "ChatOCIModelDeploymentTGI",
+    "ChatOCIModelDeploymentVLLM",
+]

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -51,6 +51,7 @@ from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResu
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_function
+from oci.generative_ai_inference import models
 from pydantic import BaseModel, ConfigDict
 
 from langchain_oci.llms.oci_generative_ai import OCIGenAIBase
@@ -360,6 +361,19 @@ class CohereProvider(Provider):
                 oci_chat_history.append(
                     self.oci_chat_message[role](
                         message=msg_content, tool_calls=tool_calls
+                    )
+                )
+            elif isinstance(msg, ToolMessage):
+                oci_chat_history.append(
+                    self.oci_chat_message[self.get_role(msg)](
+                        tool_results=[
+                            models.CohereToolResult(
+                                call=models.CohereToolCall(
+                                    name=msg.name, parameters={}
+                                ),
+                                outputs=[{"output": msg.content}],
+                            )
+                        ],
                     )
                 )
 

--- a/libs/oci/langchain_oci/embeddings/__init__.py
+++ b/libs/oci/langchain_oci/embeddings/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-from langchain_oci.embeddings.oci_data_science_model_deployment_endpoint import OCIModelDeploymentEndpointEmbeddings
+from langchain_oci.embeddings.oci_data_science_model_deployment_endpoint import (
+    OCIModelDeploymentEndpointEmbeddings,
+)
 from langchain_oci.embeddings.oci_generative_ai import OCIGenAIEmbeddings
 
 __all__ = ["OCIModelDeploymentEndpointEmbeddings", "OCIGenAIEmbeddings"]

--- a/libs/oci/langchain_oci/embeddings/oci_data_science_model_deployment_endpoint.py
+++ b/libs/oci/langchain_oci/embeddings/oci_data_science_model_deployment_endpoint.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+from typing import Any, Callable, Dict, List, Mapping, Optional
+
+import requests
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models.llms import create_base_retry_decorator
 from langchain_core.utils import get_from_dict_or_env
 from pydantic import BaseModel, Field, model_validator
-import requests
-from typing import Any, Callable, Dict, List, Mapping, Optional
-
 
 DEFAULT_HEADER = {
     "Content-Type": "application/json",
@@ -39,7 +39,7 @@ class OCIModelDeploymentEndpointEmbeddings(BaseModel, Embeddings):
             embeddings = OCIModelDeploymentEndpointEmbeddings(
                 endpoint="https://modeldeployment.us-ashburn-1.oci.customer-oci.com/<md_ocid>/predict",
             )
-    """ # noqa: E501
+    """  # noqa: E501
 
     auth: dict = Field(default_factory=dict, exclude=True)
     """ADS auth dictionary for OCI authentication:

--- a/libs/oci/langchain_oci/embeddings/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/embeddings/oci_generative_ai.py
@@ -143,13 +143,13 @@ class OCIGenAIEmbeddings(BaseModel, Embeddings):
                     oci_config=client_kwargs["config"]
                 )
             elif values["auth_type"] == OCIAuthType(3).name:
-                client_kwargs[
-                    "signer"
-                ] = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+                client_kwargs["signer"] = (
+                    oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+                )
             elif values["auth_type"] == OCIAuthType(4).name:
-                client_kwargs[
-                    "signer"
-                ] = oci.auth.signers.get_resource_principals_signer()
+                client_kwargs["signer"] = (
+                    oci.auth.signers.get_resource_principals_signer()
+                )
             else:
                 raise ValueError("Please provide valid value to auth_type")
 

--- a/libs/oci/langchain_oci/llms/oci_data_science_model_deployment_endpoint.py
+++ b/libs/oci/langchain_oci/llms/oci_data_science_model_deployment_endpoint.py
@@ -3,10 +3,10 @@
 
 """LLM for OCI data science model deployment endpoint."""
 
-from contextlib import asynccontextmanager
 import json
 import logging
 import traceback
+from contextlib import asynccontextmanager
 from typing import (
     Any,
     AsyncGenerator,
@@ -793,6 +793,7 @@ class OCIModelDeploymentTGI(OCIModelDeploymentLLM):
             )
 
     """
+
     max_tokens: int = 256
     """Denotes the number of tokens to predict per generation."""
 
@@ -943,6 +944,7 @@ class OCIModelDeploymentVLLM(OCIModelDeploymentLLM):
             )
 
     """
+
     max_tokens: int = 256
     """Denotes the number of tokens to predict per generation."""
 

--- a/libs/oci/langchain_oci/llms/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/llms/oci_generative_ai.py
@@ -22,12 +22,10 @@ CUSTOM_ENDPOINT_PREFIX = "ocid1.generativeaiendpoint"
 class Provider(ABC):
     @property
     @abstractmethod
-    def stop_sequence_key(self) -> str:
-        ...
+    def stop_sequence_key(self) -> str: ...
 
     @abstractmethod
-    def completion_response_to_text(self, response: Any) -> str:
-        ...
+    def completion_response_to_text(self, response: Any) -> str: ...
 
 
 class CohereProvider(Provider):
@@ -159,13 +157,13 @@ class OCIGenAIBase(BaseModel, ABC):
                     oci_config=client_kwargs["config"]
                 )
             elif values["auth_type"] == OCIAuthType(3).name:
-                client_kwargs[
-                    "signer"
-                ] = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+                client_kwargs["signer"] = (
+                    oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+                )
             elif values["auth_type"] == OCIAuthType(4).name:
-                client_kwargs[
-                    "signer"
-                ] = oci.auth.signers.get_resource_principals_signer()
+                client_kwargs["signer"] = (
+                    oci.auth.signers.get_resource_principals_signer()
+                )
             else:
                 raise ValueError(
                     "Please provide valid value to auth_type, "

--- a/libs/oci/tests/unit_tests/embeddings/test_oci_model_deployment_endpoint.py
+++ b/libs/oci/tests/unit_tests/embeddings/test_oci_model_deployment_endpoint.py
@@ -1,8 +1,9 @@
 """Test OCI Data Science Model Deployment Endpoint."""
 
-import responses
 import pytest
+import responses
 from pytest_mock import MockerFixture
+
 from langchain_oci.embeddings import OCIModelDeploymentEndpointEmbeddings
 
 
@@ -17,11 +18,7 @@ def test_embedding_call(mocker: MockerFixture) -> None:
         responses.POST,
         endpoint,
         json={
-            "data": [
-                {
-                    "embedding": expected_output
-                }
-            ],
+            "data": [{"embedding": expected_output}],
         },
         status=200,
     )


### PR DESCRIPTION
This PR fixes a bug in the langchain integration as ToolMessages are NOT included in the chat history. 
This leads to issues with follow-up questions where the ToolMessage content is not available in the history context for the LLM to infer from.

HOWEVER, note that there is another issue with the GenAI inference service that currently would make this bugfix FAIL with Cohere Command R/R+ (`cohere.command-r-plus-08-2024`) and Command A (`cohere.command-a-03-2025`) models, in the case where a HumanMessage follows a ToolMessage.
This is a specific use-case when using the `@tool(return_direct=True)` annotation for the tool to return direct (i.e. without another pass to the LLM to rephrase the content of the tool output). This error is not currently raised because the ToolMessages are being stripped out, so it is never the case.

With this bugfix, and in the conditions above, we get:

```
oci.exceptions.ServiceError: {'target_service': 'generative_ai_inference', 'status': 400, 'code': '400', 'opc-request-id': '', 'message': '{"message":"invalid request: cannot specify message if the last entry in chat history contains tool results"}
```

This secondary issue is being worked on by OCI and should be resolved by mid August, so this fix can be safely applied after that date for all use-cases.