### PR TITLE
bugfix(oci): handle GPT-5 parameter compatibility

### DIFF
--- a/libs/oci/langchain_oci/chat_models/async_mixin.py
+++ b/libs/oci/langchain_oci/chat_models/async_mixin.py
@@ -18,7 +18,11 @@ from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, Tool
 from langchain_core.messages.ai import UsageMetadata
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 
-from langchain_oci.common.async_support import OCIAsyncClient
+from langchain_oci.common.async_support import OCIAsyncClient, OCIAsyncRequestError
+from langchain_oci.common.param_compat import (
+    PARAM_RETRY_ATTEMPTS,
+    adjust_request_for_param_error,
+)
 from langchain_oci.llms.utils import enforce_stop_tokens
 
 
@@ -110,16 +114,30 @@ class ChatOCIGenAIAsyncMixin:
             messages, stop, stream=False, **kwargs
         )
 
-        # Get single response
+        # Get single response, retrying after fixable 400 parameter errors
+        # (mirrors the sync _chat_with_param_retry; e.g. legacy openai.gpt-5
+        # rejects non-default temperature/top_p with 400 unsupported_value).
         response_data = None
-        async for data in client.chat_async(
-            compartment_id=request_data["compartment_id"],
-            chat_request_dict=request_data["chat_request_dict"],
-            serving_mode_dict=request_data["serving_mode_dict"],
-            stream=False,
-        ):
-            response_data = data
-            break
+        for attempt in range(PARAM_RETRY_ATTEMPTS):
+            try:
+                async for data in client.chat_async(
+                    compartment_id=request_data["compartment_id"],
+                    chat_request_dict=request_data["chat_request_dict"],
+                    serving_mode_dict=request_data["serving_mode_dict"],
+                    stream=False,
+                ):
+                    response_data = data
+                    break
+                break
+            except OCIAsyncRequestError as e:
+                if (
+                    e.status != 400
+                    or attempt == PARAM_RETRY_ATTEMPTS - 1
+                    or not adjust_request_for_param_error(
+                        e.body, request_data["chat_request_dict"]
+                    )
+                ):
+                    raise
 
         if response_data is None:
             raise RuntimeError("No response received from OCI GenAI")
@@ -188,12 +206,40 @@ class ChatOCIGenAIAsyncMixin:
         if reset is not None:
             reset()
 
-        async for event_data in client.chat_async(
-            compartment_id=request_data["compartment_id"],
-            chat_request_dict=request_data["chat_request_dict"],
-            serving_mode_dict=request_data["serving_mode_dict"],
-            stream=True,
-        ):
+        async def _events_with_param_retry() -> AsyncIterator[Dict[str, Any]]:
+            """Open the stream, retrying after fixable 400 parameter errors.
+
+            A non-200 surfaces before the first event, so only the first
+            fetch is retried (mirroring the sync _chat_with_param_retry);
+            mid-stream errors propagate unchanged.
+            """
+            for attempt in range(PARAM_RETRY_ATTEMPTS):
+                stream = client.chat_async(
+                    compartment_id=request_data["compartment_id"],
+                    chat_request_dict=request_data["chat_request_dict"],
+                    serving_mode_dict=request_data["serving_mode_dict"],
+                    stream=True,
+                )
+                try:
+                    first = await stream.__anext__()
+                except StopAsyncIteration:
+                    return
+                except OCIAsyncRequestError as e:
+                    if (
+                        e.status != 400
+                        or attempt == PARAM_RETRY_ATTEMPTS - 1
+                        or not adjust_request_for_param_error(
+                            e.body, request_data["chat_request_dict"]
+                        )
+                    ):
+                        raise
+                    continue
+                yield first
+                async for event in stream:
+                    yield event
+                return
+
+        async for event_data in _events_with_param_retry():
             if not self._provider.is_chat_stream_end(event_data):  # type: ignore[attr-defined]
                 # Process streaming content
                 delta = self._provider.chat_stream_to_text(event_data)  # type: ignore[attr-defined]

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -5,6 +5,7 @@
 
 import importlib
 import json
