### PR TITLE
bump up version for langchain-oci to 0.2.4

### DIFF
--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-oci"
-version = "0.2.3"
+version = "0.2.4"
 description = "An integration package connecting OCI and LangChain"
 readme = "README.md"
 license = "UPL-1.0"


### PR DESCRIPTION
bump up version for langchain-oci to 0.2.4