### PR TITLE
create dummy AIMessage repeating ToolMessage

### DIFF
--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -365,9 +365,12 @@ class CohereProvider(Provider):
 
         # Process current turn messages in reverse order until a HumanMessage
         current_turn = []
-        for message in reversed(messages):
+        for i, message in enumerate(messages[::-1]):
             current_turn.append(message)
             if isinstance(message, HumanMessage):
+                if len(messages) > i and isinstance(messages[len(messages) - i - 2], ToolMessage):
+                    # add dummy message REPEATING the tool_result to avoid the error about ToolMessage needing to be followed by an AI message
+                    oci_chat_history.append(self.oci_chat_message['CHATBOT'](message=messages[len(messages) - i - 2].content))
                 break
         current_turn = list(reversed(current_turn))
 


### PR DESCRIPTION
create dummy AIMessage repeating ToolMessage results to circumvent the issue with ToolMessages being stripped out.

See #10 
