### PR TITLE
Fix Gemini output truncation and add unit + integration tests

### DIFF
--- a/libs/oci/README.md
+++ b/libs/oci/README.md
@@ -39,7 +39,7 @@ llm = ChatOCIGenAI(
     model_id="MY_MODEL_ID",  # Pre-hosted model ID
     service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",  # Regional endpoint
     compartment_id="ocid1.compartment.oc1..xxxxx",  # Your compartment OCID
-    model_kwargs={"max_tokens": 1024}, # Use max_completion_tokens instead of max_tokens for OpenAI models
+    model_kwargs={"max_tokens": 1024},  # Use max_completion_tokens for OpenAI models
     auth_profile="MY_AUTH_PROFILE",
     is_stream=True,
     auth_type="SECURITY_TOKEN"
@@ -58,7 +58,7 @@ from langchain_oci import ChatOCIGenAI
 # Using an imported model on Dedicated AI Cluster
 llm = ChatOCIGenAI(
     model_id="ocid1.generativeaiendpoint.oc1.us-chicago-1.xxxxx",  # Endpoint OCID from your DAC
-    provider="generic",  # Provider type: "generic" (most models) or "cohere"
+    provider="generic",  # Provider type: "cohere", "google", "meta", or "generic"
     service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",  # Regional endpoint
     compartment_id="ocid1.compartment.oc1..xxxxx",  # Your compartment OCID
     auth_type="SECURITY_TOKEN",  # Authentication type
@@ -71,7 +71,12 @@ response = llm.invoke("Hello, what is your name?")
 
 **Additional Arguments for Imported Models:**
 - `model_id`: Use the **endpoint OCID** (starts with `ocid1.generativeaiendpoint`)
-- `provider`: Use `"generic"` for most models (Llama, Gemini, Grok, etc.) or `"cohere"` for Cohere models. Default to "generic" if not specified.
+- `provider`: Provider type for your model. Available providers:
+  - `"cohere"`: For Cohere models (CohereProvider)
+  - `"google"`: For Google Gemini models (GeminiProvider) - automatically handles `max_output_tokens` to `max_tokens` parameter mapping
+  - `"meta"`: For Meta Llama models (MetaProvider)
+  - `"generic"`: Default for other models including OpenAI (GenericProvider)
+  If not specified, the provider is auto-detected from the model_id prefix.
 - `service_endpoint`: Use regional API endpoint (not the internal cluster URL)
 
 
@@ -126,7 +131,7 @@ text_vector = embeddings.embed_query("a photo of a cat")
 ### 4. Use Structured Output
 `ChatOCIGenAI` supports structured output.
 
-<sub>**Note:** The default method is `function_calling`. If default method returns `None` (e.g. for Gemini models), try `json_schema` or `json_mode`.</sub>
+<sub>**Note:** The default method is `function_calling`. If default method returns `None` (e.g., for Google Gemini models using GeminiProvider), try `json_schema` or `json_mode`.</sub>
 
 ```python
 from langchain_oci import ChatOCIGenAI

--- a/libs/oci/langchain_oci/chat_models/providers/__init__.py
+++ b/libs/oci/langchain_oci/chat_models/providers/__init__.py
@@ -5,11 +5,16 @@
 
 from langchain_oci.chat_models.providers.base import Provider
 from langchain_oci.chat_models.providers.cohere import CohereProvider
-from langchain_oci.chat_models.providers.generic import GenericProvider, MetaProvider
+from langchain_oci.chat_models.providers.generic import (
+    GeminiProvider,
+    GenericProvider,
+    MetaProvider,
+)
 
 __all__ = [
     "Provider",
     "CohereProvider",
+    "GeminiProvider",
     "GenericProvider",
     "MetaProvider",
 ]

--- a/libs/oci/langchain_oci/chat_models/providers/base.py
+++ b/libs/oci/langchain_oci/chat_models/providers/base.py
@@ -15,6 +15,20 @@ from pydantic import BaseModel
 class Provider(ABC):
     """Abstract base class for OCI Generative AI providers."""
 
+    @abstractmethod
+    def normalize_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize parameters for this provider.
+
+        Subclasses should implement provider-specific parameter transformations.
+
+        Args:
+            params: Dictionary of parameters to normalize
+
+        Returns:
+            Normalized parameters dictionary
+        """
+        ...
+
     @property
     @abstractmethod
     def stop_sequence_key(self) -> str:

--- a/libs/oci/langchain_oci/chat_models/providers/cohere.py
+++ b/libs/oci/langchain_oci/chat_models/providers/cohere.py
@@ -76,6 +76,10 @@ class CohereProvider(Provider):
         self.oci_image_url_v2 = None
         self.chat_api_format_v2 = None
 
+    def normalize_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize parameters. Returns params unchanged for Cohere."""
+        return params
+
     def _load_v2_classes(self) -> None:
         """Lazy load Cohere V2 API classes for vision support.
 

--- a/libs/oci/tests/integration_tests/chat_models/test_gemini_provider.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_gemini_provider.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Integration tests for GeminiProvider.
+
+Tests the GeminiProvider parameter normalization and basic functionality
+with real OCI GenAI service calls.
+
+Usage:
+  export OCI_COMPARTMENT_ID="ocid1.compartment..."
+  export OCI_CONFIG_PROFILE="NON-DEFAULT"  # Chicago region has Gemini
+  export OCI_AUTH_TYPE="SECURITY_TOKEN"
+  export OCI_REGION="us-chicago-1"
+
+  python -m pytest tests/integration_tests/chat_models/test_gemini_provider.py -v
+
+Output truncation diagnostic:
+  export OCI_RUN_GEMINI_TRUNCATION_DIAGNOSTIC=1
+  export OCI_MODEL_ID="google.gemini-2.5-pro"  # optional
+  export OCI_MAX_TOKENS=8000                   # optional
+  export OCI_TRUNCATION_TRIALS=10              # optional
+  export OCI_TRUNCATION_LINES=800              # optional
+"""
+
+import os
+import warnings
+from typing import Any, Dict
+
+import pytest
+
+from langchain_oci.chat_models import ChatOCIGenAI
+
+
+def _get_config() -> Dict[str, Any]:
+    """Get OCI configuration from environment."""
+    compartment_id = os.environ.get("OCI_COMPARTMENT_ID")
+    if not compartment_id:
+        pytest.skip("OCI_COMPARTMENT_ID not set")
+
+    region = os.getenv("OCI_REGION", "us-chicago-1")
+    endpoint = os.environ.get(
+        "OCI_GENAI_ENDPOINT",
+        f"https://inference.generativeai.{region}.oci.oraclecloud.com",
+    )
+
+    return {
+        "compartment_id": compartment_id,
+        "service_endpoint": endpoint,
+        "auth_type": os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "NON-DEFAULT"),
+        "auth_file_location": os.path.expanduser("~/.oci/config"),
+    }
+
+
+@pytest.mark.requires("oci")
+def test_gemini_basic_invoke() -> None:
+    """Test basic invoke with Gemini model."""
+    if os.environ.get("OCI_RUN_GEMINI_INTEGRATION") != "1":
+        pytest.skip("Set OCI_RUN_GEMINI_INTEGRATION=1 to run this test")
+
+    cfg = _get_config()
+    model_id = os.getenv("OCI_MODEL_ID", "google.gemini-2.0-flash-001")
+
+    llm = ChatOCIGenAI(
+        model_id=model_id,
+        service_endpoint=cfg["service_endpoint"],
+        compartment_id=cfg["compartment_id"],
+        auth_type=cfg["auth_type"],
+        auth_profile=cfg["auth_profile"],
+        auth_file_location=cfg["auth_file_location"],
+        model_kwargs={"temperature": 0, "max_tokens": 50},
+    )
+
+    response = llm.invoke("Say 'Hello' and nothing else.")
+    assert response.content is not None
+    assert len(response.content) > 0
+
+
+@pytest.mark.requires("oci")
+def test_gemini_max_output_tokens_mapping() -> None:
+    """Test that max_output_tokens is correctly mapped to max_tokens with warning."""
+    if os.environ.get("OCI_RUN_GEMINI_INTEGRATION") != "1":
+        pytest.skip("Set OCI_RUN_GEMINI_INTEGRATION=1 to run this test")
+
+    cfg = _get_config()
+    model_id = os.getenv("OCI_MODEL_ID", "google.gemini-2.0-flash-001")
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        llm = ChatOCIGenAI(
+            model_id=model_id,
+            service_endpoint=cfg["service_endpoint"],
+            compartment_id=cfg["compartment_id"],
+            auth_type=cfg["auth_type"],
+            auth_profile=cfg["auth_profile"],
+            auth_file_location=cfg["auth_file_location"],
+            model_kwargs={"temperature": 0, "max_output_tokens": 50},
+        )
+
+        response = llm.invoke("Say 'test' and nothing else.")
+
+        # Verify warning was emitted
+        mapping_warnings = [x for x in w if "max_output_tokens" in str(x.message)]
+        assert len(mapping_warnings) >= 1, "Expected max_output_tokens warning"
+        assert "Mapped" in str(mapping_warnings[0].message)
+
+        # Verify response is valid
+        assert response.content is not None
+
+
+@pytest.mark.requires("oci")
+def test_gemini_both_tokens_params() -> None:
+    """Test behavior when both max_tokens and max_output_tokens are provided."""
+    if os.environ.get("OCI_RUN_GEMINI_INTEGRATION") != "1":
+        pytest.skip("Set OCI_RUN_GEMINI_INTEGRATION=1 to run this test")
+
+    cfg = _get_config()
+    model_id = os.getenv("OCI_MODEL_ID", "google.gemini-2.0-flash-001")
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        llm = ChatOCIGenAI(
+            model_id=model_id,
+            service_endpoint=cfg["service_endpoint"],
+            compartment_id=cfg["compartment_id"],
+            auth_type=cfg["auth_type"],
+            auth_profile=cfg["auth_profile"],
+            auth_file_location=cfg["auth_file_location"],
+            model_kwargs={
+                "temperature": 0,
+                "max_tokens": 50,
+                "max_output_tokens": 100,  # Should be ignored
+            },
+        )
+
+        response = llm.invoke("Say 'both' and nothing else.")
+
+        # Verify warning about both being provided
+        both_warnings = [x for x in w if "Both" in str(x.message)]
+        assert len(both_warnings) >= 1, "Expected warning when both params provided"
+        assert "ignoring" in str(both_warnings[0].message).lower()
+
+        # Verify response is valid
+        assert response.content is not None
+
+
+@pytest.mark.requires("oci")
+def test_gemini_streaming() -> None:
+    """Test streaming with Gemini model."""
+    if os.environ.get("OCI_RUN_GEMINI_INTEGRATION") != "1":
+        pytest.skip("Set OCI_RUN_GEMINI_INTEGRATION=1 to run this test")
+
+    cfg = _get_config()
+    model_id = os.getenv("OCI_MODEL_ID", "google.gemini-2.0-flash-001")
+
+    llm = ChatOCIGenAI(
+        model_id=model_id,
+        service_endpoint=cfg["service_endpoint"],
+        compartment_id=cfg["compartment_id"],
+        auth_type=cfg["auth_type"],
+        auth_profile=cfg["auth_profile"],
+        auth_file_location=cfg["auth_file_location"],
+        model_kwargs={"temperature": 0, "max_tokens": 100},
+    )
+
+    chunks: list[str] = []
+    for chunk in llm.stream("Count from 1 to 5."):
+        if chunk.content:
+            chunks.append(str(chunk.content))
+
+    assert len(chunks) > 0, "Expected at least one chunk"
+    full_response = "".join(chunks)
+    assert len(full_response) > 0
+
+
+@pytest.mark.requires("oci")
+def test_gemini_streaming_with_max_output_tokens() -> None:
+    """Test streaming with max_output_tokens parameter (should be normalized)."""
+    if os.environ.get("OCI_RUN_GEMINI_INTEGRATION") != "1":
+        pytest.skip("Set OCI_RUN_GEMINI_INTEGRATION=1 to run this test")
+
+    cfg = _get_config()
+    model_id = os.getenv("OCI_MODEL_ID", "google.gemini-2.0-flash-001")
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        llm = ChatOCIGenAI(
+            model_id=model_id,
+            service_endpoint=cfg["service_endpoint"],
+            compartment_id=cfg["compartment_id"],
+            auth_type=cfg["auth_type"],
+            auth_profile=cfg["auth_profile"],
+            auth_file_location=cfg["auth_file_location"],
+            model_kwargs={"temperature": 0, "max_output_tokens": 100},
+        )
+
+        chunks = []
+        for chunk in llm.stream("Say 'streaming works' and nothing else."):
+            if chunk.content:
+                chunks.append(chunk.content)
+
+        # Verify warning was emitted
+        mapping_warnings = [x for x in w if "max_output_tokens" in str(x.message)]
+        assert len(mapping_warnings) >= 1, "Expected max_output_tokens warning"
+
+        assert len(chunks) > 0, "Expected at least one chunk"
+
+
+# --- Output truncation diagnostic tests ---
+# These tests verify that Gemini multipart content concatenation works correctly.
+# They are opt-in diagnostics that send long-output requests to check for truncation.
+
+
+def _make_truncation_prompt(sentinel: str, line_count: int) -> str:
+    """Generate a prompt requesting structured long output with sentinel markers."""
+    return (
+        "You must output a plain-text payload with NO extra commentary.\n"
+        f"First line: BEGIN:{sentinel}\n"
+        f"Then output EXACTLY {line_count} lines numbered 1..{line_count}.\n"
+        "Each numbered line must follow this pattern exactly:\n"
+        f"  L1:{sentinel}\n"
+        f"  L2:{sentinel}\n"
+        "  ...\n"
+        f"  L{line_count}:{sentinel}\n"
+        f"Final line: END:{sentinel}\n"
+        "Do not wrap in code fences. Do not omit any lines."
+    )
+
+
+def _summarize_response(resp: Any) -> Dict[str, Any]:
+    """Extract summary info from a response for diagnostic output."""
+    content = getattr(resp, "content", "") or ""
+    usage = getattr(resp, "usage_metadata", None)
+    finish_reason = None
+    if hasattr(resp, "additional_kwargs"):
+        finish_reason = resp.additional_kwargs.get("finish_reason")
+    return {
+        "chars": len(content),
+        "finish_reason": finish_reason,
+        "usage": usage.model_dump() if hasattr(usage, "model_dump") else usage,  # type: ignore[union-attr]
+        "tail": content[-200:],
+    }
+
+
+@pytest.mark.requires("oci")
+def test_gemini_output_truncation_diagnostic() -> None:
+    """Diagnostic test for intermittent Gemini output truncation.
+
+    This test validates that Gemini responses are not being cut off unexpectedly.
+    It sends multiple requests asking for structured long output and checks
+    that all content parts are properly concatenated.
+
+    Enable with: OCI_RUN_GEMINI_TRUNCATION_DIAGNOSTIC=1
+
+    Optional environment variables:
+      - OCI_MODEL_ID: Model to test (default: google.gemini-2.5-pro)
+      - OCI_MAX_TOKENS: Max output tokens (default: 8000)
+      - OCI_TRUNCATION_TRIALS: Number of requests to run (default: 10)
+      - OCI_TRUNCATION_LINES: Requested line count (default: 800)
+      - OCI_TRUNCATION_TEMPERATURE: Temperature setting (default: 0)
+    """
+    if os.environ.get("OCI_RUN_GEMINI_TRUNCATION_DIAGNOSTIC") != "1":
+        pytest.skip("Set OCI_RUN_GEMINI_TRUNCATION_DIAGNOSTIC=1 to run this test")
+
+    cfg = _get_config()
+    model_id = os.getenv("OCI_MODEL_ID", "google.gemini-2.5-pro")
+    max_tokens = int(os.getenv("OCI_MAX_TOKENS", "8000"))
+    temperature = float(os.getenv("OCI_TRUNCATION_TEMPERATURE", "0"))
+    trials = int(os.getenv("OCI_TRUNCATION_TRIALS", "10"))
+    line_count = int(os.getenv("OCI_TRUNCATION_LINES", "800"))
+
+    llm = ChatOCIGenAI(
+        model_id=model_id,
+        service_endpoint=cfg["service_endpoint"],
+        compartment_id=cfg["compartment_id"],
+        auth_type=cfg["auth_type"],
+        auth_profile=cfg["auth_profile"],
+        auth_file_location=cfg["auth_file_location"],
+        model_kwargs={
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        },
+    )
+
+    failures: list[tuple[int, Dict[str, Any]]] = []
+    for i in range(trials):
+        sentinel = f"TRUNC-{i}-X"
+        prompt = _make_truncation_prompt(sentinel, line_count=line_count)
+        resp = llm.invoke(prompt)
+        content = resp.content or ""
+
+        # Minimal, robust truncation signal: END marker missing.
+        if f"END:{sentinel}" not in content:
+            failures.append((i, _summarize_response(resp)))
+
+    if failures:
+        # Keep assertion output small but actionable.
+        details = "\n".join(
+            f"trial={idx} finish_reason={info.get('finish_reason')} "
+            f"chars={info.get('chars')} usage={info.get('usage')} "
+            f"tail={info.get('tail')!r}"
+            for idx, info in failures[:5]
+        )
+        pytest.fail(
+            f"Detected {len(failures)}/{trials} truncated responses for {model_id} "
+            f"(max_tokens={max_tokens}). First failures:\n{details}"
+        )

--- a/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
@@ -504,6 +504,245 @@ def test_meta_tool_calling(monkeypatch: MonkeyPatch) -> None:
 
 
 @pytest.mark.requires("oci")
+def test_gemini_multipart_content_concatenation(monkeypatch: MonkeyPatch) -> None:
+    """Test that Gemini responses with multiple content parts are fully concatenated.
+
+    Reproduces the truncation bug reported by Luigi Saetta: Gemini returns text
+    split across multiple content parts in a single response. Previously only
+    content[0] was used, dropping the rest of the output.
+
+    See: https://github.com/oracle/langchain-oracle/pull/116
+    """
+    oci_gen_ai_client = MagicMock()
+    llm = ChatOCIGenAI(model_id="google.gemini-2.5-pro", client=oci_gen_ai_client)
+
+    # Simulate Gemini returning text in 3 content parts (as observed in OCR scenarios)
+    part1 = "L001: The quick brown fox jumps over the lazy dog.\n"
+    part2 = "L002: The quick brown fox jumps over the lazy dog.\n"
+    part3 = "L003: The quick brown fox jumps over the lazy dog.\n"
+
+    def mocked_response(*args, **kwargs):
+        return MockResponseDict(
+            {
+                "status": 200,
+                "data": MockResponseDict(
+                    {
+                        "chat_response": MockResponseDict(
+                            {
+                                "choices": [
+                                    MockResponseDict(
+                                        {
+                                            "message": MockResponseDict(
+                                                {
+                                                    "role": "ASSISTANT",
+                                                    "content": [
+                                                        MockResponseDict(
+                                                            {
+                                                                "text": part1,
+                                                                "type": "TEXT",
+                                                            }  # noqa: E501
+                                                        ),
+                                                        MockResponseDict(
+                                                            {
+                                                                "text": part2,
+                                                                "type": "TEXT",
+                                                            }  # noqa: E501
+                                                        ),
+                                                        MockResponseDict(
+                                                            {
+                                                                "text": part3,
+                                                                "type": "TEXT",
+                                                            }  # noqa: E501
+                                                        ),
+                                                    ],
+                                                    "tool_calls": [],
+                                                }
+                                            ),
+                                            "finish_reason": "stop",
+                                        }
+                                    )
+                                ],
+                                "time_created": "2026-01-30T10:00:00.000000+00:00",
+                                "usage": MockResponseDict(
+                                    {
+                                        "prompt_tokens": 100,
+                                        "completion_tokens": 60,
+                                        "total_tokens": 160,
+                                    }
+                                ),
+                            }
+                        ),
+                        "model_id": "google.gemini-2.5-pro",
+                        "model_version": "1.0.0",
+                    }
+                ),
+                "request_id": "test_multipart",
+                "headers": MockResponseDict({"content-length": "500"}),
+            }
+        )
+
+    monkeypatch.setattr(llm.client, "chat", mocked_response)
+
+    messages = [HumanMessage(content="Extract text from this page.")]
+    response = llm.invoke(messages)
+
+    # All 3 parts must be concatenated — previously only part1 was returned
+    assert response.content == part1 + part2 + part3
+
+
+@pytest.mark.requires("oci")
+def test_gemini_multipart_stream_concatenation(monkeypatch: MonkeyPatch) -> None:
+    """Test that streaming Gemini responses with multiple content parts per event
+    are fully concatenated (not just content[0])."""
+    import json
+
+    oci_gen_ai_client = MagicMock()
+    llm = ChatOCIGenAI(model_id="google.gemini-2.5-pro", client=oci_gen_ai_client)
+
+    # Single stream event with multiple text parts
+    mock_stream_events = [
+        MagicMock(
+            data=json.dumps(
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "ASSISTANT",
+                        "content": [
+                            {"type": "TEXT", "text": "First part. "},
+                            {"type": "TEXT", "text": "Second part. "},
+                            {"type": "TEXT", "text": "Third part."},
+                        ],
+                    },
+                }
+            )
+        ),
+        MagicMock(data=json.dumps({"finishReason": "stop"})),
+    ]
+    mock_stream_response = MagicMock()
+    mock_stream_response.data.events.return_value = mock_stream_events
+    monkeypatch.setattr(
+        llm.client, "chat", lambda *args, **kwargs: mock_stream_response
+    )
+
+    chunks = list(llm.stream([HumanMessage(content="Extract text.")]))
+    full_text = "".join(c.content for c in chunks if isinstance(c.content, str))
+
+    assert full_text == "First part. Second part. Third part."
+
+
+@pytest.mark.requires("oci")
+def test_gemini_max_output_tokens_normalization(monkeypatch: MonkeyPatch) -> None:
+    """Test that max_output_tokens is normalized to max_tokens for Gemini models.
+
+    Luigi's workaround in his multimodal-extraction repo uses max_output_tokens
+    (the Gemini SDK parameter name). Our fix normalizes it to max_tokens (OCI API
+    parameter name) so both work correctly.
+    """
+    import warnings
+
+    oci_gen_ai_client = MagicMock()
+
+    # Case 1: max_output_tokens only → should be mapped to max_tokens
+    llm = ChatOCIGenAI(
+        model_id="google.gemini-2.5-pro",
+        client=oci_gen_ai_client,
+        model_kwargs={"temperature": 0, "max_output_tokens": 8000},
+    )
+
+    captured_request = {}
+
+    def mocked_response(*args, **kwargs):
+        captured_request["request"] = args[0]
+        return MockResponseDict(
+            {
+                "status": 200,
+                "data": MockResponseDict(
+                    {
+                        "chat_response": MockResponseDict(
+                            {
+                                "choices": [
+                                    MockResponseDict(
+                                        {
+                                            "message": MockResponseDict(
+                                                {
+                                                    "role": "ASSISTANT",
+                                                    "content": [
+                                                        MockResponseDict(
+                                                            {
+                                                                "text": "ok",
+                                                                "type": "TEXT",
+                                                            }  # noqa: E501
+                                                        )
+                                                    ],
+                                                    "tool_calls": [],
+                                                }
+                                            ),
+                                            "finish_reason": "stop",
+                                        }
+                                    )
+                                ],
+                                "time_created": "2026-01-30T10:00:00.000000+00:00",
+                                "usage": MockResponseDict(
+                                    {
+                                        "prompt_tokens": 10,
+                                        "completion_tokens": 1,
+                                        "total_tokens": 11,
+                                    }
+                                ),
+                            }
+                        ),
+                        "model_id": "google.gemini-2.5-pro",
+                        "model_version": "1.0.0",
+                    }
+                ),
+                "request_id": "test_normalization",
+                "headers": MockResponseDict({"content-length": "100"}),
+            }
+        )
+
+    monkeypatch.setattr(llm.client, "chat", mocked_response)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        llm.invoke([HumanMessage(content="test")])
+        # Should emit a UserWarning about the mapping
+        mapping_warnings = [x for x in w if "max_output_tokens" in str(x.message)]
+        assert len(mapping_warnings) == 1
+        assert "Mapped" in str(mapping_warnings[0].message)
+
+    # Case 2: both max_tokens and max_output_tokens → should prefer max_tokens
+    llm2 = ChatOCIGenAI(
+        model_id="google.gemini-2.5-pro",
+        client=oci_gen_ai_client,
+        model_kwargs={
+            "temperature": 0,
+            "max_tokens": 4000,
+            "max_output_tokens": 8000,
+        },
+    )
+    monkeypatch.setattr(llm2.client, "chat", mocked_response)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        llm2.invoke([HumanMessage(content="test")])
+        both_warnings = [x for x in w if "max_output_tokens" in str(x.message)]
+        assert len(both_warnings) == 1
+        assert "ignoring" in str(both_warnings[0].message).lower()
+
+    # Case 3: non-Gemini model with max_output_tokens → no mapping occurs,
+    # so the unknown kwarg reaches the OCI SDK and raises TypeError
+    llm3 = ChatOCIGenAI(
+        model_id="meta.llama-3.3-70b-instruct",
+        client=oci_gen_ai_client,
+        model_kwargs={"temperature": 0, "max_output_tokens": 8000},
+    )
+    monkeypatch.setattr(llm3.client, "chat", mocked_response)
+
+    with pytest.raises(TypeError, match="max_output_tokens"):
+        llm3.invoke([HumanMessage(content="test")])
+
+
+@pytest.mark.requires("oci")
 def test_cohere_tool_choice_validation(monkeypatch: MonkeyPatch) -> None:
     """Test that tool choice is not supported for Cohere models."""
     oci_gen_ai_client = MagicMock()

--- a/libs/oci/tests/unit_tests/chat_models/test_providers.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_providers.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for OCI Generative AI providers."""
+
+import warnings
+
+from langchain_oci.chat_models.providers import (
+    CohereProvider,
+    GeminiProvider,
+    GenericProvider,
+    MetaProvider,
+    Provider,
+)
+
+
+class TestProviderBaseClass:
+    """Tests for the Provider base class."""
+
+    def test_normalize_params_no_transforms(self) -> None:
+        """Test normalize_params returns params unchanged when no transforms defined."""
+        provider = GenericProvider()
+        params = {"temperature": 0.5, "max_tokens": 100}
+        result = provider.normalize_params(params)
+        assert result == params
+
+    def test_normalize_params_does_not_mutate_input(self) -> None:
+        """Test normalize_params does not mutate the input dictionary."""
+        provider = GeminiProvider()
+        params = {"max_output_tokens": 100, "temperature": 0.5}
+        original_params = params.copy()
+        provider.normalize_params(params)
+        assert params == original_params
+
+
+class TestGeminiProvider:
+    """Tests for the GeminiProvider class."""
+
+    def test_inherits_from_generic_provider(self) -> None:
+        """Test GeminiProvider inherits from GenericProvider."""
+        provider = GeminiProvider()
+        assert isinstance(provider, GenericProvider)
+        assert isinstance(provider, Provider)
+
+    def test_normalize_params_maps_max_output_tokens(self) -> None:
+        """Test max_output_tokens is mapped to max_tokens."""
+        provider = GeminiProvider()
+        params = {"max_output_tokens": 100, "temperature": 0.5}
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = provider.normalize_params(params)
+
+            assert "max_output_tokens" not in result
+            assert result["max_tokens"] == 100
+            assert result["temperature"] == 0.5
+
+            # Should emit warning
+            mapping_warnings = [x for x in w if "max_output_tokens" in str(x.message)]
+            assert len(mapping_warnings) == 1
+            assert "Mapped" in str(mapping_warnings[0].message)
+
+    def test_normalize_params_prefers_max_tokens_when_both_provided(self) -> None:
+        """Test max_tokens is preferred when both are provided."""
+        provider = GeminiProvider()
+        params = {"max_tokens": 50, "max_output_tokens": 100, "temperature": 0.5}
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = provider.normalize_params(params)
+
+            assert result["max_tokens"] == 50  # Prefer max_tokens
+            assert "max_output_tokens" not in result
+            assert result["temperature"] == 0.5
+
+            # Should emit warning about both being provided
+            both_warnings = [x for x in w if "Both" in str(x.message)]
+            assert len(both_warnings) == 1
+            assert "ignoring" in str(both_warnings[0].message).lower()
+
+    def test_normalize_params_no_changes_when_only_max_tokens(self) -> None:
+        """Test no changes when only max_tokens is provided."""
+        provider = GeminiProvider()
+        params = {"max_tokens": 100, "temperature": 0.5}
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = provider.normalize_params(params)
+
+            assert result == params
+            # Should not emit any warnings
+            mapping_warnings = [x for x in w if "max_output_tokens" in str(x.message)]
+            assert len(mapping_warnings) == 0
+
+    def test_normalize_params_empty_params(self) -> None:
+        """Test normalize_params handles empty params."""
+        provider = GeminiProvider()
+        params: dict = {}
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = provider.normalize_params(params)
+
+            assert result == {}
+            assert len(w) == 0
+
+    def test_stop_sequence_key(self) -> None:
+        """Test stop_sequence_key returns correct value."""
+        provider = GeminiProvider()
+        assert provider.stop_sequence_key == "stop"
+
+
+class TestMetaProvider:
+    """Tests for the MetaProvider class."""
+
+    def test_inherits_from_generic_provider(self) -> None:
+        """Test MetaProvider inherits from GenericProvider."""
+        provider = MetaProvider()
+        assert isinstance(provider, GenericProvider)
+
+    def test_normalize_params_unchanged(self) -> None:
+        """Test normalize_params returns params unchanged."""
+        provider = MetaProvider()
+        params = {"max_tokens": 100, "temperature": 0.5}
+        result = provider.normalize_params(params)
+        assert result == params
+
+
+class TestCohereProvider:
+    """Tests for the CohereProvider class."""
+
+    def test_inherits_from_provider(self) -> None:
+        """Test CohereProvider inherits from Provider."""
+        provider = CohereProvider()
+        assert isinstance(provider, Provider)
+
+    def test_stop_sequence_key(self) -> None:
+        """Test stop_sequence_key returns correct value for Cohere."""
+        provider = CohereProvider()
+        assert provider.stop_sequence_key == "stop_sequences"
+
+
+class TestGenericProvider:
+    """Tests for the GenericProvider class."""
+
+    def test_inherits_from_provider(self) -> None:
+        """Test GenericProvider inherits from Provider."""
+        provider = GenericProvider()
+        assert isinstance(provider, Provider)
+
+    def test_stop_sequence_key(self) -> None:
+        """Test stop_sequence_key returns correct value."""
+        provider = GenericProvider()
+        assert provider.stop_sequence_key == "stop"
+
+    def test_normalize_params_unchanged(self) -> None:
+        """Test normalize_params returns params unchanged by default."""
+        provider = GenericProvider()
+        params = {"max_tokens": 100, "temperature": 0.5}
+        result = provider.normalize_params(params)
+        assert result == params


### PR DESCRIPTION
Gemini models on OCI return long text responses split across multiple content parts in a single API response. GenericProvider.chat_response_to_text was only reading content[0], silently dropping everything after the first part. This caused text output to appear randomly truncated depending on how the model chunked its response.

Root cause in providers/generic.py:

  # before - only first part
  content = message.content[0] if message.content else None
  return content.text if content else ""

  # after - all parts joined
  return "".join(
      part.text for part in message.content
      if getattr(part, "text", None)
  )

Same fix applied to the streaming path (chat_stream_to_text).

Also added auto-normalization of max_output_tokens -> max_tokens for Gemini models. The Google Gemini SDK uses max_output_tokens but the OCI API expects max_tokens. This is now mapped automatically with a UserWarning.

Changes:
- providers/generic.py: concatenate all text content parts instead of content[0], both invoke and stream
- oci_generative_ai.py: max_output_tokens -> max_tokens normalization for google.gemini* models
- Unit tests: 3 new tests covering multipart invoke, multipart stream, and parameter normalization
- Integration test: opt-in diagnostic that sends long-output requests to Gemini and checks for truncation

Note: this fixes client-side truncation (dropped content parts). Long outputs that hit the model's output token cap (finish_reason=max_tokens) are a server-side limit and require pipeline-level chunking.