### PR TITLE
(bug) Harden OCI tool schema conversion for cross-model tool-calling reliability

### DIFF
--- a/libs/oci/langchain_oci/chat_models/providers/cohere.py
+++ b/libs/oci/langchain_oci/chat_models/providers/cohere.py
@@ -619,6 +619,7 @@ class CohereProvider(Provider):
                 # Resolve $ref/$defs and anyOf — OCI doesn't support them
                 schema = OCIUtils.resolve_schema_refs(schema)
                 schema = OCIUtils.resolve_anyof(schema)
+                schema = OCIUtils.sanitize_schema(schema)
                 properties = schema.get("properties", {})
             else:
                 properties = tool.args

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -641,6 +641,7 @@ class GenericProvider(Provider):
             # Resolve $ref/$defs and anyOf — OCI doesn't support them
             resolved_params = OCIUtils.resolve_schema_refs(parameters)
             resolved_params = OCIUtils.resolve_anyof(resolved_params)
+            resolved_params = OCIUtils.sanitize_schema(resolved_params)
             properties = resolved_params.get("properties", {})
 
             return self.oci_function_definition(

--- a/libs/oci/langchain_oci/common/utils.py
+++ b/libs/oci/langchain_oci/common/utils.py
@@ -83,6 +83,7 @@ class OCIUtils:
         OCI Generative AI doesn't support $ref and $defs, so we inline all references.
         """
         defs = schema.get("$defs", {})  # OCI Generative AI doesn't support $defs
+        resolving_stack: set[str] = set()
 
         def resolve(obj: Any) -> Any:
             if isinstance(obj, dict):
@@ -90,7 +91,13 @@ class OCIUtils:
                     ref = obj["$ref"]
                     if ref.startswith("#/$defs/"):
                         key = ref.split("/")[-1]
-                        return resolve(defs.get(key, obj))
+                        if key in resolving_stack:
+                            return {"type": "object"}
+                        resolving_stack.add(key)
+                        try:
+                            return resolve(defs.get(key, obj))
+                        finally:
+                            resolving_stack.discard(key)
                     return obj  # Cannot resolve $ref, return unchanged
                 return {k: resolve(v) for k, v in obj.items()}
             elif isinstance(obj, list):
@@ -126,6 +133,51 @@ class OCIUtils:
         elif isinstance(obj, list):
             return [OCIUtils.resolve_anyof(item) for item in obj]
         return obj
+
+    @staticmethod
+    def sanitize_schema(schema: Any) -> Any:
+        """Recursively sanitize a schema for OCI tool compatibility."""
+        if isinstance(schema, list):
+            return [OCIUtils.sanitize_schema(item) for item in schema]
+
+        if not isinstance(schema, dict):
+            return schema
+
+        sanitized: Dict[str, Any] = {}
+        for key, value in schema.items():
+            if key == "title":
+                continue
+            if key == "default" and value is None:
+                continue
+
+            if key == "type":
+                if value == "any":
+                    sanitized[key] = "object"
+                    continue
+                if isinstance(value, list):
+                    non_null_types = [item for item in value if item != "null"]
+                    sanitized[key] = non_null_types[0] if non_null_types else "string"
+                    continue
+
+            sanitized[key] = OCIUtils.sanitize_schema(value)
+
+        if sanitized.get("type") == "array" and "items" not in sanitized:
+            sanitized["items"] = {"type": "object"}
+
+        required = sanitized.get("required")
+        properties = sanitized.get("properties")
+        if "required" in sanitized:
+            if isinstance(required, list) and isinstance(properties, dict):
+                property_names = set(properties)
+                sanitized["required"] = [
+                    field
+                    for field in required
+                    if isinstance(field, str) and field in property_names
+                ]
+            elif not isinstance(required, list):
+                sanitized["required"] = []
+
+        return sanitized
 
     @staticmethod
     def create_usage_metadata(usage: Any) -> Optional[Any]:

--- a/libs/oci/tests/unit_tests/chat_models/test_tool_schema_constraints.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_tool_schema_constraints.py
@@ -13,6 +13,7 @@ See: https://github.com/oracle/langchain-oracle/issues/103
 
 from enum import Enum
 from typing import List, Optional
+from unittest.mock import MagicMock
 
 import pytest
 from langchain_core.tools import BaseTool, tool
@@ -20,6 +21,7 @@ from pydantic import BaseModel, Field
 
 from langchain_oci.chat_models.providers.cohere import CohereProvider
 from langchain_oci.chat_models.providers.generic import GenericProvider
+from langchain_oci.common.utils import OCIUtils
 
 # ---------------------------------------------------------------------------
 # Test tool definitions
@@ -380,6 +382,89 @@ def test_14_const_extra():
     assert p["version"]["const"] == "v1"
 
 
+def test_sanitize_schema_prunes_missing_required_fields():
+    """Required fields missing from properties should be removed."""
+    schema = {
+        "type": "object",
+        "properties": {"present": {"type": "string"}},
+        "required": ["present", "missing"],
+    }
+
+    sanitized = OCIUtils.sanitize_schema(schema)
+
+    assert sanitized["required"] == ["present"]
+
+
+def test_sanitize_schema_removes_title_and_null_defaults_recursively():
+    """Schema metadata noise should be removed recursively."""
+    schema = {
+        "type": "object",
+        "title": "Root",
+        "properties": {
+            "name": {
+                "type": ["string", "null"],
+                "title": "Name",
+                "default": None,
+            },
+            "child": {
+                "type": "object",
+                "title": "Child",
+                "properties": {
+                    "age": {
+                        "type": ["integer", "null"],
+                        "title": "Age",
+                        "default": None,
+                    }
+                },
+            },
+        },
+    }
+
+    sanitized = OCIUtils.sanitize_schema(schema)
+
+    assert "title" not in str(sanitized)
+    assert "'default': None" not in str(sanitized)
+    assert sanitized["properties"]["name"]["type"] == "string"
+    assert sanitized["properties"]["child"]["properties"]["age"]["type"] == "integer"
+
+
+def test_sanitize_schema_adds_default_array_items():
+    """Arrays without items should get a default object items schema."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "tags": {"type": "array"},
+        },
+    }
+
+    sanitized = OCIUtils.sanitize_schema(schema)
+
+    assert sanitized["properties"]["tags"]["items"] == {"type": "object"}
+
+
+def test_resolve_schema_refs_handles_circular_refs():
+    """Circular refs should degrade to object instead of recursing forever."""
+    schema = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "child": {"$ref": "#/$defs/Node"},
+                },
+            }
+        },
+        "type": "object",
+        "properties": {
+            "node": {"$ref": "#/$defs/Node"},
+        },
+    }
+
+    resolved = OCIUtils.resolve_schema_refs(schema)
+
+    assert "$ref" not in str(resolved)
+    assert resolved["properties"]["node"]["properties"]["child"]["type"] == "object"
+
+
 # ---------------------------------------------------------------------------
 # Defensive checks
 # ---------------------------------------------------------------------------
