### PR TITLE
Fix integration test consistency and reliability

### DIFF
--- a/libs/oci/tests/integration_tests/chat_models/test_chat_features.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_chat_features.py
@@ -43,7 +43,7 @@ def get_config():
         ),
         "compartment_id": compartment_id,
         "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
-        "auth_type": os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        "auth_type": os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
     }
 
 

--- a/libs/oci/tests/integration_tests/chat_models/test_gemini_provider.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_gemini_provider.py
@@ -46,7 +46,7 @@ def _get_config() -> Dict[str, Any]:
     return {
         "compartment_id": compartment_id,
         "service_endpoint": endpoint,
-        "auth_type": os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        "auth_type": os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
         "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "NON-DEFAULT"),
         "auth_file_location": os.path.expanduser("~/.oci/config"),
     }

--- a/libs/oci/tests/integration_tests/chat_models/test_langchain_compatibility.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_langchain_compatibility.py
@@ -40,7 +40,7 @@ def get_test_config():
         ),
         "compartment_id": compartment_id,
         "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
-        "auth_type": os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        "auth_type": os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
     }
 
 

--- a/libs/oci/tests/integration_tests/chat_models/test_multi_model.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_multi_model.py
@@ -74,7 +74,7 @@ def get_config():
         ),
         "compartment_id": compartment_id,
         "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
-        "auth_type": os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        "auth_type": os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
     }
 
 

--- a/libs/oci/tests/integration_tests/chat_models/test_openai_models.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_openai_models.py
@@ -57,7 +57,7 @@ def openai_config():
         "service_endpoint": f"https://inference.generativeai.{region}.oci.oraclecloud.com",
         "compartment_id": compartment_id,
         "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
-        "auth_type": os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        "auth_type": os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
     }
 
 

--- a/libs/oci/tests/integration_tests/chat_models/test_response_format.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_response_format.py
@@ -76,7 +76,7 @@ def create_chat_model(model_id: str, response_format=None, **kwargs):
         service_endpoint=endpoint,
         compartment_id=compartment_id,
         model_kwargs=model_kwargs,
-        auth_type=os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        auth_type=os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
         auth_profile=os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
         auth_file_location=os.path.expanduser("~/.oci/config"),
         **kwargs,
@@ -283,7 +283,7 @@ def test_response_format_via_model_kwargs():
             "max_tokens": 512,
             "response_format": {"type": "JSON_OBJECT"},
         },
-        auth_type=os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        auth_type=os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
         auth_profile=os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
         auth_file_location=os.path.expanduser("~/.oci/config"),
     )

--- a/libs/oci/tests/integration_tests/chat_models/test_vision.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_vision.py
@@ -108,7 +108,7 @@ def get_config():
         ),
         "compartment_id": compartment_id,
         "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
-        "auth_type": os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        "auth_type": os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
     }
 
 

--- a/libs/oci/tests/integration_tests/embeddings/test_image_embedding_integration.py
+++ b/libs/oci/tests/integration_tests/embeddings/test_image_embedding_integration.py
@@ -92,7 +92,7 @@ def get_config() -> dict:
         ),
         "compartment_id": compartment_id,
         "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
-        "auth_type": os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        "auth_type": os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
     }
 
 

--- a/libs/oci/tests/integration_tests/test_vision_real_images.py
+++ b/libs/oci/tests/integration_tests/test_vision_real_images.py
@@ -41,7 +41,7 @@ def get_config():
             "https://inference.generativeai.us-phoenix-1.oci.oraclecloud.com",
         ),
         "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
-        "auth_type": os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN"),
+        "auth_type": os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
     }
 
 


### PR DESCRIPTION
## Summary

Standardize the `OCI_AUTH_TYPE` default from `SECURITY_TOKEN` to `API_KEY` across the remaining 9 integration test files that hadn't been migrated. Tests still respect the `OCI_AUTH_TYPE` env var when set; this only changes the fallback when unset.

Aligns with the `API_KEY` default already used by ~10 other integration test files on `main`.

## Files updated (9)

- `chat_models/test_chat_features.py`
- `chat_models/test_gemini_provider.py`
- `chat_models/test_langchain_compatibility.py`
- `chat_models/test_multi_model.py`
- `chat_models/test_openai_models.py`
- `chat_models/test_response_format.py`
- `chat_models/test_vision.py`
- `embeddings/test_image_embedding_integration.py`
- `test_vision_real_images.py`

Total diff: 10 insertions, 10 deletions.

## Notes

- Rebased onto latest `main` — no conflicts.
- An earlier version of this branch contained additional unrelated logic changes (token sizes, retry logic, skip-guard removals); those were dropped to keep this PR scoped to its title.