+import warnings
 from operator import itemgetter
 from typing import (
     Any,
@@ -45,6 +46,7 @@ from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResu
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
 from langchain_openai import ChatOpenAI
+from oci.exceptions import ServiceError
 from openai import DefaultAsyncHttpxClient, DefaultHttpxClient
 from pydantic import BaseModel, ConfigDict, SecretStr, model_validator
 
@@ -65,6 +67,96 @@ API_KEY = "<NOTUSED>"
 COMPARTMENT_ID_HEADER = "opc-compartment-id"
 CONVERSATION_STORE_ID_HEADER = "opc-conversation-store-id"
 OUTPUT_VERSION = "responses/v1"
+
+
+# OCI parameter names (camelCase) → ChatRequest attribute names (snake_case)
+_OCI_PARAM_TO_ATTR = {
+    "temperature": "temperature",
+    "top_p": "top_p",
+    "topP": "top_p",
+    "maxTokens": "max_tokens",
+    "max_tokens": "max_tokens",
+    "maxCompletionTokens": "max_completion_tokens",
+}
+
+# Known parameter renames: when OCI says "use X instead", map old → new
+_OCI_PARAM_RENAME = {
+    "max_tokens": "max_completion_tokens",
+    "maxTokens": "max_completion_tokens",
+}
+
+
+def _handle_unsupported_param_error(message: str, request: Any) -> bool:
+    """Parse an OCI 400 error and fix the request in place if possible.
+
+    Returns True if the request was modified and should be retried.
+    """
+    import json as _json
+
+    # Try to parse structured error (JSON body)
+    param = None
+    code = None
+    try:
+        err = _json.loads(message).get("error", {})
+        param = err.get("param")
+        code = err.get("code")
+    except (ValueError, TypeError, AttributeError):
+        pass
+
+    chat_req = request.chat_request
+
+    # Case 1: unsupported_value — drop the param (e.g. temperature=0.3 on GPT-5)
+    if param and code == "unsupported_value":
+        attr = _OCI_PARAM_TO_ATTR.get(param, param)
+        if hasattr(chat_req, attr):
+            setattr(chat_req, attr, None)
+            warnings.warn(
+                f"OCI rejected '{param}' for this model; removed and retrying.",
+                UserWarning,
+                stacklevel=4,
+            )
+            return True
+
+    # Case 2: unsupported_parameter — drop or rename
+    if param and code == "unsupported_parameter":
+        attr = _OCI_PARAM_TO_ATTR.get(param, param)
+        rename_to = _OCI_PARAM_RENAME.get(param)
+        if rename_to and hasattr(chat_req, rename_to):
+            old_val = getattr(chat_req, attr, None)
+            if old_val is not None:
+                setattr(chat_req, rename_to, old_val)
+                setattr(chat_req, attr, None)
+                warnings.warn(
+                    f"OCI rejected '{param}'; converted to '{rename_to}' and retrying.",
+                    UserWarning,
+                    stacklevel=4,
+                )
+                return True
+        # No rename — just drop
+        if hasattr(chat_req, attr):
+            setattr(chat_req, attr, None)
+            warnings.warn(
+                f"OCI rejected '{param}' for this model; removed and retrying.",
+                UserWarning,
+                stacklevel=4,
+            )
+            return True
+
+    # Case 3: unstructured message — "Use 'maxCompletionTokens' instead"
+    if "maxTokens" in message and "maxCompletionTokens" in message:
+        old_val = getattr(chat_req, "max_tokens", None)
+        if old_val is not None:
+            chat_req.max_completion_tokens = old_val
+            chat_req.max_tokens = None
+            warnings.warn(
+                "OCI rejected 'max_tokens'; converted to 'max_completion_tokens' "
+                "and retrying.",
+                UserWarning,
+                stacklevel=4,
+            )
+            return True
+
+    return False
 
 
 def _build_headers(
@@ -482,7 +574,21 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
             return generate_from_stream(stream_iter)
 
         request = self._prepare_request(messages, stop=stop, stream=False, **kwargs)
-        response = self.client.chat(request)
+
+        # Retry loop: if OCI rejects an unsupported param, fix and retry once
+        _max_retries = 3
+        for _attempt in range(_max_retries):
+            try:
+                response = self.client.chat(request)
+                break
+            except ServiceError as e:
+                if (
+                    e.status == 400
+                    and _attempt < _max_retries - 1
+                    and _handle_unsupported_param_error(e.message, request)
+                ):
+                    continue
+                raise
 
         content = self._provider.chat_response_to_text(response)
 
@@ -544,7 +650,21 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         Processes each event and yields chunks until the stream ends.
         """
         request = self._prepare_request(messages, stop=stop, stream=True, **kwargs)
-        response = self.client.chat(request)
+
+        # Retry loop: if OCI rejects an unsupported param, fix and retry once
+        _max_retries = 3
+        for _attempt in range(_max_retries):
+            try:
+                response = self.client.chat(request)
+                break
+            except ServiceError as e:
+                if (
+                    e.status == 400
+                    and _attempt < _max_retries - 1
+                    and _handle_unsupported_param_error(e.message, request)
+                ):
+                    continue
+                raise
         tool_call_ids: Dict[int, str] = {}
 
         # Reset any per-stream provider state (currently the GenericProvider's

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -45,6 +45,7 @@ from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResu
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
 from langchain_openai import ChatOpenAI
+from oci.exceptions import ServiceError
 from openai import DefaultAsyncHttpxClient, DefaultHttpxClient
 from pydantic import BaseModel, ConfigDict, SecretStr, model_validator
 
@@ -56,6 +57,10 @@ from langchain_oci.chat_models.providers import (
     MetaProvider,
     OpenAIProvider,
     Provider,
+)
+from langchain_oci.common.param_compat import (
+    PARAM_RETRY_ATTEMPTS,
+    adjust_request_for_param_error,
 )
 from langchain_oci.common.utils import CUSTOM_ENDPOINT_PREFIX, OCIUtils
 from langchain_oci.llms.oci_generative_ai import OCIGenAIBase
@@ -482,7 +487,7 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
             return generate_from_stream(stream_iter)
 
         request = self._prepare_request(messages, stop=stop, stream=False, **kwargs)
-        response = self.client.chat(request)
+        response = self._chat_with_param_retry(request)
 
         content = self._provider.chat_response_to_text(response)
 
@@ -531,6 +536,26 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
             llm_output=llm_output,
         )
 
+    def _chat_with_param_retry(self, request: Any) -> Any:
+        """Call ``client.chat``, retrying after fixable 400 parameter errors.
+
+        Some models reject parameters only at request time (e.g. legacy
+        ``openai.gpt-5``: ``400 unsupported_value`` for non-default
+        ``temperature``/``top_p``). Parse the structured error, drop or
+        rename the rejected parameter on the request, and retry.
+        """
+        for attempt in range(PARAM_RETRY_ATTEMPTS):
+            try:
+                return self.client.chat(request)
+            except ServiceError as e:
+                if (
+                    e.status != 400
+                    or attempt == PARAM_RETRY_ATTEMPTS - 1
+                    or not adjust_request_for_param_error(e, request.chat_request)
+                ):
+                    raise
+        raise RuntimeError("unreachable")  # pragma: no cover
+
     def _stream(
         self,
         messages: List[BaseMessage],
@@ -544,7 +569,7 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         Processes each event and yields chunks until the stream ends.
         """
         request = self._prepare_request(messages, stop=stop, stream=True, **kwargs)
-        response = self.client.chat(request)
+        response = self._chat_with_param_retry(request)
         tool_call_ids: Dict[int, str] = {}
 
         # Reset any per-stream provider state (currently the GenericProvider's

--- a/libs/oci/langchain_oci/common/async_support.py
+++ b/libs/oci/langchain_oci/common/async_support.py
@@ -38,6 +38,21 @@ def _get_oci_genai_api_version() -> str:
 OCI_GENAI_API_VERSION = _get_oci_genai_api_version()
 
 
+class OCIAsyncRequestError(RuntimeError):
+    """Non-200 response from the async OCI GenAI REST call.
+
+    Subclasses ``RuntimeError`` (the exception previously raised here) so
+    existing ``except RuntimeError`` handlers keep working, while exposing
+    the HTTP ``status`` and raw response ``body`` for structured handling —
+    e.g. the parameter-compatibility retry in the async chat paths.
+    """
+
+    def __init__(self, status: int, body: str):
+        super().__init__(f"OCI GenAI request failed with status {status}: {body}")
+        self.status = status
+        self.body = body
+
+
 class OCIAsyncClient:
     """Async HTTP client for OCI Generative AI services.
 
@@ -241,10 +256,7 @@ class OCIAsyncClient:
         async with self._arequest("POST", url, headers, body, timeout) as response:
             if response.status != 200:
                 error_text = await response.text()
-                raise RuntimeError(
-                    f"OCI GenAI request failed with status "
-                    f"{response.status}: {error_text}"
-                )
+                raise OCIAsyncRequestError(response.status, error_text)
 
             if stream:
                 async for event in self._parse_sse_async(response.content):

--- a/libs/oci/langchain_oci/common/param_compat.py
+++ b/libs/oci/langchain_oci/common/param_compat.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Reactive parameter-compatibility handling for OCI GenAI 400 responses.
+
+Some models reject request parameters at call time rather than by schema —
+e.g. legacy ``openai.gpt-5`` returns ``400 unsupported_value`` for
+non-default ``temperature``/``top_p``. Instead of hardcoding per-model
+predicates, these helpers parse the structured error OCI returns, remove
+(or rename) the rejected parameter on the outgoing request, and let the
+caller retry. This works for any current or future model.
+
+Shared by the sync path (SDK ``ChatRequest`` objects raising
+``oci.exceptions.ServiceError``) and the async path (camelCase wire dicts
+raising :class:`~langchain_oci.common.async_support.OCIAsyncRequestError`).
+"""
+
+import json
+import warnings
+from typing import Any, Optional, Tuple
+
+from oci.exceptions import ServiceError
+
+# Retry budget for parameter-compatibility retries on 400 responses.
+PARAM_RETRY_ATTEMPTS = 3
+
+# Wire parameter names (camelCase, as OCI reports them in error payloads)
+# mapped to the SDK ChatRequest attribute names used on the sync path.
+_OCI_PARAM_TO_ATTR = {
+    "topP": "top_p",
+    "topK": "top_k",
+    "maxTokens": "max_tokens",
+    "maxCompletionTokens": "max_completion_tokens",
+    "frequencyPenalty": "frequency_penalty",
+    "presencePenalty": "presence_penalty",
+}
+
+# When OCI rejects a parameter outright, prefer renaming its value to the
+# supported equivalent over dropping it (wire-name space).
+_OCI_PARAM_RENAME = {
+    "maxTokens": "maxCompletionTokens",
+    "max_tokens": "maxCompletionTokens",
+}
+
+
+def extract_unsupported_param(payload: Any) -> Tuple[Optional[str], Optional[str]]:
+    """Extract ``(param, code)`` from an OCI 400 error payload.
+
+    Accepts an ``oci.exceptions.ServiceError``, a response-body string, or
+    a parsed body dict. Returns ``(None, None)`` when the error carries no
+    structured parameter info; never raises on missing or ``None`` fields.
+
+    Note: for OpenAI-style bodies (``{"error": {"param": ..., "code": ...}}``)
+    the OCI SDK does not promote the nested payload into
+    ``ServiceError.message`` (which is then ``None``); the deserialized body
+    is merged into the exception's ``args[0]`` details dict instead.
+    """
+    body: Any = payload
+    if isinstance(payload, ServiceError):
+        details = payload.args[0] if payload.args else None
+        body = details if isinstance(details, dict) else {}
+        if "error" not in body and isinstance(payload.message, str):
+            body = payload.message
+    if isinstance(body, str):
+        try:
+            body = json.loads(body)
+        except ValueError:
+            return None, None
+    if not isinstance(body, dict):
+        return None, None
+    err = body.get("error")
+    if not isinstance(err, dict):
+        # OCI envelope: {"code": "400", "message": "<json string>"} where the
+        # OpenAI-style error is double-encoded inside the message string
+        # (observed live on the async REST path).
+        inner = body.get("message")
+        if isinstance(inner, str):
+            return extract_unsupported_param(inner)
+        return None, None
+    param = err.get("param")
+    code = err.get("code")
+    return (
+        param if isinstance(param, str) else None,
+        code if isinstance(code, str) else None,
+    )
+
+
+def drop_unsupported_param(chat_request: Any, param: str) -> bool:
+    """Remove or rename a rejected parameter on the outgoing request.
+
+    Works on both the sync SDK ``ChatRequest`` object and the async
+    camelCase wire dict. Returns True if the request changed.
+    """
+    rename = _OCI_PARAM_RENAME.get(param)
+    if isinstance(chat_request, dict):
+        if chat_request.get(param) is None:
+            return False
+        value = chat_request.pop(param)
+        if rename and chat_request.get(rename) is None:
+            chat_request[rename] = value
+        return True
+    attr = _OCI_PARAM_TO_ATTR.get(param, param)
+    if getattr(chat_request, attr, None) is None:
+        return False
+    value = getattr(chat_request, attr)
+    setattr(chat_request, attr, None)
+    if rename:
+        rename_attr = _OCI_PARAM_TO_ATTR.get(rename, rename)
+        if hasattr(chat_request, rename_attr) and (
+            getattr(chat_request, rename_attr) is None
+        ):
+            setattr(chat_request, rename_attr, value)
+    return True
+
+
+def adjust_request_for_param_error(error_payload: Any, chat_request: Any) -> bool:
+    """Fix the request in place after a parameter-compatibility 400.
+
+    Returns True if the request was modified and the call should be
+    retried; False when the error isn't a recognizable parameter
+    rejection (caller should re-raise).
+    """
+    param, code = extract_unsupported_param(error_payload)
+    if not param or code not in ("unsupported_value", "unsupported_parameter"):
+        return False
+    if not drop_unsupported_param(chat_request, param):
+        return False
+    action = (
+        f"renamed to '{_OCI_PARAM_RENAME[param]}'"
+        if code == "unsupported_parameter" and param in _OCI_PARAM_RENAME
+        else "removed"
+    )
+    warnings.warn(
+        f"OCI rejected parameter '{param}' ({code}) for this model; "
+        f"{action} and retrying the request.",
+        UserWarning,
+        stacklevel=2,
+    )
+    return True

--- a/libs/oci/tests/integration_tests/agents/test_react_integration.py
+++ b/libs/oci/tests/integration_tests/agents/test_react_integration.py
@@ -348,3 +348,47 @@ def test_multi_model_support(model_id: str) -> None:
     # Verify we got a response
     assert "messages" in result
     assert len(result["messages"]) > 1
+
+
+@pytest.mark.requires("oci", "langgraph")
+@pytest.mark.skipif(
+    skip_if_no_oci_credentials(),
+    reason="OCI credentials not available (OCI_COMPARTMENT_ID not set)",
+)
+def test_openai_gpt5_tool_calling() -> None:
+    """Test GPT-5 tool calling works end-to-end with create_oci_agent."""
+    compartment_id = os.environ.get("OCI_COMPARTMENT_ID") or os.environ.get(
+        "OCI_COMP", ""
+    )
+    region = os.environ.get("OCI_REGION", "us-chicago-1")
+    service_endpoint = f"https://inference.generativeai.{region}.oci.oraclecloud.com"
+
+    agent = create_oci_agent(
+        model_id="openai.gpt-5",
+        tools=[get_weather],
+        compartment_id=compartment_id,
+        service_endpoint=service_endpoint,
+        auth_type="API_KEY",
+        auth_profile="API_KEY_AUTH",
+        system_prompt="You are a weather assistant. Always use the get_weather tool.",
+        temperature=0.3,
+        max_tokens=512,
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [
+                HumanMessage(content="What's the weather in Chicago? Use the tool.")
+            ]
+        }
+    )
+
+    assert "messages" in result
+    message_types = [type(m).__name__ for m in result["messages"]]
+    assert "ToolMessage" in message_types, (
+        "GPT-5 should issue a tool call that the agent executes. "
+        f"Message types: {message_types}"
+    )
+
+    final_message = result["messages"][-1]
+    assert getattr(final_message, "content", ""), "Final message should not be empty"

--- a/libs/oci/tests/integration_tests/agents/test_react_integration.py
+++ b/libs/oci/tests/integration_tests/agents/test_react_integration.py
@@ -348,3 +348,76 @@ def test_multi_model_support(model_id: str) -> None:
     # Verify we got a response
     assert "messages" in result
     assert len(result["messages"]) > 1
+
+
+@pytest.mark.requires("oci", "langgraph")
+@pytest.mark.skipif(
+    skip_if_no_oci_credentials(),
+    reason="OCI credentials not available (OCI_COMPARTMENT_ID not set)",
+)
+def test_openai_gpt5_tool_calling() -> None:
+    """GPT-5 tool calling works end-to-end despite unsupported params.
+
+    Legacy openai.gpt-5 rejects non-default temperature with a 400
+    unsupported_value; the reactive parameter retry must absorb it.
+    """
+    compartment_id = os.environ.get("OCI_COMPARTMENT_ID", "")
+    region = os.environ.get("OCI_REGION", "us-chicago-1")
+    service_endpoint = f"https://inference.generativeai.{region}.oci.oraclecloud.com"
+    auth_type = os.environ.get("OCI_AUTH_TYPE", "API_KEY")
+    auth_profile = os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT")
+
+    agent = create_oci_agent(
+        model_id="openai.gpt-5",
+        tools=[get_weather],
+        compartment_id=compartment_id,
+        service_endpoint=service_endpoint,
+        auth_type=auth_type,
+        auth_profile=auth_profile,
+        system_prompt="You are a weather assistant. Always use the get_weather tool.",
+        temperature=0.3,
+        max_tokens=512,
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [
+                HumanMessage(content="What's the weather in Chicago? Use the tool.")
+            ]
+        }
+    )
+
+    assert "messages" in result
+    message_types = [type(m).__name__ for m in result["messages"]]
+    assert "ToolMessage" in message_types, (
+        "GPT-5 should issue a tool call that the agent executes. "
+        f"Message types: {message_types}"
+    )
+
+    final_message = result["messages"][-1]
+    assert getattr(final_message, "content", ""), "Final message should not be empty"
+
+
+@pytest.mark.requires("oci", "langgraph")
+@pytest.mark.skipif(
+    skip_if_no_oci_credentials(),
+    reason="OCI credentials not available (OCI_COMPARTMENT_ID not set)",
+)
+async def test_openai_gpt5_async_param_retry() -> None:
+    """The async path also absorbs GPT-5 parameter rejections (ainvoke)."""
+    from langchain_oci.chat_models import ChatOCIGenAI
+
+    region = os.environ.get("OCI_REGION", "us-chicago-1")
+    llm = ChatOCIGenAI(
+        model_id="openai.gpt-5",
+        service_endpoint=(
+            f"https://inference.generativeai.{region}.oci.oraclecloud.com"
+        ),
+        compartment_id=os.environ.get("OCI_COMPARTMENT_ID", ""),
+        auth_type=os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
+        auth_profile=os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
+        model_kwargs={"temperature": 0.3, "max_tokens": 128},
+    )
+
+    response = await llm.ainvoke([HumanMessage(content="Say OK.")])
+    assert response.content

