### PR TITLE
Fix: Structured Output empty content

### DIFF
--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -1281,7 +1281,7 @@ class ChatOCIGenAI(BaseChatModel, OCIGenAIBase):
                 for tool_call in self._provider.chat_tool_calls(response)
             ]
         message = AIMessage(
-            content=content,
+            content=content or "",
             additional_kwargs=generation_info,
             tool_calls=tool_calls,
         )


### PR DESCRIPTION
# Fix: Structured Output empty content

When using structured output with newer Google Gemini (Beta) models with Generic Provider, it returns `content` as `None`, raising an Exception in langchain-core.

## Example

### Structured Response Schema

```py
from pydantic import BaseModel, Field


class PlannerPlanOutput(BaseModel):
    """Structured plan describing intent before SQL generation."""

    intent: str = Field(description="Short phrase of the main analytical intent.")
    entities: list[str] = Field(
        default_factory=list, description="Relevant table/entity names from schema only."
    )
    metrics: list[str] = Field(
        default_factory=list,
        description="Requested metrics or aggregations (e.g. count distinct shoppers).",
    )
    time_filter: str | None = Field(description="Natural language time interval required or None.")
```

### Response

```json
{
  "annotations": null,
  "content": [
    {
      "text": null,
      "type": "TEXT"
    }
  ],
  "name": null,
  "refusal": null,
  "role": "ASSISTANT",
  "tool_calls": [
    {
      "arguments": "{\"time_filter\":null,\"metrics\":[\"count distinct shopper_id\"],\"intent\":\"Contar shoppers únicos\",\"entities\":[\"gold.shopper\"]}",
      "id": null,
      "name": "PlannerPlanOutput",
      "type": "FUNCTION"
    }
  ]
}
```

### Error

```
ValidationError: 2 validation errors for AIMessage
content.str
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
content.list[union[str,dict[any,any]]]
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/list_type
```

## Proposed Fix

As the [Langchain BaseMessage content field](https://github.com/langchain-ai/langchain/blob/90280d1f58fb278c043ece63d5e6e80158b0c2d5/libs/core/langchain_core/messages/base.py#L26) only accepts `Union[str, list[Union[str, dict]]]`, when the response content is `None` we can overwrite it to be an empty string to keep the tool for structured output working as expected.