### PR TITLE
Handling Type Error

### DIFF
--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -97,9 +97,9 @@ class OCIUtils:
         return ToolCall(
             name=tool_call.name,
             args=json.loads(tool_call.arguments)
-            if "arguments" in tool_call.attribute_map
+            if tool_call.attribute_map and "arguments" in tool_call.attribute_map
             else tool_call.parameters,
-            id=tool_call.id if "id" in tool_call.attribute_map else uuid.uuid4().hex[:],
+            id=tool_call.id if tool_call.attribute_map and "id" in tool_call.attribute_map else uuid.uuid4().hex[:],
         )
 
 


### PR DESCRIPTION
w.r.t the [commit](https://github.com/oracle/langchain-oracle/commit/059c17b6064a96d4ba99f6163de31463c4513f91#diff-29dcb43f6a1ca7e578777f6097667946041cad3d8cf2739d9d86e53090e0d891R90) on convert_oci_tool_call_to_langchain . We are getting below error

```
File "/Users/sathraje/.venv/lib/python3.11/site-packages/langchain_oci/chat_models/oci_generative_ai.py", line 100, in convert_oci_tool_call_to_langchain
    if "arguments" in tool_call.attribute_map
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```
Proposing a change to make the code more defensive,