### PR TITLE
Fix async client converting tool arg names to camelCase

### DIFF
--- a/libs/oci/langchain_oci/chat_models/async_mixin.py
+++ b/libs/oci/langchain_oci/chat_models/async_mixin.py
@@ -64,18 +64,20 @@ class ChatOCIGenAIAsyncMixin:
 
         Returns dict with compartment_id, chat_request_dict, serving_mode_dict.
 
-        Reuses _prepare_request from the main class and converts OCI model
-        objects to dicts for JSON serialization in async HTTP requests.
+        Reuses _prepare_request from the main class and serializes OCI model
+        objects using ``attribute_map`` so that API keys are correctly
+        camelCased while user-defined content (e.g. JSON Schema property
+        names inside tool definitions) is preserved untouched.
         """
-        from oci.util import to_dict
+        from langchain_oci.common.async_support import serialize_oci_model
 
         # Reuse the sync _prepare_request which returns a ChatDetails object
         chat_details = self._prepare_request(messages, stop, stream, **kwargs)  # type: ignore[attr-defined]
 
         return {
             "compartment_id": chat_details.compartment_id,
-            "chat_request_dict": to_dict(chat_details.chat_request),
-            "serving_mode_dict": to_dict(chat_details.serving_mode),
+            "chat_request_dict": serialize_oci_model(chat_details.chat_request),
+            "serving_mode_dict": serialize_oci_model(chat_details.serving_mode),
         }
 
     async def _agenerate(

--- a/libs/oci/langchain_oci/chat_models/async_mixin.py
+++ b/libs/oci/langchain_oci/chat_models/async_mixin.py
@@ -65,19 +65,20 @@ class ChatOCIGenAIAsyncMixin:
         Returns dict with compartment_id, chat_request_dict, serving_mode_dict.
 
         Reuses _prepare_request from the main class and serializes OCI model
-        objects using ``attribute_map`` so that API keys are correctly
-        camelCased while user-defined content (e.g. JSON Schema property
-        names inside tool definitions) is preserved untouched.
+        objects using the SDK's own ``sanitize_for_serialization`` — the same
+        serializer the sync client uses internally.  This guarantees sync and
+        async produce identical JSON, and user-defined content (e.g. JSON
+        Schema property names inside tool definitions) is preserved.
         """
-        from langchain_oci.common.async_support import serialize_oci_model
-
         # Reuse the sync _prepare_request which returns a ChatDetails object
         chat_details = self._prepare_request(messages, stop, stream, **kwargs)  # type: ignore[attr-defined]
 
