### PR TITLE
Remove unneeded deps

### DIFF
--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -12,8 +12,8 @@ license = "UPL"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-core = "<1.0.0,>=0.3.66"
-langchain = "<1.0.0,>=0.3.26"
+langchain-core = ">=0.3.20,<1.0.0"
+langchain = ">=0.3.20,<1.0.0"
 oci = ">=2.139.0"
 pydantic = ">=2,<3"
 # aiohttp = ">=3.12.14"

--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-oci"
-version = "0.1.3"
+version = "0.1.4"
 description = "An integration package connecting OCI and LangChain"
 authors = []
 readme = "README.md"
@@ -12,10 +12,11 @@ license = "UPL"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-core = ">=0.3.15,<0.4"
-oci = ">=2.155.1"
+langchain-core = "<1.0.0,>=0.3.66"
+langchain = "<1.0.0,>=0.3.26"
+oci = ">=2.139.0"
 pydantic = ">=2,<3"
-aiohttp = ">=3.12.14"
+# aiohttp = ">=3.12.14"
 
 [tool.poetry.group.test]
 optional = true

--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -14,7 +14,7 @@ license = "UPL"
 python = ">=3.9,<4.0"
 langchain-core = ">=0.3.20,<1.0.0"
 langchain = ">=0.3.20,<1.0.0"
-oci = ">=2.139.0"
+oci = ">=2.144.0"
 pydantic = ">=2,<3"
 # aiohttp = ">=3.12.14"
 

--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -13,9 +13,7 @@ license = "UPL"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 langchain-core = ">=0.3.15,<0.4"
-langchain-openai = ">=0.3.9"
 oci = ">=2.155.1"
-oracle-ads = ">=2.13.16"
 pydantic = ">=2,<3"
 aiohttp = ">=3.12.14"
 


### PR DESCRIPTION
There are several dependencies that should be optional (ads, langchain-openai)
and there are several version requirements that are very stringent and require old apps to be upgraded for lots of packages, making it complicated to switch from the langchain-community version seamlessly