--- a/libs/oci/tests/unit_tests/chat_models/test_gpt5_param_compat.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_gpt5_param_compat.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for reactive parameter-compatibility retries (GPT-5, issue-style).
+
+Some models reject request parameters only at call time — e.g. legacy
+``openai.gpt-5`` returns ``400 unsupported_value`` for non-default
+``temperature``/``top_p``. These tests cover the structured-error
+extraction, the request adjustment on both sync SDK objects and async
+wire dicts, and the end-to-end retry on both paths.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import HumanMessage
+from oci.exceptions import ServiceError
+
+from langchain_oci.chat_models import ChatOCIGenAI
+from langchain_oci.common.async_support import OCIAsyncClient, OCIAsyncRequestError
+from langchain_oci.common.param_compat import (
+    adjust_request_for_param_error,
+    drop_unsupported_param,
+    extract_unsupported_param,
+)
+
+
+class MockResponseDict(dict):
+    def __getattr__(self, val):
+        return self.get(val)
+
+
+OPENAI_STYLE_ERROR = {"error": {"param": "temperature", "code": "unsupported_value"}}
+
+
+def _service_error(deserialized_data=None, message=None):
+    return ServiceError(
+        400,
+        "unsupported_value",
+        {},
+        message,
+        deserialized_data=deserialized_data,
+    )
+
+
+# --------------- extraction ---------------
+
+
+def test_extract_from_service_error_structured_body():
+    """OpenAI-style bodies live in args[0], not .message (which is None)."""
+    e = _service_error(deserialized_data=OPENAI_STYLE_ERROR)
+    assert e.message is None
+    assert extract_unsupported_param(e) == ("temperature", "unsupported_value")
+
+
+def test_extract_from_service_error_none_message_no_typeerror():
+    """A bare 400 with no body must yield (None, None), not raise."""
+    e = _service_error()
+    assert e.message is None
+    assert extract_unsupported_param(e) == (None, None)
+
+
+def test_extract_from_service_error_json_string_message():
+    """OCI-standard bodies may carry the JSON in the message string."""
+    body = '{"error": {"param": "topP", "code": "unsupported_value"}}'
+    e = _service_error(message=body)
+    assert extract_unsupported_param(e) == ("topP", "unsupported_value")
+
+
+def test_extract_from_async_body_string():
+    """The async path hands over the raw response body text."""
+    body = '{"error": {"param": "temperature", "code": "unsupported_value"}}'
+    assert extract_unsupported_param(body) == ("temperature", "unsupported_value")
+
+
+def test_extract_from_garbage_is_none():
+    assert extract_unsupported_param("Internal error") == (None, None)
+    assert extract_unsupported_param(None) == (None, None)
+    assert extract_unsupported_param({"error": "nope"}) == (None, None)
+
+
+# --------------- request adjustment ---------------
+
+
+def test_drop_param_on_sdk_object_with_wire_name():
+    req = SimpleNamespace(top_p=0.9, temperature=0.3)
+    assert drop_unsupported_param(req, "topP") is True
+    assert req.top_p is None
+    assert req.temperature == 0.3
+
+
+def test_rename_max_tokens_on_sdk_object():
+    req = SimpleNamespace(max_tokens=512, max_completion_tokens=None)
+    assert drop_unsupported_param(req, "maxTokens") is True
+    assert req.max_tokens is None
+    assert req.max_completion_tokens == 512
+
+
+def test_drop_param_on_wire_dict():
+    req = {"temperature": 0.3, "topP": 0.9}
+    assert drop_unsupported_param(req, "temperature") is True
+    assert "temperature" not in req
+    assert req["topP"] == 0.9
+
+
+def test_rename_max_tokens_on_wire_dict():
+    req = {"maxTokens": 512}
+    assert drop_unsupported_param(req, "maxTokens") is True
+    assert req == {"maxCompletionTokens": 512}
+
+
+def test_adjust_returns_false_when_param_absent():
+    """Unfixable errors must not claim success (caller re-raises the 400)."""
+    assert (
+        adjust_request_for_param_error(
+            '{"error": {"param": "temperature", "code": "unsupported_value"}}',
+            {"topP": 0.9},
+        )
+        is False
+    )
+    assert adjust_request_for_param_error("not json", {"temperature": 0.3}) is False
+
+
+# --------------- sync end-to-end retry ---------------
+
+
+def _mock_chat_response(text="ok"):
+    return MockResponseDict(
+        {
+            "status": 200,
+            "data": MockResponseDict(
+                {
+                    "chat_response": MockResponseDict(
+                        {
+                            "api_format": "GENERIC",
+                            "choices": [
+                                MockResponseDict(
+                                    {
+                                        "message": MockResponseDict(
+                                            {
+                                                "role": "ASSISTANT",
+                                                "content": [
+                                                    MockResponseDict(
+                                                        {"text": text, "type": "TEXT"}
+                                                    )
+                                                ],
+                                                "tool_calls": [],
+                                            }
+                                        ),
+                                        "finish_reason": "stop",
+                                    }
+                                )
+                            ],
+                            "time_created": "2026-01-01T00:00:00+00:00",
+                        }
+                    ),
+                    "model_id": "openai.gpt-5",
+                    "model_version": "1.0",
+                }
+            ),
+            "request_id": "req-1",
+            "headers": MockResponseDict({"content-length": "10"}),
+        }
+    )
+
+
+@pytest.mark.requires("oci")
+def test_sync_invoke_retries_after_unsupported_value():
+    """First call 400s on temperature; retry succeeds with it removed."""
+    oci_client = MagicMock()
+    llm = ChatOCIGenAI(
+        model_id="openai.gpt-5",
+        client=oci_client,
+        model_kwargs={"temperature": 0.3, "max_tokens": 100},
+    )
+
+    seen_temperatures = []
+
+    def chat(request):
+        seen_temperatures.append(request.chat_request.temperature)
+        if len(seen_temperatures) == 1:
+            raise _service_error(deserialized_data=OPENAI_STYLE_ERROR)
+        return _mock_chat_response()
+
+    oci_client.chat.side_effect = chat
+
+    with pytest.warns(UserWarning, match="temperature"):
+        response = llm.invoke([HumanMessage(content="hi")])
+
+    assert response.content == "ok"
+    assert seen_temperatures == [0.3, None]
+
+
+@pytest.mark.requires("oci")
+def test_sync_invoke_reraises_unfixable_400():
+    """400s without a fixable parameter propagate unchanged."""
+    oci_client = MagicMock()
+    llm = ChatOCIGenAI(
+        model_id="openai.gpt-5",
+        client=oci_client,
+        model_kwargs={"temperature": 0.3},
+    )
+    oci_client.chat.side_effect = _service_error()
+
+    with pytest.raises(ServiceError):
+        llm.invoke([HumanMessage(content="hi")])
+    assert oci_client.chat.call_count == 1
+
+
+# --------------- async end-to-end retry ---------------
+
+
+ASYNC_ERROR_BODY = '{"error": {"param": "temperature", "code": "unsupported_value"}}'
+
+
+def _install_fake_chat_async(monkeypatch, calls):
+    """chat_async that 400s the first call, then succeeds."""
+
+    def fake_chat_async(
+        self, compartment_id, chat_request_dict, serving_mode_dict, stream
+    ):
+        async def gen():
+            calls.append(dict(chat_request_dict))
+            if len(calls) == 1:
+                raise OCIAsyncRequestError(400, ASYNC_ERROR_BODY)
+            if stream:
+                yield {
+                    "message": {
+                        "role": "ASSISTANT",
+                        "content": [{"type": "TEXT", "text": "ok"}],
+                    }
+                }
+                yield {"finishReason": "stop"}
+            else:
+                yield {
+                    "chatResponse": {
+                        "choices": [
+                            {
+                                "message": {
+                                    "role": "ASSISTANT",
+                                    "content": [{"type": "TEXT", "text": "ok"}],
+                                },
+                                "finishReason": "stop",
+                            }
+                        ]
+                    },
+                    "modelId": "openai.gpt-5",
+                    "modelVersion": "1.0",
+                }
+
+        return gen()
+
+    monkeypatch.setattr(OCIAsyncClient, "chat_async", fake_chat_async)
+
+
+def _fake_serialize(obj):
+    """Minimal stand-in for BaseClient.sanitize_for_serialization: SDK
+    model objects -> camelCase wire dicts, skipping None fields."""
+    if hasattr(obj, "attribute_map"):
+        return {
+            wire: _fake_serialize(getattr(obj, attr))
+            for attr, wire in obj.attribute_map.items()
+            if getattr(obj, attr) is not None
+        }
+    if isinstance(obj, list):
+        return [_fake_serialize(o) for o in obj]
+    if isinstance(obj, dict):
+        return {k: _fake_serialize(v) for k, v in obj.items()}
+    return obj
+
+
+def _make_async_llm():
+    oci_client = MagicMock()
+    oci_client.base_client.signer = MagicMock()
+    oci_client.base_client.config = {}
+    oci_client.base_client.sanitize_for_serialization = _fake_serialize
+    return ChatOCIGenAI(
+        model_id="openai.gpt-5",
+        client=oci_client,
+        service_endpoint="https://example.invalid",
+        model_kwargs={"temperature": 0.3},
+    )
+
+
+@pytest.mark.requires("oci")
+async def test_async_invoke_retries_after_unsupported_value(monkeypatch):
+    calls: list = []
+    _install_fake_chat_async(monkeypatch, calls)
+    llm = _make_async_llm()
+
+    with pytest.warns(UserWarning, match="temperature"):
+        response = await llm.ainvoke([HumanMessage(content="hi")])
+
+    assert response.content == "ok"
+    assert len(calls) == 2
+    assert calls[0].get("temperature") == 0.3
+    assert "temperature" not in calls[1]
+
+
+@pytest.mark.requires("oci")
+async def test_async_stream_retries_after_unsupported_value(monkeypatch):
+    calls: list = []
+    _install_fake_chat_async(monkeypatch, calls)
+    llm = _make_async_llm()
+
+    with pytest.warns(UserWarning, match="temperature"):
+        chunks = [c async for c in llm.astream([HumanMessage(content="hi")])]
+
+    assert any(c.content == "ok" for c in chunks)
+    assert len(calls) == 2
+    assert "temperature" not in calls[1]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+
+
+def test_extract_from_double_encoded_oci_envelope():
+    """Live async wire shape: OCI envelope with the error JSON re-encoded
+    inside the message string (observed against openai.gpt-5)."""
+    body = (
+        '{ "code": "400", "message": "{\\n  \\"error\\": {\\n    '
+        '\\"message\\": \\"Unsupported value...\\",\\n    '
+        '\\"type\\": \\"invalid_request_error\\",\\n    '
+        '\\"param\\": \\"temperature\\",\\n    '
+        '\\"code\\": \\"unsupported_value\\"\\n  }\\n}" }'
+    )
+    assert extract_unsupported_param(body) == ("temperature", "unsupported_value")

