### PR TITLE
Add changes to vectorstore for supporting upsert , userids and other vector formats.

### DIFF
--- a/libs/js/langchain-oracledb/src/tests/vectorstores.int.test.ts
+++ b/libs/js/langchain-oracledb/src/tests/vectorstores.int.test.ts
@@ -349,7 +349,7 @@ describe("OracleVectorStore", () => {
             metadata: { version: 2, updated: true },
           }),
         ],
-        { ids: [docId], upsert: true }
+        { ids: [docId], mutateOnDuplicate: true }
       );
 
       const updatedRow = await getRow();
@@ -414,7 +414,7 @@ describe("OracleVectorStore", () => {
 
       const upsertIds = await oraclevs.addDocuments(updatedDocs, {
         ids: storedIdsList,
-        upsert: true,
+        mutateOnDuplicate: true,
       });
       if (!upsertIds) {
         throw new Error("Expected upsert to return ids.");
@@ -493,6 +493,83 @@ describe("OracleVectorStore", () => {
         ? (countResult.rows[0] as unknown[])[0]
         : 0;
       expect(Number(remaining)).toBe(0);
+    } finally {
+      await connection.close();
+    }
+  });
+
+  test("addDocuments rolls back when serialization fails without mutateOnDuplicate", async () => {
+    oraclevs = new OracleVS(embedder, dbConfig);
+    await oraclevs.initialize();
+
+    const validDoc = new Document({
+      pageContent: "valid payload",
+      metadata: { idx: 1 },
+    });
+    const cyclicMetadata: Record<string, unknown> & { self?: unknown } = { idx: 2 };
+    cyclicMetadata.self = cyclicMetadata;
+    const invalidDoc = new Document({
+      pageContent: "invalid payload",
+      metadata: cyclicMetadata,
+    });
+
+    await expect(
+      oraclevs.addDocuments([validDoc, invalidDoc], {
+        ids: ["rollback-no-upsert-1", "rollback-no-upsert-2"],
+      }),
+    ).rejects.toThrow(/circular structure|unexpected error/i);
+
+    const connection = await pool.getConnection();
+    try {
+      const countResult = await connection.execute(
+        `SELECT COUNT(*) AS TOTAL FROM "${tableName}"`,
+        [],
+        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      );
+      const row = countResult.rows?.[0] as
+        | { TOTAL?: number; total?: number; "COUNT(*)"?: number }
+        | undefined;
+      const total = row?.TOTAL ?? row?.total ?? row?.["COUNT(*)"] ?? 0;
+      expect(Number(total)).toBe(0);
+    } finally {
+      await connection.close();
+    }
+  });
+
+  test("addDocuments rolls back when serialization fails with mutateOnDuplicate", async () => {
+    oraclevs = new OracleVS(embedder, dbConfig);
+    await oraclevs.initialize();
+
+    const validDoc = new Document({
+      pageContent: "valid payload",
+      metadata: { idx: 1 },
+    });
+    const cyclicMetadata: Record<string, unknown> & { self?: unknown } = { idx: 2 };
+    cyclicMetadata.self = cyclicMetadata;
+    const invalidDoc = new Document({
+      pageContent: "invalid payload",
+      metadata: cyclicMetadata,
+    });
+
+    await expect(
+      oraclevs.addDocuments([validDoc, invalidDoc], {
+        ids: ["rollback-upsert-1", "rollback-upsert-2"],
+        mutateOnDuplicate: true,
+      }),
+    ).rejects.toThrow(/circular structure|unexpected error/i);
+
+    const connection = await pool.getConnection();
+    try {
+      const countResult = await connection.execute(
+        `SELECT COUNT(*) AS TOTAL FROM "${tableName}"`,
+        [],
+        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      );
+      const row = countResult.rows?.[0] as
+        | { TOTAL?: number; total?: number; "COUNT(*)"?: number }
+        | undefined;
+      const total = row?.TOTAL ?? row?.total ?? row?.["COUNT(*)"] ?? 0;
+      expect(Number(total)).toBe(0);
     } finally {
       await connection.close();
     }

--- a/libs/js/langchain-oracledb/src/vectorstores.ts
+++ b/libs/js/langchain-oracledb/src/vectorstores.ts
@@ -11,7 +11,7 @@ import { maximalMarginalRelevance } from "@langchain/core/utils/math";
 export type Metadata = Record<string, unknown>;
 interface AddDocumentOptions {
   ids?: string[];
-  upsert?: boolean;
+  mutateOnDuplicate?: boolean;
 }
 
 export function generateWhereClause(
@@ -802,7 +802,7 @@ export class OracleVS extends VectorStore {
    * @param vectors The vectors to add.
    * @param documents The documents associated with the vectors.
    * @param options
-   * ** Add { upsert?: boolean } to do upsert
+   * ** Add { mutateOnDuplicate?: boolean } to do upsert
    * @returns Promise that resolves when the vectors have been added.
    */
   public async addVectors(
@@ -848,7 +848,7 @@ export class OracleVS extends VectorStore {
         binds.push(row as oracledb.BindParameters);
       }
 
-      const isUpsert = options?.upsert ?? false; // Default to false for better performance
+      const isMutateOnDuplicate = options?.mutateOnDuplicate ?? false; // Default to false for better performance
       const insertSql = `
         INSERT INTO ${this.tableName} (external_id, embedding, text, metadata)
         VALUES (:ext_id, :embedding, :text, :metadata)`;
@@ -868,7 +868,7 @@ export class OracleVS extends VectorStore {
         INSERT (external_id, embedding, metadata, text)
         VALUES (s.external_id, s.embedding, s.metadata, s.text)`;
 
-      const sql = isUpsert ? mergeSql : insertSql;
+      const sql = isMutateOnDuplicate ? mergeSql : insertSql;
       const executeOptions: oracledb.ExecuteManyOptions = {
         bindDefs: {
           ext_id: { type: oracledb.STRING, maxSize: 255 },


### PR DESCRIPTION

## Changes made 

### Table schema change with  , `external_id` column

New schema is like this:

```
'CREATE TABLE IF NOT EXISTS "testlangchain_1_meta"  id RAW(16) DEFAULT SYS_GUID() PRIMARY KEY, 
external_id VARCHAR2(36) UNIQUE, embedding VECTOR(384, FLOAT64, SPARSE), text CLOB, metadata JSON)
```

Reason for keeping both id and external_id:
- `id` is the compact, database-generated anchor that keeps integrity and joins efficient; 
- `external_id` is the stable, client-visible handle. Example: internal ETL jobs insert rows without touching app code
- `SYS_GUID()` fills `id` automatically, while the app still upserts on `external_id`. Another: reporting tables can foreign-key to `id` for tight joins, yet your API accepts `external_id` so clients never see the surrogate key.
- As the module is not released with stable version yet, We should be fine changing the schema of the table.

### other changes
- VectorType (dense| sparse),  VectorElementFormat (float32, float64, ..) config from user before creating table.
- OracleDBVSArgs is enhanced to accept description, annotations (comments) , vectorType and vector ElementFormat. I have not added dimensions as embedder will decide dimensions and addVectors can be used to get the dimensions based on input vectors[]

- Added `upsert` flag  to `addVectors` which is default false . It does upsert if it is made true. 
- lint issues are fixed 
- more tests are added to improve coverage
- - simplify the create index sql


### sql with comments  comments and Description
`BEGIN
  EXECUTE IMMEDIATE 'CREATE TABLE IF NOT EXISTS "testlangchain_1_meta"
                   (
                       id RAW(16) DEFAULT SYS_GUID() PRIMARY KEY, external_id VARCHAR2(36) UNIQUE, embedding VECTOR(384, FLOAT64, SPARSE), text CLOB, metadata JSON
                   )';
  EXECUTE IMMEDIATE 'COMMENT ON TABLE "testlangchain_1_meta" IS ''Integration test table description''';
  EXECUTE IMMEDIATE 'COMMENT ON COLUMN "testlangchain_1_meta"."EXTERNAL_ID" IS ''External identifier for documents''';
  EXECUTE IMMEDIATE 'COMMENT ON COLUMN "testlangchain_1_meta"."METADATA" IS ''JSON metadata payload''';
END;`


