### PR TITLE
Upgrade Support for Imported Models on Dedicated AI Clusters

### DIFF
--- a/libs/oci/README.md
+++ b/libs/oci/README.md
@@ -24,7 +24,7 @@ This repository includes two main integration categories:
 ## OCI Generative AI Examples
 
 OCI Generative AI supports two types of models:
-- **On-Demand Models**: Pre-hosted foundation models (Meta Llama, Cohere, Google Gemini, etc.)
+- **On-Demand Models**: Pre-hosted foundation models.
 - **DAC Models**: Models hosted on Dedicated AI Clusters (DAC), including custom models imported from Hugging Face or Object Storage
 
 ### 1a. Use a Chat Model (On-Demand)
@@ -36,7 +36,7 @@ from langchain_oci import ChatOCIGenAI
 
 # Using a pre-hosted on-demand model
 llm = ChatOCIGenAI(
-    model_id="MY_MODEL_ID",  # Pre-hosted model ID, for example: meta.llama-3.3-70b-instruct
+    model_id="MY_MODEL_ID",  # Pre-hosted model ID
     service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",  # Regional endpoint
     compartment_id="ocid1.compartment.oc1..xxxxx",  # Your compartment OCID
     model_kwargs={"max_tokens": 1024}, # Use max_completion_tokens instead of max_tokens for OpenAI models

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -51,6 +51,7 @@ from pydantic import BaseModel, ConfigDict, SecretStr, model_validator
 from langchain_oci.chat_models.providers import (
     CohereProvider,
     GenericProvider,
+    MetaProvider,
     Provider,
 )
 from langchain_oci.common.utils import CUSTOM_ENDPOINT_PREFIX, OCIUtils
@@ -169,6 +170,7 @@ class ChatOCIGenAI(BaseChatModel, OCIGenAIBase):
         """Mapping from provider name to provider instance."""
         return {
             "cohere": CohereProvider(),
+            "meta": MetaProvider(),
             "generic": GenericProvider(),
         }
 

--- a/libs/oci/langchain_oci/llms/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/llms/oci_generative_ai.py
@@ -239,6 +239,7 @@ class OCIGenAI(LLM, OCIGenAIBase):
         """Get the provider map"""
         return {
             "cohere": CohereProvider(),
+            "meta": MetaProvider(),
             "generic": GenericProvider(),
         }
 

--- a/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
@@ -1009,7 +1009,7 @@ def test_get_provider():
     oci_gen_ai_client = MagicMock()
     model_provider_map = {
         "cohere.command-latest": "CohereProvider",
-        "meta.llama-3.3-70b-instruct": "GenericProvider",
+        "meta.llama-3.3-70b-instruct": "MetaProvider",
         "xai.grok-3": "GenericProvider",
     }
     for model_id, provider_name in model_provider_map.items():
@@ -1064,7 +1064,7 @@ def test_v2_api_guard_for_non_cohere_providers(monkeypatch: MonkeyPatch) -> None
     """
     oci_gen_ai_client = MagicMock()
 
-    # Test with Meta model (uses GenericProvider)
+    # Test with Meta model (uses GenericProvider via MetaProvider)
     llm = ChatOCIGenAI(model_id="meta.llama-3.3-70b-instruct", client=oci_gen_ai_client)
 
     # Mock the provider's messages_to_oci_params to return _use_v2_api=True


### PR DESCRIPTION
## Summary

This PR adds support for imported models hosted on Dedicated AI Clusters (DAC) in the `langchain-oci` library, enabling users to seamlessly use custom models imported from Hugging Face or Object Storage.

## Changes

- **Provider**: Endpoint OCIDs (starting with `ocid1.generativeaiendpoint`) now automatically default to `generic` provider with a helpful warning
- **Removed redundant MetaProvider**: Meta models now use `GenericProvider` directly (functionally identical)
- **User-friendly warnings**: Clear guidance when provider auto-detection occurs for custom endpoints
- **README.md**: Added comprehensive examples for both on-demand and DAC-hosted models
  - Clear distinction between model types
  - Detailed argument explanations
  - Example code for imported models with endpoint OCIDs

### Tests
- Updated `test_get_provider()` to expect `GenericProvider` for Meta models
- Added `test_custom_endpoint_defaults_to_generic_provider()` - verifies warning behavior
- Added `test_custom_endpoint_explicit_provider()` - verifies explicit provider suppresses warning

## Usage Example

```python
from langchain_oci import ChatOCIGenAI

# Using an imported model on Dedicated AI Cluster
llm = ChatOCIGenAI(
    model_id="ocid1.generativeaiendpoint.oc1.us-chicago-1.xxxxx",  # Endpoint OCID from your DAC
    provider="generic",  # Provider type: "generic" (most models) or "cohere"
    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",  # Regional endpoint
    compartment_id="ocid1.compartment.oc1..xxxxx",  # Your compartment OCID
    auth_type="SECURITY_TOKEN",  # Authentication type
    auth_profile="MY_AUTH_PROFILE",
    model_kwargs={"temperature": 0.7, "max_tokens": 500},
)

response = llm.invoke("Hello, what is your name?")
```