### PR TITLE
Fix demo guide link in README.md

### DIFF
--- a/libs/oracledb/README.md
+++ b/libs/oracledb/README.md
@@ -19,7 +19,7 @@ python -m pip install -U langchain-oracledb
 
 The following examples showcase basic usage of the components provided by `langchain-oracledb`.
 
-Please refer to our complete demo guide [Oracle AI Vector Search End-to-End Demo Guide](https://github.com/langchain-ai/langchain/tree/master/cookbook/oracleai_demo.ipynb) to build an end to end RAG pipeline with the help of Oracle AI Vector Search.
+Please refer to our complete demo guide [Oracle AI Vector Search End-to-End Demo Guide](https://github.com/langchain-ai/langchain/blob/v0.3/cookbook/oracleai_demo.ipynb) to build an end to end RAG pipeline with the help of Oracle AI Vector Search.
 
 ### Connect to Oracle Database
 


### PR DESCRIPTION
Updated the link in the demo guide to point to the correct version of the Oracle AI Vector Search End-to-End Demo Guide.