--- a/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
@@ -1397,6 +1397,132 @@ def test_tool_choice_none_after_tool_results() -> None:
     assert len(request.chat_request.tools) > 0
 
 
+@pytest.mark.requires("oci")
+def test_retry_strips_unsupported_temperature() -> None:
+    """OCI 400 for unsupported temperature should be retried with param removed."""
+    import json as _json
+
+    from langchain_oci.chat_models.oci_generative_ai import (
+        _handle_unsupported_param_error,
+    )
+
+    oci_gen_ai_client = MagicMock()
+    llm = ChatOCIGenAI(
+        model_id="openai.gpt-5",
+        client=oci_gen_ai_client,
+        model_kwargs={"temperature": 0.3, "max_completion_tokens": 1024},
+    )
+
+    request = llm._prepare_request(
+        [HumanMessage(content="hi")], stop=None, stream=False
+    )
+    assert request.chat_request.temperature == 0.3
+
+    error_msg = _json.dumps(
+        {
+            "error": {
+                "message": "Unsupported value",
+                "type": "invalid_request_error",
+                "param": "temperature",
+                "code": "unsupported_value",
+            }
+        }
+    )
+    modified = _handle_unsupported_param_error(error_msg, request)
+    assert modified is True
+    assert request.chat_request.temperature is None
+    assert request.chat_request.max_completion_tokens == 1024
+
+
+@pytest.mark.requires("oci")
+def test_retry_converts_max_tokens_to_max_completion_tokens() -> None:
+    """OCI 400 for maxTokens should rename to max_completion_tokens and retry."""
+    from langchain_oci.chat_models.oci_generative_ai import (
+        _handle_unsupported_param_error,
+    )
+
+    oci_gen_ai_client = MagicMock()
+    llm = ChatOCIGenAI(
+        model_id="openai.gpt-5",
+        client=oci_gen_ai_client,
+        model_kwargs={"max_tokens": 512},
+    )
+
+    request = llm._prepare_request(
+        [HumanMessage(content="hi")], stop=None, stream=False
+    )
+    assert request.chat_request.max_tokens == 512
+
+    error_msg = (
+        "Invalid 'maxTokens': Unsupported parameter: "
+        "'maxTokens' is not supported with this model. "
+        "Use 'maxCompletionTokens' instead."
+    )
+    modified = _handle_unsupported_param_error(error_msg, request)
+    assert modified is True
+    assert request.chat_request.max_tokens is None
+    assert request.chat_request.max_completion_tokens == 512
+
+
+@pytest.mark.requires("oci")
+def test_retry_strips_unsupported_top_p() -> None:
+    """OCI 400 for unsupported top_p should be retried with param removed."""
+    import json as _json
+
+    from langchain_oci.chat_models.oci_generative_ai import (
+        _handle_unsupported_param_error,
+    )
+
+    oci_gen_ai_client = MagicMock()
+    llm = ChatOCIGenAI(
+        model_id="openai.gpt-5",
+        client=oci_gen_ai_client,
+        model_kwargs={"top_p": 0.8},
+    )
+
+    request = llm._prepare_request(
+        [HumanMessage(content="hi")], stop=None, stream=False
+    )
+    assert request.chat_request.top_p == 0.8
+
+    error_msg = _json.dumps(
+        {
+            "error": {
+                "message": "Unsupported parameter",
+                "type": "invalid_request_error",
+                "param": "top_p",
+                "code": "unsupported_parameter",
+            }
+        }
+    )
+    modified = _handle_unsupported_param_error(error_msg, request)
+    assert modified is True
+    assert request.chat_request.top_p is None
+
+
+@pytest.mark.requires("oci")
+def test_no_retry_on_unrelated_400() -> None:
+    """Unrelated 400 errors should not trigger retry logic."""
+    from langchain_oci.chat_models.oci_generative_ai import (
+        _handle_unsupported_param_error,
+    )
+
+    oci_gen_ai_client = MagicMock()
+    llm = ChatOCIGenAI(
+        model_id="openai.gpt-5",
+        client=oci_gen_ai_client,
+        model_kwargs={"temperature": 0.3},
+    )
+
+    request = llm._prepare_request(
+        [HumanMessage(content="hi")], stop=None, stream=False
+    )
+
+    modified = _handle_unsupported_param_error("Some other error", request)
+    assert modified is False
+    assert request.chat_request.temperature == 0.3
+
+
 # =============================================================================
 # Tool Result Guidance Tests
 # =============================================================================