@@ -422,6 +507,47 @@ def test_no_refs_anywhere():
         s = str(r.parameters)
         assert "$ref" not in s, f"{tool_obj.name} has $ref"
         assert "$defs" not in s, f"{tool_obj.name} has $defs"
+
+
+@pytest.mark.requires("oci")
+def test_converted_tool_schema_strips_title_and_null_defaults():
+    """Converted tool schemas should not retain title or default null metadata."""
+    r = _result(multi_optional_tool)
+    s = str(r.parameters)
+    assert "title" not in s
+    assert "'default': None" not in s
+
+
+@pytest.mark.requires("oci")
+def test_public_chat_model_tool_conversion_sanitizes_metadata():
+    """Public ChatOCIGenAI tool conversion should strip noisy schema metadata."""
+    from langchain_oci.chat_models import ChatOCIGenAI
+
+    class OptionalMetadataInput(BaseModel):
+        tags: List[str] = Field(
+            description="Tags",
+            json_schema_extra={"items": {"type": "string"}},
+        )
+        nickname: Optional[str] = Field(default=None, description="Optional nickname")
+
+    @tool(args_schema=OptionalMetadataInput)
+    def optional_metadata_tool(tags: List[str], nickname: Optional[str] = None) -> str:
+        """Return normalized metadata."""
+        return f"{tags}:{nickname}"
+
+    llm = ChatOCIGenAI(
+        model_id="google.gemini-2.5-flash",
+        client=MagicMock(),
+        model_kwargs={"temperature": 0, "max_tokens": 32},
+    )
+
+    oci_tool = llm._provider.convert_to_oci_tool(optional_metadata_tool)
+    params = oci_tool.parameters
+    schema_str = str(params)
+
+    assert "title" not in schema_str
+    assert "'default': None" not in schema_str
+    assert params["properties"]["tags"]["items"]["type"] == "string"
 
 
 @pytest.mark.requires("oci")


### PR DESCRIPTION
## Summary
Harden OCI tool schema conversion before provider-specific tool conversion.

Closes #156.

## Why this change exists
OCI tool calling is only as reliable as the schema we send to the backend. The shared conversion path already resolves some schema features, but it still allows a few invalid or noisy constructs through.

That creates two practical problems:
- correctness risk, where OCI receives an internally inconsistent schema
- reliability risk, where models see extra schema noise or underspecified shapes and produce worse tool-call arguments

This shows up most clearly with stricter models such as Gemini, but it is not a Gemini-only problem. Meta, Cohere, Grok, and GPT-family models also benefit when the tool schema is smaller, internally consistent, and OCI-safe.

Fixing this in the common OCI conversion layer is higher-value than leaving downstream applications to patch tool schemas individually.

## What changed
- add a shared schema sanitization step in `langchain_oci.common.utils`
- prune `required` entries that no longer exist in `properties`
- remove recursive `title` and `default: null` metadata
- normalize `type: any` and nullable type arrays
- ensure arrays always declare an `items` schema
- handle circular `$ref` chains defensively
- apply the sanitizer in both Generic and Cohere tool conversion paths

## Value
This improves the shared OCI integration across model families:
- fewer invalid schemas at the OCI boundary
- less schema noise sent to the model
- more consistent tool definitions across Gemini, Meta, Cohere, Grok, and GPT-family models
- less need for downstream application-level schema cleanup shims

## Validation
Unit coverage:
- `python -m pytest tests/unit_tests/chat_models/test_tool_schema_constraints.py`

Integration coverage:
- `python -m pytest tests/integration_tests/chat_models/test_tool_schema_constraints.py`

Live OCI validation:
- Gemini: schema conversion and tool-calling constraints verified
- Meta: schema conversion and tool-calling constraints verified
- Cohere: schema conversion and tool-calling constraints verified
- Grok: schema conversion and tool-calling constraints verified
- GPT-family: schema conversion and tool-calling constraints verified

## Non-goals
This PR does not change:
- ToolMessage handling
- message ordering rules
- model-specific runtime behavior

Those should stay in follow-up PRs.
