### PR TITLE
Fix homepage URL in @oracle/langchain-oracledb package.json

### DIFF
--- a/libs/js/langchain-oracledb/package.json
+++ b/libs/js/langchain-oracledb/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/oracle/langchain-oracle.git",
     "directory": "libs/js/oracledb/langchain-oracledb"
   },
-  "homepage": "https://github.com/oracle/langchain-oracle/tree/main/libs/js/oracledb/langchain-oracledb",
+  "homepage": "https://github.com/oracle/langchain-oracle/tree/main/libs/js/langchain-oracledb",
   "scripts": {
     "build": "pnpm clean && pnpm build:esm && pnpm build:cjs && pnpm build:types:cjs && pnpm build:scripts",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",


### PR DESCRIPTION
Fix homepage URL in @oracle/langchain-oracledb package.json.

Noticed this when I tried to create an npm package.