--- a/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
@@ -1451,7 +1451,12 @@ def test_retry_converts_max_tokens_to_max_completion_tokens() -> None:
     request = llm._prepare_request(
         [HumanMessage(content="hi")], stop=None, stream=False
     )
-    assert request.chat_request.max_tokens == 512
+    # OpenAIProvider.normalize_params rewrites max_tokens -> max_completion_tokens
+    # eagerly at prep time, so this handler is the fallback for cases the lookup
+    # misses (unknown params, unstructured error messages). Reset to the "param
+    # reached the wire" state to exercise the handler path itself.
+    request.chat_request.max_completion_tokens = None
+    request.chat_request.max_tokens = 512
 
     error_msg = (
         "Invalid 'maxTokens': Unsupported parameter: "


### PR DESCRIPTION
## Bug
OCI rejects certain parameters for some models at request time:
- `temperature` / `top_p` with non-default values on GPT-5 legacy → `400 unsupported_value`
- `max_tokens` on OpenAI models → `400 unsupported_parameter` (requires `max_completion_tokens`)

Previously, users of `ChatOCIGenAI` with these models would get unrecoverable 400 errors.

## Fix
Instead of hardcoding model-specific predicates, the fix catches OCI `ServiceError` 400s, parses the structured error response to identify the rejected parameter, fixes or renames it on the request object, and retries. This works for any current or future model — no model ID checks needed.

- `unsupported_value` errors → param is removed (e.g. `temperature`)
- `unsupported_parameter` with a known rename → param is converted (e.g. `max_tokens` → `max_completion_tokens`)
- `unsupported_parameter` without rename → param is removed (e.g. `top_p`)
- Up to 3 retries to handle multiple rejected params in one request
- User gets a warning for each auto-fixed param

## Validation
**Unit tests (4 new):**
- `test_retry_strips_unsupported_temperature`
- `test_retry_converts_max_tokens_to_max_completion_tokens`
- `test_retry_strips_unsupported_top_p`
- `test_no_retry_on_unrelated_400`

**Integration test:** `test_openai_gpt5_tool_calling` — passes against live OCI GPT-5, retry visible in warnings

**Lint:** `ruff check` + `ruff format` — pass

Closes #214
