### PR TITLE
Add Query Transformation Hint (#130)

### DIFF
--- a/libs/oracledb/langchain_oracledb/vectorstores/oraclevs.py
+++ b/libs/oracledb/langchain_oracledb/vectorstores/oraclevs.py
@@ -875,7 +875,7 @@ def _get_similarity_search_query(
         where_clause = _generate_where_clause(filter, bind_variables)
 
     query = f"""
-    SELECT 
+    SELECT /*+ VECTOR_INDEX_TRANSFORM({table_name}) */ 
         text,
         metadata,
         vector_distance(embedding, :embedding,


### PR DESCRIPTION
* To ensure that both the JSON Search Index and the Vector Index are used in the execution plan, a query transformation hint was added after the SELECT clause.