### PR TITLE
Improve tool call streaming aggregation for edge cases

### DIFF
--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -16,7 +16,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    Set,
     Type,
     Union,
 )
@@ -534,7 +533,7 @@ class ChatOCIGenAI(BaseChatModel, OCIGenAIBase):
         """
         request = self._prepare_request(messages, stop=stop, stream=True, **kwargs)
         response = self.client.chat(request)
-        tool_call_ids: Set[str] = set()
+        tool_call_ids: Dict[int, str] = {}
 
         for event in response.data.events():
             event_data = json.loads(event.data)

--- a/libs/oci/langchain_oci/chat_models/providers/base.py
+++ b/libs/oci/langchain_oci/chat_models/providers/base.py
@@ -4,7 +4,7 @@
 """Abstract base class for OCI Generative AI providers."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Literal, Optional, Set, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union
 
 from langchain_core.messages import BaseMessage
 from langchain_core.messages.tool import ToolCallChunk
@@ -97,7 +97,7 @@ class Provider(ABC):
     def process_stream_tool_calls(
         self,
         event_data: Dict,
-        tool_call_ids: Set[str],
+        tool_call_ids: Dict[int, str],
     ) -> List[ToolCallChunk]:
         """Process streaming tool calls from event data into chunks."""
         ...

--- a/libs/oci/langchain_oci/chat_models/providers/cohere.py
+++ b/libs/oci/langchain_oci/chat_models/providers/cohere.py
@@ -13,7 +13,6 @@ from typing import (
     Literal,
     Optional,
     Sequence,
-    Set,
     Type,
     Union,
 )
@@ -554,14 +553,14 @@ class CohereProvider(Provider):
         return None
 
     def process_stream_tool_calls(
-        self, event_data: Dict, tool_call_ids: Set[str]
+        self, event_data: Dict, tool_call_ids: Dict[int, str]
     ) -> List[ToolCallChunk]:
         """
         Process Cohere stream tool calls and return them as ToolCallChunk objects.
 
         Args:
             event_data: The event data from the stream
-            tool_call_ids: Set of existing tool call IDs for index tracking
+            tool_call_ids: Dict mapping tool call IDs for aggregation
 
         Returns:
             List of ToolCallChunk objects
@@ -572,10 +571,12 @@ class CohereProvider(Provider):
         if not tool_call_response:
             return tool_call_chunks
 
-        for tool_call in self.format_stream_tool_calls(tool_call_response):
+        for idx, tool_call in enumerate(
+            self.format_stream_tool_calls(tool_call_response)
+        ):
             tool_id = tool_call.get("id")
             if tool_id:
-                tool_call_ids.add(tool_id)
+                tool_call_ids[idx] = tool_id
 
             tool_call_chunks.append(
                 tool_call_chunk(


### PR DESCRIPTION
### Problem

Streaming tool calls were failing for certain models:

1. **OpenAI/GPT-OSS models**: Tool arguments returned empty `{}`, causing `ToolException: Missing required argument`
2. **Grok models**: Parallel tool calls were incorrectly merged into a single tool call

Related issue: https://github.com/oracle/langchain-oracle/issues/100

### Root Cause

The `process_stream_tool_calls` method used `Set[str]` for tracking tool IDs and generated new UUIDs for chunks without IDs. This broke LangChain's `AIMessageChunk.__add__` aggregation which requires matching `id` and `index` to merge chunks.

**OpenAI pattern** (fragmented streaming):
Event 1: id="abc", args='{"loc' -> ID present Event 2: id=None, args='ation"}' -> ID missing, got new UUID → aggregation failed

**Grok pattern** (parallel calls):
Event 1: idx=0, id="abc" ->  First tool Event 2: idx=0, id="def" ->  Second tool, same idx → incorrectly merged


### Solution

Changed `tool_call_ids` from `Set[str]` to `Dict[int, str]` to track `index → tool_id` mapping:

- **Fragmented streaming**: Reuse stored `tool_id` for subsequent chunks at same `idx`
- **Parallel calls**: Assign new `index` when different `tool_id` arrives at occupied `idx`

### Changes

| File | Change |
|------|--------|
| [providers/generic.py](cci:7://file:///Users/panxia/Documents/GitHub/langchain-oracle/libs/oci/langchain_oci/chat_models/providers/generic.py:0:0-0:0) | New aggregation logic with index-based ID tracking |
| [providers/base.py](cci:7://file:///Users/panxia/Documents/GitHub/langchain-oracle/libs/oci/langchain_oci/chat_models/providers/base.py:0:0-0:0) | Updated abstract method signature |
| [providers/cohere.py](cci:7://file:///Users/panxia/Documents/GitHub/langchain-oracle/libs/oci/langchain_oci/chat_models/providers/cohere.py:0:0-0:0) | Updated to match new signature |
| [oci_generative_ai.py](cci:7://file:///Users/panxia/Documents/GitHub/langchain-oracle/libs/oci/langchain_oci/chat_models/oci_generative_ai.py:0:0-0:0) | Changed `tool_call_ids` initialization |
| [test_oci_generative_ai.py](cci:7://file:///Users/panxia/Documents/GitHub/langchain-oracle/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py:0:0-0:0) | Added unit tests for GPT-OSS and Grok patterns |

### Testing

- Unit tests for fragmented streaming (GPT-OSS pattern)
- Unit tests for parallel tool calls (Grok pattern)
- Existing Gemini test (no ID) continues to pass