### PR TITLE
Use MetaProvider for xai and openai models.

### DIFF
--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -1018,6 +1018,8 @@ class ChatOCIGenAI(BaseChatModel, OCIGenAIBase):
         return {
             "cohere": CohereProvider(),
             "meta": MetaProvider(),
+            "xai": MetaProvider(),
+            "openai": MetaProvider(),
         }
 
     @property

--- a/libs/oci/langchain_oci/llms/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/llms/oci_generative_ai.py
@@ -269,6 +269,8 @@ class OCIGenAI(LLM, OCIGenAIBase):
         return {
             "cohere": CohereProvider(),
             "meta": MetaProvider(),
+            "xai": MetaProvider(),
+            "openai": MetaProvider(),
         }
 
     @property


### PR DESCRIPTION
As part of ongoing enhancements, the OCI Generative AI Service is introducing additional models from xAI and OpenAI. These new models adhere to the same API specifications as the Meta models; however, the existing implementation does not automatically derive the associated `provider` for xAI or OpenAI models.

The `MetaProvider` provider can be used for xAI and OpenAI models provided by the OCI Generative AI service.
This PR adds a simple change to automatically use `MetaProvider` when user is using xAI or OpenAI models.