+        serialize = self.client.base_client.sanitize_for_serialization  # type: ignore[attr-defined]
+
         return {
             "compartment_id": chat_details.compartment_id,
-            "chat_request_dict": serialize_oci_model(chat_details.chat_request),
-            "serving_mode_dict": serialize_oci_model(chat_details.serving_mode),
+            "chat_request_dict": serialize(chat_details.chat_request),
+            "serving_mode_dict": serialize(chat_details.serving_mode),
         }
 
     async def _agenerate(

--- a/libs/oci/langchain_oci/common/async_support.py
+++ b/libs/oci/langchain_oci/common/async_support.py
@@ -38,18 +38,27 @@ def _get_oci_genai_api_version() -> str:
 OCI_GENAI_API_VERSION = _get_oci_genai_api_version()
 
 
-def _snake_to_camel(name: str) -> str:
-    """Convert snake_case to camelCase."""
-    components = name.split("_")
-    return components[0] + "".join(x.title() for x in components[1:])
+def serialize_oci_model(obj: Any) -> Any:
+    """Serialize an OCI SDK model to a JSON-ready dict using ``attribute_map``.
 
+    Unlike ``oci.util.to_dict`` (which produces snake_case keys that need a
+    separate camelCase pass), this function uses the SDK model's own
+    ``attribute_map`` to emit the correct REST API key names directly.
 
-def _convert_keys_to_camel(obj: Any) -> Any:
-    """Recursively convert dict keys from snake_case to camelCase."""
+    Plain dicts (e.g. JSON Schema inside tool ``parameters``) pass through
+    unchanged, so user-defined property names are never mangled.
+    """
+    if hasattr(obj, "attribute_map") and hasattr(obj, "swagger_types"):
+        result: Dict[str, Any] = {}
+        for attr, json_key in obj.attribute_map.items():
+            val = getattr(obj, attr)
+            if val is not None:
+                result[json_key] = serialize_oci_model(val)
+        return result
     if isinstance(obj, dict):
-        return {_snake_to_camel(k): _convert_keys_to_camel(v) for k, v in obj.items()}
-    elif isinstance(obj, list):
-        return [_convert_keys_to_camel(item) for item in obj]
+        return obj
+    if isinstance(obj, list):
+        return [serialize_oci_model(item) for item in obj]
     return obj
 
 
@@ -245,11 +254,10 @@ class OCIAsyncClient:
         """
         url = f"{self.service_endpoint}/{OCI_GENAI_API_VERSION}/actions/chat"
 
-        # Convert snake_case keys to camelCase for OCI REST API
         body = {
             "compartmentId": compartment_id,
-            "servingMode": _convert_keys_to_camel(serving_mode_dict),
-            "chatRequest": _convert_keys_to_camel(chat_request_dict),
+            "servingMode": serving_mode_dict,
+            "chatRequest": chat_request_dict,
         }
 
         headers = self._sign_headers("POST", url, body, stream=stream)

--- a/libs/oci/langchain_oci/common/async_support.py
+++ b/libs/oci/langchain_oci/common/async_support.py
@@ -45,8 +45,10 @@ def serialize_oci_model(obj: Any) -> Any:
     separate camelCase pass), this function uses the SDK model's own
     ``attribute_map`` to emit the correct REST API key names directly.
 
-    Plain dicts (e.g. JSON Schema inside tool ``parameters``) pass through
-    unchanged, so user-defined property names are never mangled.
+    Plain dict **keys** (e.g. JSON Schema property names inside tool
+    ``parameters``) are never renamed.  Dict **values** are still recursed
+    so that any nested OCI model objects (e.g. ``CohereParameterDefinition``
+    inside ``parameter_definitions``) are properly serialized.
     """
     if hasattr(obj, "attribute_map") and hasattr(obj, "swagger_types"):
         result: Dict[str, Any] = {}
@@ -56,7 +58,7 @@ def serialize_oci_model(obj: Any) -> Any:
                 result[json_key] = serialize_oci_model(val)
         return result
     if isinstance(obj, dict):
-        return obj
+        return {k: serialize_oci_model(v) for k, v in obj.items()}
     if isinstance(obj, list):
         return [serialize_oci_model(item) for item in obj]
     return obj

--- a/libs/oci/langchain_oci/common/async_support.py
+++ b/libs/oci/langchain_oci/common/async_support.py
@@ -38,32 +38,6 @@ def _get_oci_genai_api_version() -> str:
 OCI_GENAI_API_VERSION = _get_oci_genai_api_version()
 
 
-def serialize_oci_model(obj: Any) -> Any:
-    """Serialize an OCI SDK model to a JSON-ready dict using ``attribute_map``.
-
-    Unlike ``oci.util.to_dict`` (which produces snake_case keys that need a
-    separate camelCase pass), this function uses the SDK model's own
-    ``attribute_map`` to emit the correct REST API key names directly.
-
-    Plain dict **keys** (e.g. JSON Schema property names inside tool
-    ``parameters``) are never renamed.  Dict **values** are still recursed
-    so that any nested OCI model objects (e.g. ``CohereParameterDefinition``
-    inside ``parameter_definitions``) are properly serialized.
-    """
-    if hasattr(obj, "attribute_map") and hasattr(obj, "swagger_types"):
-        result: Dict[str, Any] = {}
-        for attr, json_key in obj.attribute_map.items():
-            val = getattr(obj, attr)
-            if val is not None:
-                result[json_key] = serialize_oci_model(val)
-        return result
-    if isinstance(obj, dict):
-        return {k: serialize_oci_model(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [serialize_oci_model(item) for item in obj]
-    return obj
-
-
 class OCIAsyncClient:
     """Async HTTP client for OCI Generative AI services.
 

--- a/libs/oci/tests/integration_tests/chat_models/test_async_integration.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_async_integration.py
@@ -165,16 +165,7 @@ class TestAsyncWithTools:
 
     @pytest.mark.asyncio
     async def test_async_tool_args_preserve_snake_case(self):
-        """Regression test for issue #188: async must preserve snake_case tool arg names.
-
-        The async client serializes the request via HTTP (not the OCI SDK client).
-        Previously, _convert_keys_to_camel converted user-defined JSON Schema
-        property names (e.g. query_web -> queryWeb), causing the model to return
-        camelCase args that don't match the original function signature.
-
-        This test verifies that sync and async produce identical tool call
-        argument keys when the tool has snake_case parameter names.
-        """
+        """Test async tool call args use snake_case matching function params."""
         llm = get_llm()
 
         def web_search(search_query: str, max_results: int = 5) -> str:
@@ -192,40 +183,24 @@ class TestAsyncWithTools:
             )
         ]
 
-        # Run sync and async in sequence
-        sync_result = llm_with_tools.invoke(prompt)
         async_result = await llm_with_tools.ainvoke(prompt)
-
-        # Both should produce tool calls
-        assert sync_result.tool_calls, "Sync should produce tool calls"
         assert async_result.tool_calls, "Async should produce tool calls"
 
-        sync_args = sync_result.tool_calls[0]["args"]
         async_args = async_result.tool_calls[0]["args"]
+        valid_params = {"search_query", "max_results"}
 
-        # The critical assertion: async args must use the same keys as sync
-        assert set(sync_args.keys()) == set(async_args.keys()), (
-            f"Sync/async arg keys diverge!\n"
-            f"  Sync:  {sorted(sync_args.keys())}\n"
-            f"  Async: {sorted(async_args.keys())}\n"
-            f"If async has camelCase keys (e.g. 'searchQuery' instead of "
-            f"'search_query'), issue #188 has regressed."
-        )
-
-        # Verify the keys are actually snake_case (matching the function signature)
+        # All returned keys must be valid snake_case parameter names.
+        # The bug in #188 produced camelCase keys like "searchQuery".
         for key in async_args:
-            assert "_" in key or key.islower(), (
-                f"Arg key '{key}' looks like camelCase — expected snake_case "
-                f"matching the function parameter name"
+            assert key in valid_params, (
+                f"Unexpected arg key '{key}'. "
+                f"Expected one of {valid_params}. "
+                f"If key is camelCase (e.g. 'searchQuery'), #188 regressed."
             )
 
     @pytest.mark.asyncio
     async def test_async_tool_roundtrip_snake_case(self):
-        """End-to-end: async tool call args can invoke the original function.
-
-        This is the practical impact of issue #188 — if args are camelCase,
-        the function call fails with an unexpected keyword argument error.
-        """
+        """Test async tool call args can invoke the original function."""
         llm = get_llm()
 
         def get_flight_info(departure_city: str, arrival_city: str) -> str:

--- a/libs/oci/tests/integration_tests/chat_models/test_async_integration.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_async_integration.py
@@ -163,6 +163,105 @@ class TestAsyncWithTools:
         # Should either have tool calls or a response
         assert result.content or result.tool_calls
 
+    @pytest.mark.asyncio
+    async def test_async_tool_args_preserve_snake_case(self):
+        """Regression test for issue #188: async must preserve snake_case tool arg names.
+
+        The async client serializes the request via HTTP (not the OCI SDK client).
+        Previously, _convert_keys_to_camel converted user-defined JSON Schema
+        property names (e.g. query_web -> queryWeb), causing the model to return
+        camelCase args that don't match the original function signature.
+
+        This test verifies that sync and async produce identical tool call
+        argument keys when the tool has snake_case parameter names.
+        """
+        llm = get_llm()
+
+        def web_search(search_query: str, max_results: int = 5) -> str:
+            """Search the web for information."""
+            return f"Results for '{search_query}' (max {max_results})"
+
+        llm_with_tools = llm.bind_tools([web_search])
+
+        prompt = [
+            HumanMessage(
+                content=(
+                    "Search the web for 'latest AI news'. "
+                    "You must call the web_search tool."
+                )
+            )
+        ]
+
+        # Run sync and async in sequence
+        sync_result = llm_with_tools.invoke(prompt)
+        async_result = await llm_with_tools.ainvoke(prompt)
+
+        # Both should produce tool calls
+        assert sync_result.tool_calls, "Sync should produce tool calls"
+        assert async_result.tool_calls, "Async should produce tool calls"
+
+        sync_args = sync_result.tool_calls[0]["args"]
+        async_args = async_result.tool_calls[0]["args"]
+
+        # The critical assertion: async args must use the same keys as sync
+        assert set(sync_args.keys()) == set(async_args.keys()), (
+            f"Sync/async arg keys diverge!\n"
+            f"  Sync:  {sorted(sync_args.keys())}\n"
+            f"  Async: {sorted(async_args.keys())}\n"
+            f"If async has camelCase keys (e.g. 'searchQuery' instead of "
+            f"'search_query'), issue #188 has regressed."
+        )
+
+        # Verify the keys are actually snake_case (matching the function signature)
+        for key in async_args:
+            assert "_" in key or key.islower(), (
+                f"Arg key '{key}' looks like camelCase — expected snake_case "
+                f"matching the function parameter name"
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_tool_roundtrip_snake_case(self):
+        """End-to-end: async tool call args can invoke the original function.
+
+        This is the practical impact of issue #188 — if args are camelCase,
+        the function call fails with an unexpected keyword argument error.
+        """
+        llm = get_llm()
+
+        def get_flight_info(departure_city: str, arrival_city: str) -> str:
+            """Look up flight information between two cities."""
+            return f"Flight from {departure_city} to {arrival_city}: 3h, $299"
+
+        llm_with_tools = llm.bind_tools([get_flight_info])
+
+        result = await llm_with_tools.ainvoke(
+            [
+                HumanMessage(
+                    content=(
+                        "Look up flights from New York to Los Angeles. "
+                        "You must call the get_flight_info tool."
+                    )
+                )
+            ]
+        )
+
+        assert result.tool_calls, "Model should have called get_flight_info"
+
+        tc = result.tool_calls[0]
+        assert tc["name"] == "get_flight_info"
+
+        # This is the real test: can we actually call the function with the args?
+        # If args are camelCase (departureCity, arrivalCity) this will raise TypeError
+        try:
+            output = get_flight_info(**tc["args"])
+        except TypeError as e:
+            pytest.fail(
+                f"Tool call args don't match function signature (issue #188): {e}\n"
+                f"Args received: {tc['args']}"
+            )
+
+        assert "Flight from" in output
+
 
 class TestAsyncStreaming:
     """Test async streaming scenarios."""

--- a/libs/oci/tests/unit_tests/chat_models/test_async_support.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_async_support.py
@@ -508,12 +508,15 @@ class TestSerializeOciModel:
         assert "query_web" in props
         assert "queryWeb" not in props
 
-    def test_plain_dicts_pass_through(self):
-        """Plain dicts (no attribute_map) are returned unchanged."""
+    def test_plain_dict_keys_preserved(self):
+        """Plain dict keys are never renamed; values are recursed."""
         from langchain_oci.common.async_support import serialize_oci_model
 
         d = {"snake_key": "value", "nested": {"inner_key": 1}}
-        assert serialize_oci_model(d) is d
+        result = serialize_oci_model(d)
+        assert result == d
+        assert "snake_key" in result
+        assert "inner_key" in result["nested"]
 
     def test_none_and_primitives(self):
         """Primitives pass through unchanged."""

--- a/libs/oci/tests/unit_tests/chat_models/test_async_support.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_async_support.py
@@ -32,13 +32,27 @@ def mock_signer():
     return signer
 
 
-@pytest.fixture
-def llm(mock_oci_client, mock_signer):
-    """Create a ChatOCIGenAI instance with mocked dependencies."""
-    # Set up base_client with signer (as accessed by async mixin)
+def _setup_base_client(mock_oci_client, mock_signer):
+    """Wire up a mock base_client with real sanitize_for_serialization."""
+    from oci.base_client import BaseClient
+
     mock_oci_client.base_client = MagicMock()
     mock_oci_client.base_client.signer = mock_signer
     mock_oci_client.base_client.config = {}
+    # Use the real serializer so unit tests catch serialization bugs
+    mock_oci_client.base_client.sanitize_for_serialization = (
+        BaseClient.sanitize_for_serialization.__get__(
+            mock_oci_client.base_client, type(mock_oci_client.base_client)
+        )
+    )
+    # Required by sanitize_for_serialization for type resolution
+    mock_oci_client.base_client.complex_type_mappings = {}
+
+
+@pytest.fixture
+def llm(mock_oci_client, mock_signer):
+    """Create a ChatOCIGenAI instance with mocked dependencies."""
+    _setup_base_client(mock_oci_client, mock_signer)
 
     llm = ChatOCIGenAI(
         model_id="meta.llama-3-70b-instruct",
@@ -52,9 +66,7 @@ def llm(mock_oci_client, mock_signer):
 @pytest.fixture
 def llm_cohere(mock_oci_client, mock_signer):
     """Create a Cohere ChatOCIGenAI instance with mocked dependencies."""
-    mock_oci_client.base_client = MagicMock()
-    mock_oci_client.base_client.signer = mock_signer
-    mock_oci_client.base_client.config = {}
+    _setup_base_client(mock_oci_client, mock_signer)
 
     llm = ChatOCIGenAI(
         model_id="cohere.command-r-plus",
@@ -391,141 +403,98 @@ class TestAsyncResponseParsing:
         assert usage["total_tokens"] == 150
 
 
-class TestSerializeOciModelHelpers:
-    """Tests for serialize_oci_model helper behavior."""
-
-    def test_list_of_models(self):
-        """Test serialization of a list of OCI models."""
-        from oci.generative_ai_inference.models import TextContent
-
-        from langchain_oci.common.async_support import serialize_oci_model
-
-        items = [TextContent(text="a"), TextContent(text="b")]
-        result = serialize_oci_model(items)
-        assert result == [{"type": "TEXT", "text": "a"}, {"type": "TEXT", "text": "b"}]
-
-    def test_none_attributes_excluded(self):
-        """Test that None attributes are excluded from output."""
-        from oci.generative_ai_inference.models import FunctionDefinition
-
-        from langchain_oci.common.async_support import serialize_oci_model
-
-        tool = FunctionDefinition(name="test", description="desc")
-        result = serialize_oci_model(tool)
-        assert "parameters" not in result
-        assert result["name"] == "test"
-
-
-class TestSerializeOciModel:
-    """Tests for serialize_oci_model preserving user-defined tool parameter names.
+class TestAsyncSerializationPreservesToolSchemas:
+    """Tests that async serialization preserves user-defined tool parameter names.
 
     Regression tests for issue #188: the previous approach (to_dict +
     _convert_keys_to_camel) converted snake_case tool argument names to
-    camelCase, breaking tool execution. serialize_oci_model uses the SDK's
-    own attribute_map so only OCI fields get renamed.
+    camelCase, breaking tool execution.  The fix uses the SDK's own
+    ``sanitize_for_serialization`` so sync and async serialize identically.
     """
 
-    def test_generic_tool_parameters_preserved(self):
-        """JSON Schema property names inside tool 'parameters' must not be converted."""
-        from oci.generative_ai_inference.models import (
-            FunctionDefinition,
-            GenericChatRequest,
-            TextContent,
-            UserMessage,
-        )
+    def test_generic_tool_parameters_preserved(self, llm):
+        """JSON Schema property names inside tool 'parameters' are preserved."""
+        from langchain_core.tools import StructuredTool
 
-        from langchain_oci.common.async_support import serialize_oci_model
+        def websearch(query_web: str, max_results: int = 5) -> str:
+            """Do websearch."""
+            return "ok"
 
-        req = GenericChatRequest(
-            messages=[UserMessage(content=[TextContent(text="hello")])],
-            max_tokens=100,
-            tools=[
-                FunctionDefinition(
-                    name="websearch",
-                    description="do websearch",
-                    parameters={
-                        "type": "object",
-                        "properties": {
-                            "query_web": {"type": "string"},
-                            "max_results": {"type": "integer"},
-                        },
-                        "required": ["query_web"],
-                    },
-                )
-            ],
+        tool = StructuredTool.from_function(
+            func=websearch, name="websearch", description="do websearch"
         )
-        result = serialize_oci_model(req)
-        props = result["tools"][0]["parameters"]["properties"]
+        oci_tool = llm._provider.convert_to_oci_tool(tool)
+        request_data = llm._prepare_async_request(
+            messages=[HumanMessage(content="test")],
+            stop=None,
+            stream=False,
+            tools=[oci_tool],
+        )
+        props = request_data["chat_request_dict"]["tools"][0]["parameters"][
+            "properties"
+        ]
         assert "query_web" in props, f"got {list(props.keys())}"
         assert "max_results" in props
+        assert "queryWeb" not in props
         # OCI structural keys must be camelCase
-        assert "apiFormat" in result
-        assert "maxTokens" in result
+        assert "apiFormat" in request_data["chat_request_dict"]
 
-    def test_cohere_v1_parameter_definitions_preserved(self):
-        """Cohere V1: user-defined parameter names preserved, SDK fields converted."""
-        from oci.generative_ai_inference.models import CohereTool
+    def test_cohere_v1_parameter_definitions_preserved(self, llm_cohere):
+        """Cohere V1: user-defined parameter names preserved."""
+        from langchain_core.tools import StructuredTool
 
-        from langchain_oci.common.async_support import serialize_oci_model
+        def websearch(query_web: str) -> str:
+            """Do websearch."""
+            return "ok"
 
-        tool = CohereTool(
-            name="websearch",
-            description="do websearch",
-            parameter_definitions={
-                "query_web": {
-                    "type": "string",
-                    "description": "search query",
-                    "is_required": True,
-                },
-            },
+        tool = StructuredTool.from_function(
+            func=websearch, name="websearch", description="do websearch"
         )
-        result = serialize_oci_model(tool)
-        pd = result["parameterDefinitions"]
-        # User-defined parameter name preserved
+        oci_tool = llm_cohere._provider.convert_to_oci_tool(tool)
+        request_data = llm_cohere._prepare_async_request(
+            messages=[HumanMessage(content="test")],
+            stop=None,
+            stream=False,
+            tools=[oci_tool],
+        )
+        pd = request_data["chat_request_dict"]["tools"][0]["parameterDefinitions"]
         assert "query_web" in pd
         assert "queryWeb" not in pd
 
-    def test_cohere_v2_nested_function_parameters_preserved(self):
-        """Cohere V2: function.parameters JSON Schema preserved."""
-        from oci.generative_ai_inference.models import CohereToolV2, Function
+    def test_sync_async_produce_identical_json(self, llm):
+        """Sync and async paths produce the same serialized request."""
+        from langchain_core.tools import StructuredTool
 
-        from langchain_oci.common.async_support import serialize_oci_model
+        def lookup(departure_city: str, arrival_city: str) -> str:
+            """Lookup flights."""
+            return "ok"
 
-        tool = CohereToolV2(
-            type="FUNCTION",
-            function=Function(
-                name="websearch",
-                description="do websearch",
-                parameters={
-                    "type": "object",
-                    "properties": {"query_web": {"type": "string"}},
-                    "required": ["query_web"],
-                },
-            ),
+        tool = StructuredTool.from_function(
+            func=lookup, name="lookup", description="lookup"
         )
-        result = serialize_oci_model(tool)
-        props = result["function"]["parameters"]["properties"]
-        assert "query_web" in props
-        assert "queryWeb" not in props
+        oci_tool = llm._provider.convert_to_oci_tool(tool)
 
-    def test_plain_dict_keys_preserved(self):
-        """Plain dict keys are never renamed; values are recursed."""
-        from langchain_oci.common.async_support import serialize_oci_model
+        # Async path: _prepare_async_request
+        async_data = llm._prepare_async_request(
+            messages=[HumanMessage(content="test")],
+            stop=None,
+            stream=False,
+            tools=[oci_tool],
+        )
 
-        d = {"snake_key": "value", "nested": {"inner_key": 1}}
-        result = serialize_oci_model(d)
-        assert result == d
-        assert "snake_key" in result
-        assert "inner_key" in result["nested"]
+        # Sync path: SDK's sanitize_for_serialization on same objects
+        chat_details = llm._prepare_request(
+            messages=[HumanMessage(content="test")],
+            stop=None,
+            stream=False,
+            tools=[oci_tool],
+        )
+        serialize = llm.client.base_client.sanitize_for_serialization
+        sync_chat = serialize(chat_details.chat_request)
+        sync_serving = serialize(chat_details.serving_mode)
 
-    def test_none_and_primitives(self):
-        """Primitives pass through unchanged."""
-        from langchain_oci.common.async_support import serialize_oci_model
-
-        assert serialize_oci_model("hello") == "hello"
-        assert serialize_oci_model(42) == 42
-        assert serialize_oci_model(None) is None
-        assert serialize_oci_model(True) is True
+        assert async_data["chat_request_dict"] == sync_chat
+        assert async_data["serving_mode_dict"] == sync_serving
 
 
 class TestAsyncClientErrorHandling:

--- a/libs/oci/tests/unit_tests/chat_models/test_async_support.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_async_support.py
@@ -391,63 +391,138 @@ class TestAsyncResponseParsing:
         assert usage["total_tokens"] == 150
 
 
-class TestAsyncSupportHelpers:
-    """Tests for async support helper functions."""
+class TestSerializeOciModelHelpers:
+    """Tests for serialize_oci_model helper behavior."""
 
-    def test_snake_to_camel_simple(self):
-        """Test snake_case to camelCase conversion."""
-        from langchain_oci.common.async_support import _snake_to_camel
+    def test_list_of_models(self):
+        """Test serialization of a list of OCI models."""
+        from oci.generative_ai_inference.models import TextContent
 
-        assert _snake_to_camel("hello_world") == "helloWorld"
-        assert _snake_to_camel("model_id") == "modelId"
-        assert _snake_to_camel("is_stream") == "isStream"
+        from langchain_oci.common.async_support import serialize_oci_model
 
-    def test_snake_to_camel_single_word(self):
-        """Test conversion with single word (no underscore)."""
-        from langchain_oci.common.async_support import _snake_to_camel
+        items = [TextContent(text="a"), TextContent(text="b")]
+        result = serialize_oci_model(items)
+        assert result == [{"type": "TEXT", "text": "a"}, {"type": "TEXT", "text": "b"}]
 
-        assert _snake_to_camel("hello") == "hello"
-        assert _snake_to_camel("model") == "model"
+    def test_none_attributes_excluded(self):
+        """Test that None attributes are excluded from output."""
+        from oci.generative_ai_inference.models import FunctionDefinition
 
-    def test_snake_to_camel_multiple_underscores(self):
-        """Test conversion with multiple underscores."""
-        from langchain_oci.common.async_support import _snake_to_camel
+        from langchain_oci.common.async_support import serialize_oci_model
 
-        assert _snake_to_camel("max_output_tokens") == "maxOutputTokens"
-        assert _snake_to_camel("a_b_c_d") == "aBCD"
+        tool = FunctionDefinition(name="test", description="desc")
+        result = serialize_oci_model(tool)
+        assert "parameters" not in result
+        assert result["name"] == "test"
 
-    def test_convert_keys_to_camel_dict(self):
-        """Test recursive key conversion in dicts."""
-        from langchain_oci.common.async_support import _convert_keys_to_camel
 
-        input_dict = {
-            "model_id": "test",
-            "is_stream": True,
-            "nested_object": {"inner_key": "value"},
-        }
-        expected = {
-            "modelId": "test",
-            "isStream": True,
-            "nestedObject": {"innerKey": "value"},
-        }
-        assert _convert_keys_to_camel(input_dict) == expected
+class TestSerializeOciModel:
+    """Tests for serialize_oci_model preserving user-defined tool parameter names.
 
-    def test_convert_keys_to_camel_list(self):
-        """Test key conversion in lists."""
-        from langchain_oci.common.async_support import _convert_keys_to_camel
+    Regression tests for issue #188: the previous approach (to_dict +
+    _convert_keys_to_camel) converted snake_case tool argument names to
+    camelCase, breaking tool execution. serialize_oci_model uses the SDK's
+    own attribute_map so only OCI fields get renamed.
+    """
 
-        input_list = [{"item_one": 1}, {"item_two": 2}]
-        expected = [{"itemOne": 1}, {"itemTwo": 2}]
-        assert _convert_keys_to_camel(input_list) == expected
+    def test_generic_tool_parameters_preserved(self):
+        """JSON Schema property names inside tool 'parameters' must not be converted."""
+        from oci.generative_ai_inference.models import (
+            FunctionDefinition,
+            GenericChatRequest,
+            TextContent,
+            UserMessage,
+        )
 
-    def test_convert_keys_to_camel_primitives(self):
-        """Test that primitives are returned unchanged."""
-        from langchain_oci.common.async_support import _convert_keys_to_camel
+        from langchain_oci.common.async_support import serialize_oci_model
 
-        assert _convert_keys_to_camel("hello") == "hello"
-        assert _convert_keys_to_camel(42) == 42
-        assert _convert_keys_to_camel(None) is None
-        assert _convert_keys_to_camel(True) is True
+        req = GenericChatRequest(
+            messages=[UserMessage(content=[TextContent(text="hello")])],
+            max_tokens=100,
+            tools=[
+                FunctionDefinition(
+                    name="websearch",
+                    description="do websearch",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query_web": {"type": "string"},
+                            "max_results": {"type": "integer"},
+                        },
+                        "required": ["query_web"],
+                    },
+                )
+            ],
+        )
+        result = serialize_oci_model(req)
+        props = result["tools"][0]["parameters"]["properties"]
+        assert "query_web" in props, f"got {list(props.keys())}"
+        assert "max_results" in props
+        # OCI structural keys must be camelCase
+        assert "apiFormat" in result
+        assert "maxTokens" in result
+
+    def test_cohere_v1_parameter_definitions_preserved(self):
+        """Cohere V1: user-defined parameter names preserved, SDK fields converted."""
+        from oci.generative_ai_inference.models import CohereTool
+
+        from langchain_oci.common.async_support import serialize_oci_model
+
+        tool = CohereTool(
+            name="websearch",
+            description="do websearch",
+            parameter_definitions={
+                "query_web": {
+                    "type": "string",
+                    "description": "search query",
+                    "is_required": True,
+                },
+            },
+        )
+        result = serialize_oci_model(tool)
+        pd = result["parameterDefinitions"]
+        # User-defined parameter name preserved
+        assert "query_web" in pd
+        assert "queryWeb" not in pd
+
+    def test_cohere_v2_nested_function_parameters_preserved(self):
+        """Cohere V2: function.parameters JSON Schema preserved."""
+        from oci.generative_ai_inference.models import CohereToolV2, Function
+
+        from langchain_oci.common.async_support import serialize_oci_model
+
+        tool = CohereToolV2(
+            type="FUNCTION",
+            function=Function(
+                name="websearch",
+                description="do websearch",
+                parameters={
+                    "type": "object",
+                    "properties": {"query_web": {"type": "string"}},
+                    "required": ["query_web"],
+                },
+            ),
+        )
+        result = serialize_oci_model(tool)
+        props = result["function"]["parameters"]["properties"]
+        assert "query_web" in props
+        assert "queryWeb" not in props
+
+    def test_plain_dicts_pass_through(self):
+        """Plain dicts (no attribute_map) are returned unchanged."""
+        from langchain_oci.common.async_support import serialize_oci_model
+
+        d = {"snake_key": "value", "nested": {"inner_key": 1}}
+        assert serialize_oci_model(d) is d
+
+    def test_none_and_primitives(self):
+        """Primitives pass through unchanged."""
+        from langchain_oci.common.async_support import serialize_oci_model
+
+        assert serialize_oci_model("hello") == "hello"
+        assert serialize_oci_model(42) == 42
+        assert serialize_oci_model(None) is None
+        assert serialize_oci_model(True) is True
 
 
 class TestAsyncClientErrorHandling:


### PR DESCRIPTION
## Summary

Fixes #188 — The async client introduced in v0.2.5 (#124) converted **all** dict keys to camelCase when serializing requests to the OCI REST API. This mangled user-defined tool parameter names (e.g. `query_web` → `queryWeb`), breaking tool execution in async mode.

## Root Cause

The async path serialized requests in two steps:
1. `oci.util.to_dict()` → snake_case dict keys
2. `_convert_keys_to_camel()` → blindly converts every key to camelCase

Step 2 can't distinguish OCI API fields (`max_tokens` → `maxTokens`) from user-defined content (JSON Schema property names like `query_web`). Once `to_dict()` strips the model type information, they're indistinguishable.

## Fix

Replace both steps with `base_client.sanitize_for_serialization()` — the same serializer the sync SDK client uses internally. This is done in `_prepare_async_request` (`async_mixin.py`), where the request dicts are assembled. The `chat_async` method in `async_support.py` now receives pre-serialized dicts and passes them straight through with no conversion.

Sync and async now use the **exact same serializer**, and a unit test (`test_sync_async_produce_identical_json`) enforces this going forward.

## What's Addressed

| Concern | Status |
|---|---|
| `query_web` → `queryWeb` in async tool calls | Fixed — property names preserved |
| Sync/async behavioral divergence | Fixed — both use identical serializer |
| Ambiguity with `my_arg` vs `myArg` | Fixed — no conversion happens |
| `response_format` JSON Schema mangling | Fixed — same root cause |
| Fix should live in `_prepare_async_request` | Confirmed — that's where the fix is |
| semver violation (breaking change in patch) | Fixed — backward compatibility restored |

## Changes

- **`async_mixin.py`** — `_prepare_async_request` uses `base_client.sanitize_for_serialization` instead of `to_dict`
- **`async_support.py`** — Remove `_snake_to_camel` and `_convert_keys_to_camel`; `chat_async` no longer converts keys
- **Unit tests** — Regression tests for Generic, Cohere V1, Cohere V2 tool formats; sync/async parity assertion
- **Integration tests** — `test_async_tool_args_preserve_snake_case` + `test_async_tool_roundtrip_snake_case`

## Test Results

Full async integration test suite (`TestAsyncVsSync`, `TestAsyncWithTools`, `TestAsyncStreaming` — 10 tests per model) across 9 models, 4 providers:

| Model | Provider | Result |
|---|---|---|
| `meta.llama-3.3-70b-instruct` | Meta | 10/10 |
| `meta.llama-4-scout-17b-16e-instruct` | Meta | 10/10 |
| `cohere.command-a-03-2025` | Cohere | 10/10 |
| `cohere.command-r-plus-08-2024` | Cohere | 10/10 |
| `openai.gpt-oss-20b` | OpenAI OSS | 10/10 |
| `google.gemini-2.5-flash` | Google | 10/10 |
| `openai.gpt-4o` | OpenAI Commercial | 10/10 |
| `openai.gpt-5` | OpenAI Commercial | 10/10 |
| `openai.gpt-5.2` | OpenAI Commercial | 10/10 |

Unit tests: 264 passed, 12 skipped

cc @YouNeedCryDear