### PR TITLE
[BUGS] Handle double-escaped JSON in streaming tool calls

### DIFF
--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -563,10 +563,19 @@ class CohereProvider(Provider):
             if tool_id:
                 tool_call_ids.add(tool_id)
 
+            args = tool_call["function"].get("arguments")
+            # If args is a double-escaped JSON string, parse it twice to get the original JSON  # noqa: E501
+            try:
+                parsed_args = json.loads(json.loads(args))
+                args = json.dumps(parsed_args)
+            # If args is not a double-escaped JSON string, keep it as is
+            except (json.JSONDecodeError, TypeError):
+                pass
+
             tool_call_chunks.append(
                 tool_call_chunk(
                     name=tool_call["function"].get("name"),
-                    args=tool_call["function"].get("arguments"),
+                    args=args,
                     id=tool_id,
                     index=len(tool_call_ids) - 1,  # index tracking
                 )
@@ -1027,10 +1036,19 @@ class GenericProvider(Provider):
             if tool_id:
                 tool_call_ids.add(tool_id)
 
+            args = tool_call["function"].get("arguments")
+            # If args is a double-escaped JSON string, parse it twice to get the original JSON  # noqa: E501
+            try:
+                parsed_args = json.loads(json.loads(args))
+                args = json.dumps(parsed_args)
+            # If args is not a double-escaped JSON string, keep it as is
+            except (json.JSONDecodeError, TypeError):
+                pass
+
             tool_call_chunks.append(
                 tool_call_chunk(
                     name=tool_call["function"].get("name"),
-                    args=tool_call["function"].get("arguments"),
+                    args=args,
                     id=tool_id,
                     index=len(tool_call_ids) - 1,  # index tracking
                 )


### PR DESCRIPTION
# Problem
Streaming tool calls were not handling double-escaped JSON arguments, while the non-streaming path (convert_oci_tool_call_to_langchain) already had this fix. This caused tool call arguments to be incorrectly parsed in streaming mode.

# Solution
Applied the same double-escape handling logic to process_stream_tool_calls in both CohereProvider and GenericProvider:

```
args = tool_call["function"].get("arguments")
try:
    parsed_args = json.loads(json.loads(args))
    args = json.dumps(parsed_args)
except (json.JSONDecodeError, TypeError):
    pass
```

Logic:

- Normal JSON ('{"key": "value"}'): First parse succeeds → dict → second parse raises TypeError → keep original

- Double-escaped JSON ('"{\"key\": \"value\"}"'): First parse → string → second parse → dict → convert back to unescaped JSON

- Invalid/empty JSON: First parse raises JSONDecodeError → keep original