### PR TITLE
feat(oci): parse inline <tool_call> blocks for DAC fine-tunes

### DIFF
--- a/libs/oci/langchain_oci/chat_models/async_mixin.py
+++ b/libs/oci/langchain_oci/chat_models/async_mixin.py
@@ -183,6 +183,11 @@ class ChatOCIGenAIAsyncMixin:
         )
         tool_call_ids: Dict[int, str] = {}
 
+        # Reset per-stream provider state (see _stream's note).
+        reset = getattr(self._provider, "reset_stream_state", None)  # type: ignore[attr-defined]
+        if reset is not None:
+            reset()
+
         async for event_data in client.chat_async(
             compartment_id=request_data["compartment_id"],
             chat_request_dict=request_data["chat_request_dict"],
@@ -206,6 +211,13 @@ class ChatOCIGenAIAsyncMixin:
                     await run_manager.on_llm_new_token(delta, chunk=chunk)
                 yield chunk
             else:
+                # Flush any held-back text from the provider's <tool_call>
+                # buffer so trailing characters don't disappear.
+                flush = getattr(self._provider, "flush_stream_state", None)  # type: ignore[attr-defined]
+                tail = flush() if flush is not None else ""
+                if tail:
+                    yield ChatGenerationChunk(message=AIMessageChunk(content=tail))
+
                 generation_info = self._provider.chat_stream_generation_info(event_data)  # type: ignore[attr-defined]
                 yield ChatGenerationChunk(
                     message=AIMessageChunk(

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -547,6 +547,13 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         response = self.client.chat(request)
         tool_call_ids: Dict[int, str] = {}
 
+        # Reset any per-stream provider state (currently the GenericProvider's
+        # incremental <tool_call> XML buffer used for Hermes/Llama-style DAC
+        # fine-tunes). Older providers don't define this hook.
+        reset = getattr(self._provider, "reset_stream_state", None)
+        if reset is not None:
+            reset()
+
         for event in response.data.events():
             event_data = json.loads(event.data)
 
@@ -567,6 +574,14 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                     run_manager.on_llm_new_token(delta, chunk=chunk)
                 yield chunk
             else:
+                # Flush any text the provider was holding back waiting on a
+                # potential <tool_call> opener; emit it as a final delta so
+                # callers don't lose trailing characters.
+                flush = getattr(self._provider, "flush_stream_state", None)
+                tail = flush() if flush is not None else ""
+                if tail:
+                    yield ChatGenerationChunk(message=AIMessageChunk(content=tail))
+
                 generation_info = self._provider.chat_stream_generation_info(event_data)
                 yield ChatGenerationChunk(
                     message=AIMessageChunk(

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -42,17 +42,25 @@ from pydantic import BaseModel
 from langchain_oci.chat_models.providers.base import Provider
 from langchain_oci.common.utils import OCIUtils
 
-# Hermes/Llama-style inline tool-call format. Some fine-tuned models hosted on
-# OCI Dedicated AI Clusters return tool calls as `<tool_call>{...}</tool_call>`
-# blocks inside the assistant message text instead of populating the structured
-# `tool_calls` field on the response. We extract those here so callers see
-# normal structured tool calls in both `_generate` and `_stream`.
-_XML_TOOL_OPEN = "<tool_call>"
-_XML_TOOL_CLOSE = "</tool_call>"
+# Hermes/Llama/Qwen-style inline tool-call format. Some fine-tuned models
+# hosted on OCI Dedicated AI Clusters return tool calls inside the assistant
+# message text using one of two equivalent tag pairs:
+#
+#   <tool_call>{"name": ..., "arguments": {...}}</tool_call>
+#   <tool_calling>{"name": ..., "arguments": {...}}</tool_calling>
+#
+# (Qwen3 has been observed emitting either form — see
+# https://github.com/oracle/langchain-oracle/issues/207.) We extract both
+# variants here so callers see normal structured tool calls in `_generate`
+# and `_stream`.
+_XML_TOOL_TAG_NAMES = ("tool_call", "tool_calling")
 _XML_TOOL_BLOCK_RE = re.compile(
-    re.escape(_XML_TOOL_OPEN) + r"\s*(.*?)\s*" + re.escape(_XML_TOOL_CLOSE),
+    r"<(?P<tag>" + "|".join(_XML_TOOL_TAG_NAMES) + r")>\s*(?P<body>.*?)\s*</(?P=tag)>",
     re.DOTALL,
 )
+# Used by the streaming buffer to detect that the trailing portion of the
+# buffer could still be the start of an opening tag for either variant.
+_XML_TOOL_OPENERS = tuple(f"<{name}>" for name in _XML_TOOL_TAG_NAMES)
 
 
 def _parse_xml_tool_call_payload(payload: str) -> Optional[Dict[str, Any]]:
@@ -83,20 +91,22 @@ def _parse_xml_tool_call_payload(payload: str) -> Optional[Dict[str, Any]]:
 
 
 def _extract_xml_tool_calls(text: str) -> Tuple[str, List[Dict[str, Any]]]:
-    """Strip ``<tool_call>...</tool_call>`` blocks and return parsed calls.
+    """Strip ``<tool_call>``/``<tool_calling>`` blocks and return parsed calls.
 
     Returns ``(cleaned_text, [{"id", "name", "arguments"}, ...])``. Blocks
     whose JSON payload doesn't parse are left intact in ``cleaned_text`` so
     no information is silently lost.
     """
-    if _XML_TOOL_OPEN not in text or _XML_TOOL_CLOSE not in text:
+    # Cheap pre-check: skip the regex scan entirely when the text doesn't
+    # contain either opener — the common case for plain assistant turns.
+    if not any(opener in text for opener in _XML_TOOL_OPENERS):
         return text, []
 
     parsed: List[Dict[str, Any]] = []
     cleaned_parts: List[str] = []
     cursor = 0
     for match in _XML_TOOL_BLOCK_RE.finditer(text):
-        payload = _parse_xml_tool_call_payload(match.group(1))
+        payload = _parse_xml_tool_call_payload(match.group("body"))
         if payload is None:
             # Malformed block — leave it in the text and continue scanning.
             continue
@@ -135,9 +145,9 @@ def _safe_emit_split(buffer: str) -> Tuple[str, str]:
     """Split a streaming buffer into (safe_to_emit, hold_back).
 
     ``hold_back`` covers any trailing portion that could still be the start of
-    a ``<tool_call>`` opening tag, or a complete-but-not-yet-closed tag whose
-    closing marker hasn't arrived. Everything before the earliest such ``<``
-    is safe to forward to the caller as text.
+    a ``<tool_call>`` / ``<tool_calling>`` opening tag, or a
+    complete-but-not-yet-closed tag whose closing marker hasn't arrived.
+    Everything before the earliest such ``<`` is safe to forward as text.
     """
     earliest_hold = len(buffer)
     pos = 0
@@ -146,9 +156,12 @@ def _safe_emit_split(buffer: str) -> Tuple[str, str]:
         if idx == -1:
             break
         rem = buffer[idx:]
-        # Either rem is a strict prefix of "<tool_call>" (still arriving) or
-        # rem already starts with "<tool_call>" (full opener, body in flight).
-        if _XML_TOOL_OPEN.startswith(rem) or rem.startswith(_XML_TOOL_OPEN):
+        # Either rem is a strict prefix of an opener (still arriving) or
+        # rem already starts with one (full opener, body in flight).
+        if any(
+            opener.startswith(rem) or rem.startswith(opener)
+            for opener in _XML_TOOL_OPENERS
+        ):
             earliest_hold = idx
             break
         pos = idx + 1

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -22,9 +22,10 @@ Currently, Google Gemini models have the broadest multimodal support on OCI.
 """
 
 import json
+import re
 import uuid
 import warnings
-from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
 from langchain_core.messages import (
     AIMessage,
@@ -40,6 +41,118 @@ from pydantic import BaseModel
 
 from langchain_oci.chat_models.providers.base import Provider
 from langchain_oci.common.utils import OCIUtils
+
+# Hermes/Llama-style inline tool-call format. Some fine-tuned models hosted on
+# OCI Dedicated AI Clusters return tool calls as `<tool_call>{...}</tool_call>`
+# blocks inside the assistant message text instead of populating the structured
+# `tool_calls` field on the response. We extract those here so callers see
+# normal structured tool calls in both `_generate` and `_stream`.
+_XML_TOOL_OPEN = "<tool_call>"
+_XML_TOOL_CLOSE = "</tool_call>"
+_XML_TOOL_BLOCK_RE = re.compile(
+    re.escape(_XML_TOOL_OPEN) + r"\s*(.*?)\s*" + re.escape(_XML_TOOL_CLOSE),
+    re.DOTALL,
+)
+
+
+def _parse_xml_tool_call_payload(payload: str) -> Optional[Dict[str, Any]]:
+    """Parse the JSON payload of a single ``<tool_call>...</tool_call>`` block.
+
+    Returns ``{"name": str, "arguments": str}`` (arguments serialised as JSON)
+    on success, or ``None`` if the payload is not parseable / not in the
+    expected ``{"name": ..., "arguments": ...}`` shape — which lets callers
+    leave the original text alone instead of silently dropping it.
+    """
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    name = decoded.get("name")
+    if not isinstance(name, str) or not name:
+        return None
+    arguments = decoded.get("arguments", {})
+    if isinstance(arguments, str):
+        # Some models double-encode arguments as a JSON string. Keep it as-is —
+        # downstream parsers already handle both shapes.
+        arguments_str = arguments
+    else:
+        arguments_str = json.dumps(arguments)
+    return {"name": name, "arguments": arguments_str}
+
+
+def _extract_xml_tool_calls(text: str) -> Tuple[str, List[Dict[str, Any]]]:
+    """Strip ``<tool_call>...</tool_call>`` blocks and return parsed calls.
+
+    Returns ``(cleaned_text, [{"id", "name", "arguments"}, ...])``. Blocks
+    whose JSON payload doesn't parse are left intact in ``cleaned_text`` so
+    no information is silently lost.
+    """
+    if _XML_TOOL_OPEN not in text or _XML_TOOL_CLOSE not in text:
+        return text, []
+
+    parsed: List[Dict[str, Any]] = []
+    cleaned_parts: List[str] = []
+    cursor = 0
+    for match in _XML_TOOL_BLOCK_RE.finditer(text):
+        payload = _parse_xml_tool_call_payload(match.group(1))
+        if payload is None:
+            # Malformed block — leave it in the text and continue scanning.
+            continue
+        cleaned_parts.append(text[cursor : match.start()])
+        cursor = match.end()
+        parsed.append(
+            {
+                "id": str(uuid.uuid4()),
+                "name": payload["name"],
+                "arguments": payload["arguments"],
+            }
+        )
+    cleaned_parts.append(text[cursor:])
+    cleaned = "".join(cleaned_parts).strip()
+    return cleaned, parsed
+
+
+class _XmlToolCall:
+    """Stand-in for ``oci.generative_ai_inference.models.FunctionCall``.
+
+    Provides the attributes (``id``, ``name``, ``arguments``) and the
+    ``attribute_map`` that ``OCIUtils.convert_oci_tool_call_to_langchain``
+    inspects, so calls parsed out of inline ``<tool_call>`` text flow through
+    the same downstream conversion code as the structured ones.
+    """
+
+    attribute_map = {"id": "id", "name": "name", "arguments": "arguments"}
+
+    def __init__(self, *, id: str, name: str, arguments: str) -> None:
+        self.id = id
+        self.name = name
+        self.arguments = arguments
+
+
+def _safe_emit_split(buffer: str) -> Tuple[str, str]:
+    """Split a streaming buffer into (safe_to_emit, hold_back).
+
+    ``hold_back`` covers any trailing portion that could still be the start of
+    a ``<tool_call>`` opening tag, or a complete-but-not-yet-closed tag whose
+    closing marker hasn't arrived. Everything before the earliest such ``<``
+    is safe to forward to the caller as text.
+    """
+    earliest_hold = len(buffer)
+    pos = 0
+    while True:
+        idx = buffer.find("<", pos)
+        if idx == -1:
+            break
+        rem = buffer[idx:]
+        # Either rem is a strict prefix of "<tool_call>" (still arriving) or
+        # rem already starts with "<tool_call>" (full opener, body in flight).
+        if _XML_TOOL_OPEN.startswith(rem) or rem.startswith(_XML_TOOL_OPEN):
+            earliest_hold = idx
+            break
+        pos = idx + 1
+    return buffer[:earliest_hold], buffer[earliest_hold:]
 
 
 def _should_allow_more_tool_calls(
@@ -129,6 +242,13 @@ class GenericProvider(Provider):
     def __init__(self) -> None:
         from oci.generative_ai_inference import models
 
+        # Per-stream state for incremental <tool_call>...</tool_call> parsing.
+        # Reset by `reset_stream_state()` at the start of each `_stream` call.
+        self._xml_stream_state: Dict[str, Any] = {
+            "buffer": "",
+            "pending_tool_calls": [],
+        }
+
         # Chat request and message models
         self.oci_chat_request = models.GenericChatRequest
         self.oci_chat_message = {
@@ -172,7 +292,12 @@ class GenericProvider(Provider):
         self.chat_api_format = models.BaseChatRequest.API_FORMAT_GENERIC
 
     def chat_response_to_text(self, response: Any) -> str:
-        """Extract text from chat response, or '' if unavailable."""
+        """Extract text from chat response, or '' if unavailable.
+
+        Strips any ``<tool_call>...</tool_call>`` blocks emitted inline by
+        Hermes/Llama-style fine-tunes — those are surfaced as structured
+        ``tool_calls`` by ``chat_tool_calls`` instead.
+        """
         chat_resp = getattr(response.data, "chat_response", None)
         choices = getattr(chat_resp, "choices", None)
         text = ""
@@ -183,7 +308,8 @@ class GenericProvider(Provider):
                 text = "".join(
                     part.text for part in msg.content if getattr(part, "text", None)
                 )
-        if text == "":
+        cleaned, _ = _extract_xml_tool_calls(text)
+        if cleaned == "" and text == "":
             warnings.warn(
                 "GenericProvider could not extract text and returned an empty "
                 "string. Ensure the selected provider matches the response "
@@ -192,10 +318,14 @@ class GenericProvider(Provider):
                 UserWarning,
                 stacklevel=2,
             )
-        return text
+        return cleaned
 
     def chat_response_to_text_from_dict(self, response_data: Dict[str, Any]) -> str:
-        """Extract text from chat response dict (async path)."""
+        """Extract text from chat response dict (async path).
+
+        Strips inline ``<tool_call>...</tool_call>`` blocks for the same reason
+        as :meth:`chat_response_to_text`.
+        """
         chat_response = response_data.get("chatResponse", {})
         choices = chat_response.get("choices", [])
         text = ""
@@ -210,7 +340,8 @@ class GenericProvider(Provider):
                     )
                 else:
                     text = str(content)
-        if text == "":
+        cleaned, _ = _extract_xml_tool_calls(text)
+        if cleaned == "" and text == "":
             warnings.warn(
                 "GenericProvider could not extract text and returned an empty "
                 "string. Ensure the selected provider matches the response "
@@ -219,14 +350,68 @@ class GenericProvider(Provider):
                 UserWarning,
                 stacklevel=2,
             )
-        return text
+        return cleaned
 
     def chat_stream_to_text(self, event_data: Dict) -> str:
-        """Extract text from Meta chat stream event."""
+        """Extract text from Meta chat stream event.
+
+        Routes the raw delta through an incremental ``<tool_call>`` parser:
+        text inside a tool-call block is buffered and surfaced via
+        :meth:`process_stream_tool_calls`; everything else is forwarded as
+        normal token-stream content.
+        """
         content = event_data.get("message", {}).get("content", None)
         if not content:
-            return ""
-        return "".join(part.get("text", "") for part in content if part.get("text"))
+            raw_delta = ""
+        else:
+            raw_delta = "".join(
+                part.get("text", "") for part in content if part.get("text")
+            )
+        return self._feed_xml_stream(raw_delta)
+
+    def reset_stream_state(self) -> None:
+        """Clear per-stream ``<tool_call>`` parsing state.
+
+        Called by ``ChatOCIGenAI._stream`` / ``_astream`` at the start of each
+        new stream so a previous, possibly-aborted stream's leftover buffer
+        doesn't leak into the next one.
+        """
+        self._xml_stream_state["buffer"] = ""
+        self._xml_stream_state["pending_tool_calls"] = []
+
+    def flush_stream_state(self) -> str:
+        """Return any held-back text and reset the per-stream buffer.
+
+        Called once at end-of-stream so trailing characters that were held
+        back as a possible ``<tool_call>`` prefix don't get dropped if the
+        opener never actually arrived.
+        """
+        tail = self._xml_stream_state.get("buffer", "")
+        self._xml_stream_state["buffer"] = ""
+        self._xml_stream_state["pending_tool_calls"] = []
+        return tail
+
+    def _feed_xml_stream(self, delta: str) -> str:
+        """Append ``delta`` to the buffer and return the safe-to-emit prefix.
+
+        Side effect: when one or more ``<tool_call>...</tool_call>`` blocks
+        complete inside the buffer, parses them and stashes them on
+        ``self._xml_stream_state["pending_tool_calls"]`` for
+        :meth:`process_stream_tool_calls` to drain on the same event.
+        """
+        state = self._xml_stream_state
+        state["buffer"] += delta
+
+        # Drain any complete <tool_call>...</tool_call> blocks present in
+        # the buffer, leaving partial / incomplete blocks in place.
+        cleaned, parsed = _extract_xml_tool_calls(state["buffer"])
+        if parsed:
+            state["pending_tool_calls"].extend(parsed)
+            state["buffer"] = cleaned
+
+        safe, hold_back = _safe_emit_split(state["buffer"])
+        state["buffer"] = hold_back
+        return safe
 
     def is_chat_stream_end(self, event_data: Dict) -> bool:
         """Determine if Meta chat stream event indicates the end."""
@@ -263,11 +448,30 @@ class GenericProvider(Provider):
         return {"finish_reason": event_data["finishReason"]}
 
     def chat_tool_calls(self, response: Any) -> List[Any]:
-        """Retrieve tool calls from chat response."""
+        """Retrieve tool calls from chat response.
+
+        Falls back to parsing inline ``<tool_call>...</tool_call>`` blocks out
+        of the assistant message text when the model didn't populate the
+        structured ``tool_calls`` field — typical for Hermes/Llama-style
+        fine-tunes hosted on OCI Dedicated AI Clusters.
+        """
         choices = response.data.chat_response.choices
         if not choices or choices[0].message is None:
             return []
-        return choices[0].message.tool_calls
+        message = choices[0].message
+        native = message.tool_calls or []
+        if native:
+            return native
+        # Fallback: parse <tool_call>...</tool_call> blocks from the text.
+        text = "".join(
+            part.text for part in (message.content or []) if getattr(part, "text", None)
+        )
+        _, parsed = _extract_xml_tool_calls(text)
+        if not parsed:
+            return []
+        # Synthesise objects shaped like OCI FunctionCall so the downstream
+        # `format_response_tool_calls` path keeps working unchanged.
+        return [_XmlToolCall(**tc) for tc in parsed]
 
     def chat_stream_tool_calls(self, event_data: Dict) -> List[Any]:
         """Retrieve tool calls from Meta stream event."""
@@ -821,6 +1025,10 @@ class GenericProvider(Provider):
         """
         Process Meta stream tool calls and convert them to ToolCallChunks.
 
+        Drains any inline ``<tool_call>...</tool_call>`` blocks parsed by
+        :meth:`chat_stream_to_text` first, then falls through to the standard
+        OCI structured tool-call path.
+
         Args:
             event_data: The event data from the stream
             tool_call_ids: Dict mapping tool call index to ID for aggregation
@@ -829,6 +1037,23 @@ class GenericProvider(Provider):
             List of ToolCallChunk objects
         """
         tool_call_chunks: List[ToolCallChunk] = []
+
+        # Drain XML tool calls that completed during this event.
+        pending = self._xml_stream_state.get("pending_tool_calls", [])
+        if pending:
+            for parsed in pending:
+                index = len(tool_call_ids)
+                tool_call_ids[index] = parsed["id"]
+                tool_call_chunks.append(
+                    tool_call_chunk(
+                        name=parsed["name"],
+                        args=parsed["arguments"],
+                        id=parsed["id"],
+                        index=index,
+                    )
+                )
+            self._xml_stream_state["pending_tool_calls"] = []
+
         tool_call_response = self.chat_stream_tool_calls(event_data)
 
         if not tool_call_response:

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -22,10 +22,9 @@ Currently, Google Gemini models have the broadest multimodal support on OCI.
 """
 
 import json
-import re
 import uuid
 import warnings
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union
 
 from langchain_core.messages import (
     AIMessage,
@@ -41,131 +40,11 @@ from pydantic import BaseModel
 
 from langchain_oci.chat_models.providers.base import Provider
 from langchain_oci.common.utils import OCIUtils
-
-# Hermes/Llama/Qwen-style inline tool-call format. Some fine-tuned models
-# hosted on OCI Dedicated AI Clusters return tool calls inside the assistant
-# message text using one of two equivalent tag pairs:
-#
-#   <tool_call>{"name": ..., "arguments": {...}}</tool_call>
-#   <tool_calling>{"name": ..., "arguments": {...}}</tool_calling>
-#
-# (Qwen3 has been observed emitting either form — see
-# https://github.com/oracle/langchain-oracle/issues/207.) We extract both
-# variants here so callers see normal structured tool calls in `_generate`
-# and `_stream`.
-_XML_TOOL_TAG_NAMES = ("tool_call", "tool_calling")
-_XML_TOOL_BLOCK_RE = re.compile(
-    r"<(?P<tag>" + "|".join(_XML_TOOL_TAG_NAMES) + r")>\s*(?P<body>.*?)\s*</(?P=tag)>",
-    re.DOTALL,
+from langchain_oci.common.xml_tool_call_parser import (
+    XmlStreamBuffer,
+    XmlToolCall,
+    extract_xml_tool_calls,
 )
-# Used by the streaming buffer to detect that the trailing portion of the
-# buffer could still be the start of an opening tag for either variant.
-_XML_TOOL_OPENERS = tuple(f"<{name}>" for name in _XML_TOOL_TAG_NAMES)
-
-
-def _parse_xml_tool_call_payload(payload: str) -> Optional[Dict[str, Any]]:
-    """Parse the JSON payload of a single ``<tool_call>...</tool_call>`` block.
-
-    Returns ``{"name": str, "arguments": str}`` (arguments serialised as JSON)
-    on success, or ``None`` if the payload is not parseable / not in the
-    expected ``{"name": ..., "arguments": ...}`` shape — which lets callers
-    leave the original text alone instead of silently dropping it.
-    """
-    try:
-        decoded = json.loads(payload)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(decoded, dict):
-        return None
-    name = decoded.get("name")
-    if not isinstance(name, str) or not name:
-        return None
-    arguments = decoded.get("arguments", {})
-    if isinstance(arguments, str):
-        # Some models double-encode arguments as a JSON string. Keep it as-is —
-        # downstream parsers already handle both shapes.
-        arguments_str = arguments
-    else:
-        arguments_str = json.dumps(arguments)
-    return {"name": name, "arguments": arguments_str}
-
-
-def _extract_xml_tool_calls(text: str) -> Tuple[str, List[Dict[str, Any]]]:
-    """Strip ``<tool_call>``/``<tool_calling>`` blocks and return parsed calls.
-
-    Returns ``(cleaned_text, [{"id", "name", "arguments"}, ...])``. Blocks
-    whose JSON payload doesn't parse are left intact in ``cleaned_text`` so
-    no information is silently lost.
-    """
-    # Cheap pre-check: skip the regex scan entirely when the text doesn't
-    # contain either opener — the common case for plain assistant turns.
-    if not any(opener in text for opener in _XML_TOOL_OPENERS):
-        return text, []
-
-    parsed: List[Dict[str, Any]] = []
-    cleaned_parts: List[str] = []
-    cursor = 0
-    for match in _XML_TOOL_BLOCK_RE.finditer(text):
-        payload = _parse_xml_tool_call_payload(match.group("body"))
-        if payload is None:
-            # Malformed block — leave it in the text and continue scanning.
-            continue
-        cleaned_parts.append(text[cursor : match.start()])
-        cursor = match.end()
-        parsed.append(
-            {
-                "id": str(uuid.uuid4()),
-                "name": payload["name"],
-                "arguments": payload["arguments"],
-            }
-        )
-    cleaned_parts.append(text[cursor:])
-    cleaned = "".join(cleaned_parts).strip()
-    return cleaned, parsed
-
-
-class _XmlToolCall:
-    """Stand-in for ``oci.generative_ai_inference.models.FunctionCall``.
-
-    Provides the attributes (``id``, ``name``, ``arguments``) and the
-    ``attribute_map`` that ``OCIUtils.convert_oci_tool_call_to_langchain``
-    inspects, so calls parsed out of inline ``<tool_call>`` text flow through
-    the same downstream conversion code as the structured ones.
-    """
-
-    attribute_map = {"id": "id", "name": "name", "arguments": "arguments"}
-
-    def __init__(self, *, id: str, name: str, arguments: str) -> None:
-        self.id = id
-        self.name = name
-        self.arguments = arguments
-
-
-def _safe_emit_split(buffer: str) -> Tuple[str, str]:
-    """Split a streaming buffer into (safe_to_emit, hold_back).
-
-    ``hold_back`` covers any trailing portion that could still be the start of
-    a ``<tool_call>`` / ``<tool_calling>`` opening tag, or a
-    complete-but-not-yet-closed tag whose closing marker hasn't arrived.
-    Everything before the earliest such ``<`` is safe to forward as text.
-    """
-    earliest_hold = len(buffer)
-    pos = 0
-    while True:
-        idx = buffer.find("<", pos)
-        if idx == -1:
-            break
-        rem = buffer[idx:]
-        # Either rem is a strict prefix of an opener (still arriving) or
-        # rem already starts with one (full opener, body in flight).
-        if any(
-            opener.startswith(rem) or rem.startswith(opener)
-            for opener in _XML_TOOL_OPENERS
-        ):
-            earliest_hold = idx
-            break
-        pos = idx + 1
-    return buffer[:earliest_hold], buffer[earliest_hold:]
 
 
 def _should_allow_more_tool_calls(
@@ -255,12 +134,10 @@ class GenericProvider(Provider):
     def __init__(self) -> None:
         from oci.generative_ai_inference import models
 
-        # Per-stream state for incremental <tool_call>...</tool_call> parsing.
-        # Reset by `reset_stream_state()` at the start of each `_stream` call.
-        self._xml_stream_state: Dict[str, Any] = {
-            "buffer": "",
-            "pending_tool_calls": [],
-        }
+        # Per-stream incremental parser for inline <tool_call>...</tool_call>
+        # blocks emitted by Hermes/Llama/Qwen-style fine-tunes. Reset by
+        # `reset_stream_state()` at the start of each `_stream` call.
+        self._xml_buffer = XmlStreamBuffer()
 
         # Chat request and message models
         self.oci_chat_request = models.GenericChatRequest
@@ -321,7 +198,7 @@ class GenericProvider(Provider):
                 text = "".join(
                     part.text for part in msg.content if getattr(part, "text", None)
                 )
-        cleaned, _ = _extract_xml_tool_calls(text)
+        cleaned, _ = extract_xml_tool_calls(text)
         if cleaned == "" and text == "":
             warnings.warn(
                 "GenericProvider could not extract text and returned an empty "
@@ -353,7 +230,7 @@ class GenericProvider(Provider):
                     )
                 else:
                     text = str(content)
-        cleaned, _ = _extract_xml_tool_calls(text)
+        cleaned, _ = extract_xml_tool_calls(text)
         if cleaned == "" and text == "":
             warnings.warn(
                 "GenericProvider could not extract text and returned an empty "
@@ -368,10 +245,10 @@ class GenericProvider(Provider):
     def chat_stream_to_text(self, event_data: Dict) -> str:
         """Extract text from Meta chat stream event.
 
-        Routes the raw delta through an incremental ``<tool_call>`` parser:
-        text inside a tool-call block is buffered and surfaced via
-        :meth:`process_stream_tool_calls`; everything else is forwarded as
-        normal token-stream content.
+        Routes the raw delta through :class:`XmlStreamBuffer` so inline
+        ``<tool_call>``/``<tool_calling>`` blocks (Hermes/Llama/Qwen-style
+        fine-tunes) are surfaced via :meth:`process_stream_tool_calls`
+        instead of leaking into normal token-stream content.
         """
         content = event_data.get("message", {}).get("content", None)
         if not content:
@@ -380,7 +257,7 @@ class GenericProvider(Provider):
             raw_delta = "".join(
                 part.get("text", "") for part in content if part.get("text")
             )
-        return self._feed_xml_stream(raw_delta)
+        return self._xml_buffer.feed(raw_delta)
 
     def reset_stream_state(self) -> None:
         """Clear per-stream ``<tool_call>`` parsing state.
@@ -389,8 +266,7 @@ class GenericProvider(Provider):
         new stream so a previous, possibly-aborted stream's leftover buffer
         doesn't leak into the next one.
         """
-        self._xml_stream_state["buffer"] = ""
-        self._xml_stream_state["pending_tool_calls"] = []
+        self._xml_buffer.reset()
 
     def flush_stream_state(self) -> str:
         """Return any held-back text and reset the per-stream buffer.
@@ -399,32 +275,7 @@ class GenericProvider(Provider):
         back as a possible ``<tool_call>`` prefix don't get dropped if the
         opener never actually arrived.
         """
-        tail = self._xml_stream_state.get("buffer", "")
-        self._xml_stream_state["buffer"] = ""
-        self._xml_stream_state["pending_tool_calls"] = []
-        return tail
-
-    def _feed_xml_stream(self, delta: str) -> str:
-        """Append ``delta`` to the buffer and return the safe-to-emit prefix.
-
-        Side effect: when one or more ``<tool_call>...</tool_call>`` blocks
-        complete inside the buffer, parses them and stashes them on
-        ``self._xml_stream_state["pending_tool_calls"]`` for
-        :meth:`process_stream_tool_calls` to drain on the same event.
-        """
-        state = self._xml_stream_state
-        state["buffer"] += delta
-
-        # Drain any complete <tool_call>...</tool_call> blocks present in
-        # the buffer, leaving partial / incomplete blocks in place.
-        cleaned, parsed = _extract_xml_tool_calls(state["buffer"])
-        if parsed:
-            state["pending_tool_calls"].extend(parsed)
-            state["buffer"] = cleaned
-
-        safe, hold_back = _safe_emit_split(state["buffer"])
-        state["buffer"] = hold_back
-        return safe
+        return self._xml_buffer.flush()
 
     def is_chat_stream_end(self, event_data: Dict) -> bool:
         """Determine if Meta chat stream event indicates the end."""
@@ -479,12 +330,12 @@ class GenericProvider(Provider):
         text = "".join(
             part.text for part in (message.content or []) if getattr(part, "text", None)
         )
-        _, parsed = _extract_xml_tool_calls(text)
+        _, parsed = extract_xml_tool_calls(text)
         if not parsed:
             return []
         # Synthesise objects shaped like OCI FunctionCall so the downstream
         # `format_response_tool_calls` path keeps working unchanged.
-        return [_XmlToolCall(**tc) for tc in parsed]
+        return [XmlToolCall(**tc) for tc in parsed]
 
     def chat_stream_tool_calls(self, event_data: Dict) -> List[Any]:
         """Retrieve tool calls from Meta stream event."""
@@ -1052,20 +903,17 @@ class GenericProvider(Provider):
         tool_call_chunks: List[ToolCallChunk] = []
 
         # Drain XML tool calls that completed during this event.
-        pending = self._xml_stream_state.get("pending_tool_calls", [])
-        if pending:
-            for parsed in pending:
-                index = len(tool_call_ids)
-                tool_call_ids[index] = parsed["id"]
-                tool_call_chunks.append(
-                    tool_call_chunk(
-                        name=parsed["name"],
-                        args=parsed["arguments"],
-                        id=parsed["id"],
-                        index=index,
-                    )
+        for parsed in self._xml_buffer.drain_completed():
+            index = len(tool_call_ids)
+            tool_call_ids[index] = parsed["id"]
+            tool_call_chunks.append(
+                tool_call_chunk(
+                    name=parsed["name"],
+                    args=parsed["arguments"],
+                    id=parsed["id"],
+                    index=index,
                 )
-            self._xml_stream_state["pending_tool_calls"] = []
+            )
 
         tool_call_response = self.chat_stream_tool_calls(event_data)
 

--- a/libs/oci/langchain_oci/common/xml_tool_call_parser.py
+++ b/libs/oci/langchain_oci/common/xml_tool_call_parser.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Inline ``<tool_call>...</tool_call>`` parser for Hermes-style fine-tunes.
+
+Some fine-tuned chat models hosted on OCI Dedicated AI Cluster (DAC) endpoints
+follow the Hermes (NousResearch) function-calling convention and emit tool
+calls inline as either ``<tool_call>{...}</tool_call>`` or
+``<tool_calling>{...}</tool_calling>`` blocks inside the assistant message
+text — instead of populating the structured ``tool_calls`` field. Qwen3 in
+particular has been observed emitting either form (see issue #207).
+
+This module owns:
+
+* The pure helpers (:func:`parse_xml_tool_call_payload`,
+  :func:`extract_xml_tool_calls`, :func:`safe_emit_split`,
+  :class:`XmlToolCall`) used in the non-streaming response path.
+* :class:`XmlStreamBuffer`, the stateful class that drives the incremental
+  streaming parse — append a delta, drain any complete blocks, return only
+  the prefix that cannot still be the start of an opener.
+
+The parsing logic itself is provider-agnostic — providers wire it in (today
+only ``GenericProvider``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+# Hermes/Llama/Qwen-style inline tool-call format. Two equivalent tag pairs
+# in the wild — Qwen3 is known to emit either form.
+XML_TOOL_TAG_NAMES: Tuple[str, ...] = ("tool_call", "tool_calling")
+XML_TOOL_BLOCK_RE = re.compile(
+    r"<(?P<tag>" + "|".join(XML_TOOL_TAG_NAMES) + r")>\s*(?P<body>.*?)\s*</(?P=tag)>",
+    re.DOTALL,
+)
+# Used by the streaming buffer to detect that the trailing portion of the
+# buffer could still be the start of an opening tag for either variant.
+XML_TOOL_OPENERS: Tuple[str, ...] = tuple(f"<{name}>" for name in XML_TOOL_TAG_NAMES)
+
+
+def parse_xml_tool_call_payload(payload: str) -> Optional[Dict[str, Any]]:
+    """Parse the JSON payload of a single ``<tool_call>...</tool_call>`` block.
+
+    Returns ``{"name": str, "arguments": str}`` (arguments serialised as JSON)
+    on success, or ``None`` if the payload is not parseable / not in the
+    expected ``{"name": ..., "arguments": ...}`` shape — which lets callers
+    leave the original text alone instead of silently dropping it.
+    """
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    name = decoded.get("name")
+    if not isinstance(name, str) or not name:
+        return None
+    arguments = decoded.get("arguments", {})
+    if isinstance(arguments, str):
+        # Some models double-encode arguments as a JSON string. Keep it as-is —
+        # downstream parsers already handle both shapes.
+        arguments_str = arguments
+    else:
+        arguments_str = json.dumps(arguments)
+    return {"name": name, "arguments": arguments_str}
+
+
+def extract_xml_tool_calls(text: str) -> Tuple[str, List[Dict[str, Any]]]:
+    """Strip ``<tool_call>``/``<tool_calling>`` blocks and return parsed calls.
+
+    Returns ``(cleaned_text, [{"id", "name", "arguments"}, ...])``. Blocks
+    whose JSON payload doesn't parse are left intact in ``cleaned_text`` so
+    no information is silently lost.
+    """
+    # Cheap pre-check: skip the regex scan entirely when the text doesn't
+    # contain either opener — the common case for plain assistant turns.
+    if not any(opener in text for opener in XML_TOOL_OPENERS):
+        return text, []
+
+    parsed: List[Dict[str, Any]] = []
+    cleaned_parts: List[str] = []
+    cursor = 0
+    for match in XML_TOOL_BLOCK_RE.finditer(text):
+        payload = parse_xml_tool_call_payload(match.group("body"))
+        if payload is None:
+            # Malformed block — leave it in the text and continue scanning.
+            continue
+        cleaned_parts.append(text[cursor : match.start()])
+        cursor = match.end()
+        parsed.append(
+            {
+                "id": str(uuid.uuid4()),
+                "name": payload["name"],
+                "arguments": payload["arguments"],
+            }
+        )
+    cleaned_parts.append(text[cursor:])
+    cleaned = "".join(cleaned_parts).strip()
+    return cleaned, parsed
+
+
+def safe_emit_split(buffer: str) -> Tuple[str, str]:
+    """Split a streaming buffer into ``(safe_to_emit, hold_back)``.
+
+    ``hold_back`` covers any trailing portion that could still be the start of
+    a ``<tool_call>`` / ``<tool_calling>`` opening tag, or a
+    complete-but-not-yet-closed tag whose closing marker hasn't arrived.
+    Everything before the earliest such ``<`` is safe to forward as text.
+    """
+    earliest_hold = len(buffer)
+    pos = 0
+    while True:
+        idx = buffer.find("<", pos)
+        if idx == -1:
+            break
+        rem = buffer[idx:]
+        # Either rem is a strict prefix of an opener (still arriving) or
+        # rem already starts with one (full opener, body in flight).
+        if any(
+            opener.startswith(rem) or rem.startswith(opener)
+            for opener in XML_TOOL_OPENERS
+        ):
+            earliest_hold = idx
+            break
+        pos = idx + 1
+    return buffer[:earliest_hold], buffer[earliest_hold:]
+
+
+class XmlToolCall:
+    """Stand-in for ``oci.generative_ai_inference.models.FunctionCall``.
+
+    Provides the attributes (``id``, ``name``, ``arguments``) and the
+    ``attribute_map`` that ``OCIUtils.convert_oci_tool_call_to_langchain``
+    inspects, so calls parsed out of inline ``<tool_call>`` text flow through
+    the same downstream conversion code as the structured ones.
+    """
+
+    attribute_map = {"id": "id", "name": "name", "arguments": "arguments"}
+
+    def __init__(self, *, id: str, name: str, arguments: str) -> None:
+        self.id = id
+        self.name = name
+        self.arguments = arguments
+
+
+class XmlStreamBuffer:
+    """Per-stream incremental parser for inline tool-call blocks.
+
+    Handles ``<tool_call>...</tool_call>`` and the equivalent
+    ``<tool_calling>...</tool_calling>`` variant. Wire into a streaming
+    provider as:
+
+    1. ``reset()`` at start of a new stream so leftover state from a prior
+       stream can't leak forward.
+    2. For each delta: ``safe = buffer.feed(delta)`` returns safe-to-emit
+       text. Blocks that completed during this delta are queued internally;
+       retrieve them with :meth:`drain_completed`.
+    3. ``flush()`` at end-of-stream returns any held-back tail (e.g. an
+       unclosed block, or a partial-opener prefix that never resolved).
+    """
+
+    def __init__(self) -> None:
+        self._buffer: str = ""
+        self._completed: List[Dict[str, Any]] = []
+
+    def reset(self) -> None:
+        """Clear the buffer and any pending completed blocks."""
+        self._buffer = ""
+        self._completed = []
+
+    def feed(self, delta: str) -> str:
+        """Append ``delta`` and return the safe-to-emit prefix.
+
+        Any ``<tool_call>...</tool_call>`` blocks that completed inside the
+        buffer during this call are queued internally for
+        :meth:`drain_completed`.
+        """
+        self._buffer += delta
+        # Drain any complete <tool_call>...</tool_call> blocks present in
+        # the buffer, leaving partial / incomplete blocks in place.
+        cleaned, parsed = extract_xml_tool_calls(self._buffer)
+        if parsed:
+            self._completed.extend(parsed)
+            self._buffer = cleaned
+        safe, hold_back = safe_emit_split(self._buffer)
+        self._buffer = hold_back
+        return safe
+
+    def drain_completed(self) -> List[Dict[str, Any]]:
+        """Return and clear any completed XML tool-call dicts."""
+        if not self._completed:
+            return []
+        out = self._completed
+        self._completed = []
+        return out
+
+    def flush(self) -> str:
+        """Return any held-back text and reset state for the next stream.
+
+        Trailing characters that were held back as a possible-opener prefix
+        but never resolved into a ``<tool_call>`` block surface as a final
+        delta here so they don't get dropped.
+        """
+        tail = self._buffer
+        self._buffer = ""
+        self._completed = []
+        return tail

--- a/libs/oci/tests/integration_tests/chat_models/test_dac_endpoint.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_dac_endpoint.py
@@ -260,6 +260,21 @@ def test_stream_unicode_round_trip() -> None:
         assert token in text
 
 
+def test_invoke_does_not_leak_tool_calling_variant_marker() -> None:
+    """Belt-and-braces: even if the model emits ``<tool_calling>...`` instead of
+    ``<tool_call>...``, the tags must not bleed into ``content``.
+
+    See https://github.com/oracle/langchain-oracle/issues/207.
+    """
+    chat = _make_llm().bind_tools([add_numbers])
+    result = chat.invoke("Use add_numbers to compute 41 plus 1.")
+    content = result.content or ""
+    assert "<tool_call>" not in content
+    assert "<tool_calling>" not in content
+    assert "</tool_call>" not in content
+    assert "</tool_calling>" not in content
+
+
 def test_chat_instance_reuse_across_stream_invoke_stream() -> None:
     """The provider's per-stream buffer must not leak across calls on the same chat."""
     shared = _make_llm().bind_tools([add_numbers])

--- a/libs/oci/tests/integration_tests/chat_models/test_dac_endpoint.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_dac_endpoint.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Integration tests for ChatOCIGenAI against an OCI Dedicated AI Cluster (DAC).
+
+These tests verify that DAC fine-tunes which emit tool calls inline as
+``<tool_call>{...}</tool_call>`` blocks (Hermes/Llama style) round-trip
+through `GenericProvider`'s parsing — both for `invoke` (non-streaming) and
+`stream` — so calling code never has to subclass `ChatOCIGenAI`.
+
+Required env (skip otherwise):
+
+    DAC_ENDPOINT_OCID    # ocid1.generativeaiendpoint.oc1.<region>.<...>
+    DAC_COMPARTMENT_ID   # ocid1.compartment.oc1..<...>
+    DAC_SERVICE_ENDPOINT # https://inference.generativeai.<region>.oci.oraclecloud.com
+    OCI_CONFIG_PROFILE   # ~/.oci/config profile name (default: DEFAULT)
+    OCI_AUTH_TYPE        # default: API_KEY
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+from langchain_oci.chat_models import ChatOCIGenAI
+
+REQUIRED_ENV = ("DAC_ENDPOINT_OCID", "DAC_COMPARTMENT_ID", "DAC_SERVICE_ENDPOINT")
+
+
+def _missing_env() -> bool:
+    return any(not os.environ.get(k) for k in REQUIRED_ENV)
+
+
+pytestmark = [
+    pytest.mark.requires("oci"),
+    pytest.mark.skipif(
+        _missing_env(),
+        reason=f"DAC integration tests need {', '.join(REQUIRED_ENV)}",
+    ),
+]
+
+
+def _make_llm(**kw):
+    return ChatOCIGenAI(
+        model_id=os.environ["DAC_ENDPOINT_OCID"],
+        compartment_id=os.environ["DAC_COMPARTMENT_ID"],
+        service_endpoint=os.environ["DAC_SERVICE_ENDPOINT"],
+        auth_profile=os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
+        auth_type=os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool functions
+# ---------------------------------------------------------------------------
+
+
+def add_numbers(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+def multiply_numbers(a: int, b: int) -> int:
+    """Multiply two numbers."""
+    return a * b
+
+
+def lookup_user(user_id: str, fields: list[str]) -> dict:
+    """Look up a user by id, returning the requested fields."""
+    return {"user_id": user_id, **{f: f"<{f}>" for f in fields}}
+
+
+# ---------------------------------------------------------------------------
+# Plain text — no tool calling involved
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_plain_text() -> None:
+    result = _make_llm().invoke("Reply with exactly: 'pong'")
+    assert isinstance(result.content, str) and result.content
+    assert result.tool_calls == []
+
+
+def test_stream_plain_text_reassembles() -> None:
+    chunks = list(_make_llm().stream("Count: one two three four five."))
+    assert len(chunks) > 1, "expected more than one streamed chunk"
+    text = "".join(c.content for c in chunks)
+    assert text, "reassembled text should be non-empty"
+    # Plain-text stream must never leak tool_call XML markers.
+    assert "<tool_call>" not in text
+    assert "</tool_call>" not in text
+    assert not any(c.tool_call_chunks for c in chunks)
+
+
+def test_stream_plain_text_no_xml_marker_leak_with_literal_lt() -> None:
+    """Literal `<` characters in plain text must not be held back forever."""
+    chunks = list(
+        _make_llm().stream(
+            "Print these comparison expressions one per line and nothing else: "
+            "a < b, c < d, e < f"
+        )
+    )
+    text = "".join(c.content for c in chunks)
+    assert "<" in text, "expected the literal '<' to round-trip"
+    assert "<tool_call>" not in text
+    assert not any(c.tool_call_chunks for c in chunks)
+
+
+def test_invoke_with_system_and_multi_turn() -> None:
+    result = _make_llm().invoke(
+        [
+            SystemMessage(
+                content="You are a terse cat. Answer with one short sentence."
+            ),
+            HumanMessage(content="What's 2+2?"),
+            AIMessage(content="Four, mrow."),
+            HumanMessage(content="And 3+3?"),
+        ]
+    )
+    assert "6" in result.content or "six" in result.content.lower()
+
+
+def test_invoke_respects_max_tokens() -> None:
+    short = _make_llm(model_kwargs={"temperature": 0.0, "max_tokens": 20}).invoke(
+        "Reply with the alphabet."
+    )
+    # 20-token cap → short response. Don't pin to exact length (tokenisation
+    # varies); just assert it didn't run away with hundreds of characters.
+    assert len(short.content) < 200
+
+
+# ---------------------------------------------------------------------------
+# Tool calling — invoke (non-streaming)
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_single_tool_call_returns_structured() -> None:
+    chat = _make_llm().bind_tools([add_numbers])
+    result = chat.invoke("Use add_numbers to compute 17 plus 25.")
+
+    # Inline <tool_call> XML must not bleed into the text.
+    assert "<tool_call>" not in (result.content or "")
+    assert len(result.tool_calls) == 1
+
+    tc = result.tool_calls[0]
+    assert tc["name"] == "add_numbers"
+    assert tc["args"] == {"a": 17, "b": 25}
+    assert tc["id"], "tool call must have a non-empty id for the agent loop"
+
+
+def test_invoke_picks_correct_tool_from_two_options() -> None:
+    chat = _make_llm().bind_tools([add_numbers, multiply_numbers])
+    result = chat.invoke("Use the right tool to compute 7 times 8.")
+    assert len(result.tool_calls) == 1
+    tc = result.tool_calls[0]
+    assert tc["name"] == "multiply_numbers"
+    assert tc["args"] == {"a": 7, "b": 8}
+
+
+def test_invoke_tool_with_nested_args() -> None:
+    chat = _make_llm().bind_tools([lookup_user])
+    result = chat.invoke(
+        "Look up user 'u-42' and return their name and email "
+        "using the lookup_user tool."
+    )
+    assert len(result.tool_calls) == 1
+    tc = result.tool_calls[0]
+    assert tc["name"] == "lookup_user"
+    assert tc["args"]["user_id"] == "u-42"
+    assert set(tc["args"]["fields"]) == {"name", "email"}
+
+
+def test_invoke_multi_step_tool_orchestration() -> None:
+    """Tool call → ToolMessage feedback → final natural-language answer."""
+    chat = _make_llm().bind_tools([add_numbers])
+    prompt = "Use add_numbers to compute 200 plus 50, then tell me the answer."
+
+    turn1 = chat.invoke(prompt)
+    assert len(turn1.tool_calls) == 1
+    tc = turn1.tool_calls[0]
+
+    tool_result = add_numbers(**tc["args"])
+    turn2 = chat.invoke(
+        [
+            HumanMessage(content=prompt),
+            turn1,
+            ToolMessage(
+                content=str(tool_result), name=tc["name"], tool_call_id=tc["id"]
+            ),
+        ]
+    )
+    assert turn2.tool_calls == [], "second turn should not call a tool again"
+    assert "250" in turn2.content
+
+
+# ---------------------------------------------------------------------------
+# Tool calling — stream
+# ---------------------------------------------------------------------------
+
+
+def _collect_stream_tool_calls(chunks):
+    return [tc for c in chunks if c.tool_call_chunks for tc in c.tool_call_chunks]
+
+
+def test_stream_single_tool_call_returns_chunks() -> None:
+    chat = _make_llm().bind_tools([add_numbers])
+    chunks = list(chat.stream("Use add_numbers to compute 100 plus 1."))
+    text = "".join(c.content for c in chunks)
+
+    # The XML markers and JSON payload must never appear in the streamed text.
+    assert "<tool_call>" not in text
+    assert "</tool_call>" not in text
+
+    tool_chunks = _collect_stream_tool_calls(chunks)
+    assert len(tool_chunks) == 1
+    tc = tool_chunks[0]
+    assert tc["name"] == "add_numbers"
+    assert tc["args"] is not None
+    assert json.loads(tc["args"]) == {"a": 100, "b": 1}
+    assert tc["id"]
+
+
+def test_stream_picks_correct_tool_from_two_options() -> None:
+    chat = _make_llm().bind_tools([add_numbers, multiply_numbers])
+    chunks = list(chat.stream("Use the right tool to compute 7 times 8."))
+    tool_chunks = _collect_stream_tool_calls(chunks)
+    assert len(tool_chunks) == 1
+    tc = tool_chunks[0]
+    assert tc["name"] == "multiply_numbers"
+    assert tc["args"] is not None
+    assert json.loads(tc["args"]) == {"a": 7, "b": 8}
+
+
+# ---------------------------------------------------------------------------
+# Round-trip / robustness
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_unicode_round_trip() -> None:
+    target = "café — naïve — ✓ — 漢字"
+    result = _make_llm().invoke(f"Reply with: '{target}' and nothing else.")
+    for token in ("café", "naïve", "✓", "漢字"):
+        assert token in result.content
+
+
+def test_stream_unicode_round_trip() -> None:
+    target = "café — naïve — ✓ — 漢字"
+    chunks = list(_make_llm().stream(f"Reply with: '{target}' and nothing else."))
+    text = "".join(c.content for c in chunks)
+    for token in ("café", "naïve", "✓", "漢字"):
+        assert token in text
+
+
+def test_chat_instance_reuse_across_stream_invoke_stream() -> None:
+    """The provider's per-stream buffer must not leak across calls on the same chat."""
+    shared = _make_llm().bind_tools([add_numbers])
+
+    r1 = list(shared.stream("Use add_numbers for 1 plus 1."))
+    tcs1 = _collect_stream_tool_calls(r1)
+    assert len(tcs1) == 1
+    assert json.loads(tcs1[0]["args"]) == {"a": 1, "b": 1}
+
+    r2 = shared.invoke("Use add_numbers for 2 plus 2.")
+    assert len(r2.tool_calls) == 1
+    assert r2.tool_calls[0]["args"] == {"a": 2, "b": 2}
+
+    r3 = list(shared.stream("Use add_numbers for 3 plus 3."))
+    tcs3 = _collect_stream_tool_calls(r3)
+    assert len(tcs3) == 1
+    assert json.loads(tcs3[0]["args"]) == {"a": 3, "b": 3}

--- a/libs/oci/tests/unit_tests/chat_models/test_xml_tool_calls.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_xml_tool_calls.py
@@ -1,0 +1,325 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for the inline ``<tool_call>...</tool_call>`` parser used by
+GenericProvider when talking to Hermes/Llama-style fine-tunes (e.g. served
+through OCI Dedicated AI Cluster endpoints) that return tool calls inside the
+assistant message text instead of in the structured ``tool_calls`` field.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from langchain_oci.chat_models.providers.generic import (
+    GenericProvider,
+    _extract_xml_tool_calls,
+    _parse_xml_tool_call_payload,
+    _safe_emit_split,
+)
+
+# ---------------------------------------------------------------------------
+# _parse_xml_tool_call_payload
+# ---------------------------------------------------------------------------
+
+
+def test_parse_payload_happy_path() -> None:
+    payload = '{"name": "add", "arguments": {"a": 1, "b": 2}}'
+    parsed = _parse_xml_tool_call_payload(payload)
+    assert parsed is not None
+    assert parsed["name"] == "add"
+    assert json.loads(parsed["arguments"]) == {"a": 1, "b": 2}
+
+
+def test_parse_payload_string_arguments_preserved() -> None:
+    """Some models double-encode args; we leave the string for downstream parsers."""
+    payload = '{"name": "add", "arguments": "{\\"a\\": 1}"}'
+    parsed = _parse_xml_tool_call_payload(payload)
+    assert parsed is not None
+    assert parsed["arguments"] == '{"a": 1}'
+
+
+def test_parse_payload_missing_arguments_defaults_to_empty_object() -> None:
+    parsed = _parse_xml_tool_call_payload('{"name": "ping"}')
+    assert parsed == {"name": "ping", "arguments": "{}"}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not json at all",
+        '{"arguments": {}}',  # missing name
+        '{"name": ""}',  # empty name
+        '{"name": 123}',  # name not a string
+        "[1, 2, 3]",  # not an object
+    ],
+)
+def test_parse_payload_returns_none_on_invalid(payload: str) -> None:
+    assert _parse_xml_tool_call_payload(payload) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_xml_tool_calls
+# ---------------------------------------------------------------------------
+
+
+def test_extract_no_markers_returns_text_unchanged() -> None:
+    text = "Just a normal response with < and > characters."
+    cleaned, calls = _extract_xml_tool_calls(text)
+    assert cleaned == text
+    assert calls == []
+
+
+def test_extract_single_block() -> None:
+    text = (
+        "Sure, calling the tool now.\n"
+        '<tool_call>{"name": "add", "arguments": {"a": 1, "b": 2}}</tool_call>'
+    )
+    cleaned, calls = _extract_xml_tool_calls(text)
+    assert cleaned == "Sure, calling the tool now."
+    assert len(calls) == 1
+    assert calls[0]["name"] == "add"
+    assert json.loads(calls[0]["arguments"]) == {"a": 1, "b": 2}
+    assert calls[0]["id"]  # uuid populated
+
+
+def test_extract_multiple_blocks_preserves_order_and_strips_text() -> None:
+    text = (
+        "Step 1.\n"
+        '<tool_call>{"name": "first", "arguments": {"x": 1}}</tool_call>\n'
+        "Step 2.\n"
+        '<tool_call>{"name": "second", "arguments": {"y": 2}}</tool_call>\n'
+        "All done."
+    )
+    cleaned, calls = _extract_xml_tool_calls(text)
+    assert "tool_call" not in cleaned
+    assert "Step 1." in cleaned and "Step 2." in cleaned and "All done." in cleaned
+    assert [c["name"] for c in calls] == ["first", "second"]
+
+
+def test_extract_malformed_block_left_in_text() -> None:
+    text = (
+        "<tool_call>not valid json</tool_call>"
+        ' <tool_call>{"name": "ok", "arguments": {}}</tool_call>'
+    )
+    cleaned, calls = _extract_xml_tool_calls(text)
+    assert "<tool_call>not valid json</tool_call>" in cleaned
+    assert len(calls) == 1
+    assert calls[0]["name"] == "ok"
+
+
+def test_extract_handles_whitespace_around_payload() -> None:
+    text = '<tool_call>\n  {"name": "ws", "arguments": {"a": 1}}\n  </tool_call>'
+    cleaned, calls = _extract_xml_tool_calls(text)
+    assert cleaned == ""
+    assert len(calls) == 1
+    assert calls[0]["name"] == "ws"
+
+
+# ---------------------------------------------------------------------------
+# _safe_emit_split
+# ---------------------------------------------------------------------------
+
+
+def test_safe_emit_no_lt_emits_everything() -> None:
+    safe, hold = _safe_emit_split("hello world")
+    assert safe == "hello world"
+    assert hold == ""
+
+
+def test_safe_emit_unrelated_lt_emits_everything() -> None:
+    safe, hold = _safe_emit_split("use < to compare")
+    assert safe == "use < to compare"
+    assert hold == ""
+
+
+@pytest.mark.parametrize(
+    "tail",
+    [
+        "<",
+        "<t",
+        "<too",
+        "<tool",
+        "<tool_call",
+        "<tool_call>",
+        "<tool_call>{partial",
+    ],
+)
+def test_safe_emit_holds_back_partial_or_open_tag(tail: str) -> None:
+    safe, hold = _safe_emit_split("text " + tail)
+    assert safe == "text "
+    assert hold == tail
+
+
+# ---------------------------------------------------------------------------
+# GenericProvider.{chat_stream_to_text, process_stream_tool_calls}
+# ---------------------------------------------------------------------------
+
+
+def _stream_event(text: str) -> dict:
+    """Wrap a text delta in the OCI streaming event shape GenericProvider expects."""
+    return {"message": {"content": [{"type": "TEXT", "text": text}]}}
+
+
+def test_stream_plain_text_passes_through() -> None:
+    p = GenericProvider()
+    p.reset_stream_state()
+    out = [
+        p.chat_stream_to_text(_stream_event("Hello, ")),
+        p.chat_stream_to_text(_stream_event("world!")),
+    ]
+    assert "".join(out) == "Hello, world!"
+    assert p.flush_stream_state() == ""
+
+
+def test_stream_tool_call_split_across_chunks_emits_chunk_after_close() -> None:
+    """The realistic scenario: <tool_call>...</tool_call> arrives across many events."""
+    p = GenericProvider()
+    p.reset_stream_state()
+    deltas = [
+        "Calling tool: ",
+        "<tool_",
+        'call>{"name": ',
+        '"add", "argum',
+        'ents": {"a": 1, ',
+        '"b": 2}}</to',
+        "ol_call>",
+        " all done",
+    ]
+    text_buf = ""
+    tool_calls = []
+    tool_call_ids: dict = {}
+    for d in deltas:
+        text_buf += p.chat_stream_to_text(_stream_event(d))
+        # process_stream_tool_calls drains XML tool calls; pass an empty
+        # event so the OCI-native code path is a no-op.
+        tool_calls.extend(p.process_stream_tool_calls({}, tool_call_ids))
+    text_buf += p.flush_stream_state()
+
+    # Text never contains the marker characters — they were buffered.
+    assert "<tool_call>" not in text_buf
+    assert "</tool_call>" not in text_buf
+    assert text_buf.startswith("Calling tool: ")
+    assert text_buf.endswith(" all done")
+
+    assert len(tool_calls) == 1
+    chunk = tool_calls[0]
+    assert chunk["name"] == "add"
+    assert json.loads(chunk["args"]) == {"a": 1, "b": 2}
+    assert chunk["id"]
+
+
+def test_stream_partial_open_tag_then_unrelated_text_releases_held_back() -> None:
+    """If '<' turns out not to be a <tool_call> opener, we must release the buffer."""
+    p = GenericProvider()
+    p.reset_stream_state()
+
+    held = p.chat_stream_to_text(_stream_event("see <"))
+    # Held back: "<" alone could still be a partial opener.
+    assert held == "see "
+
+    released = p.chat_stream_to_text(_stream_event("nope, just less-than"))
+    # Once we see '<n', it's no longer a possible <tool_call> prefix.
+    assert released == "<nope, just less-than"
+    assert p.flush_stream_state() == ""
+
+
+def test_stream_unclosed_tool_call_flushed_at_end_of_stream() -> None:
+    """If a stream ends mid-block, the buffered text must surface, not vanish."""
+    p = GenericProvider()
+    p.reset_stream_state()
+    p.chat_stream_to_text(_stream_event('<tool_call>{"name": "incompl'))
+    flushed = p.flush_stream_state()
+    assert flushed.startswith("<tool_call>")
+
+
+def test_reset_stream_state_clears_between_streams() -> None:
+    p = GenericProvider()
+    p.chat_stream_to_text(_stream_event("leftover <tool_call>{"))
+    p.reset_stream_state()
+    out = p.chat_stream_to_text(_stream_event("fresh"))
+    assert out == "fresh"
+    assert p.flush_stream_state() == ""
+
+
+# ---------------------------------------------------------------------------
+# GenericProvider.chat_tool_calls fallback to text-parsing
+# ---------------------------------------------------------------------------
+
+
+class _FakePart:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeMessage:
+    def __init__(self, text: str, structured_tool_calls: list | None = None) -> None:
+        self.content = [_FakePart(text)] if text else []
+        self.tool_calls = structured_tool_calls or []
+
+
+class _FakeChoice:
+    def __init__(self, message: _FakeMessage) -> None:
+        self.message = message
+
+
+class _FakeChatResponse:
+    def __init__(self, choices: list) -> None:
+        self.choices = choices
+
+
+class _FakeData:
+    def __init__(self, chat_response: _FakeChatResponse) -> None:
+        self.chat_response = chat_response
+
+
+class _FakeResponse:
+    def __init__(self, data: _FakeData) -> None:
+        self.data = data
+
+
+def _response_with_text(text: str, structured: list | None = None) -> _FakeResponse:
+    msg = _FakeMessage(text, structured)
+    return _FakeResponse(_FakeData(_FakeChatResponse([_FakeChoice(msg)])))
+
+
+def test_chat_tool_calls_prefers_native_field() -> None:
+    p = GenericProvider()
+    sentinel = object()
+    resp = _response_with_text(
+        '<tool_call>{"name": "x", "arguments": {}}</tool_call>',
+        structured=[sentinel],
+    )
+    assert p.chat_tool_calls(resp) == [sentinel]
+
+
+def test_chat_tool_calls_falls_back_to_xml_when_native_empty() -> None:
+    p = GenericProvider()
+    resp = _response_with_text(
+        '<tool_call>{"name": "add", "arguments": {"a": 1, "b": 2}}</tool_call>'
+    )
+    calls = p.chat_tool_calls(resp)
+    assert len(calls) == 1
+    assert calls[0].name == "add"
+    assert json.loads(calls[0].arguments) == {"a": 1, "b": 2}
+
+
+def test_chat_response_to_text_strips_xml_blocks() -> None:
+    p = GenericProvider()
+    resp = _response_with_text(
+        'Here it is: <tool_call>{"name": "x", "arguments": {}}</tool_call>'
+    )
+    assert p.chat_response_to_text(resp) == "Here it is:"
+
+
+def test_chat_response_to_text_from_dict_strips_xml_blocks() -> None:
+    p = GenericProvider()
+    text = '<tool_call>{"name": "x", "arguments": {}}</tool_call>'
+    response_data = {
+        "chatResponse": {
+            "choices": [{"message": {"content": [{"type": "TEXT", "text": text}]}}]
+        }
+    }
+    assert p.chat_response_to_text_from_dict(response_data) == ""

--- a/libs/oci/tests/unit_tests/chat_models/test_xml_tool_calls.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_xml_tool_calls.py
@@ -207,7 +207,9 @@ def test_stream_tool_call_split_across_chunks_emits_chunk_after_close() -> None:
     assert len(tool_calls) == 1
     chunk = tool_calls[0]
     assert chunk["name"] == "add"
-    assert json.loads(chunk["args"]) == {"a": 1, "b": 2}
+    args = chunk["args"]
+    assert args is not None
+    assert json.loads(args) == {"a": 1, "b": 2}
     assert chunk["id"]
 
 

--- a/libs/oci/tests/unit_tests/chat_models/test_xml_tool_calls.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_xml_tool_calls.py
@@ -118,6 +118,45 @@ def test_extract_handles_whitespace_around_payload() -> None:
     assert calls[0]["name"] == "ws"
 
 
+def test_extract_supports_tool_calling_variant() -> None:
+    """Qwen3 also emits ``<tool_calling>...</tool_calling>``; both must work.
+
+    See https://github.com/oracle/langchain-oracle/issues/207.
+    """
+    text = (
+        "Calling now.\n"
+        '<tool_calling>{"name": "ping", "arguments": {"x": 1}}</tool_calling>'
+    )
+    cleaned, calls = _extract_xml_tool_calls(text)
+    assert cleaned == "Calling now."
+    assert len(calls) == 1
+    assert calls[0]["name"] == "ping"
+    assert json.loads(calls[0]["arguments"]) == {"x": 1}
+
+
+def test_extract_mixed_tag_variants_in_one_response() -> None:
+    """One model turn occasionally mixes both tags; both must extract."""
+    text = (
+        '<tool_call>{"name": "first", "arguments": {"a": 1}}</tool_call>'
+        " then "
+        '<tool_calling>{"name": "second", "arguments": {"b": 2}}</tool_calling>'
+    )
+    cleaned, calls = _extract_xml_tool_calls(text)
+    assert "tool_call" not in cleaned
+    assert "tool_calling" not in cleaned
+    assert [c["name"] for c in calls] == ["first", "second"]
+
+
+def test_extract_does_not_match_mismatched_open_close() -> None:
+    """``<tool_call>...</tool_calling>`` is malformed — must NOT be parsed."""
+    text = '<tool_call>{"name": "x", "arguments": {}}</tool_calling>'
+    cleaned, calls = _extract_xml_tool_calls(text)
+    assert calls == []
+    # The text comes back unchanged so the caller can see what happened.
+    assert "<tool_call>" in cleaned
+    assert "</tool_calling>" in cleaned
+
+
 # ---------------------------------------------------------------------------
 # _safe_emit_split
 # ---------------------------------------------------------------------------
@@ -138,6 +177,7 @@ def test_safe_emit_unrelated_lt_emits_everything() -> None:
 @pytest.mark.parametrize(
     "tail",
     [
+        # <tool_call> partials and full opener
         "<",
         "<t",
         "<too",
@@ -145,6 +185,14 @@ def test_safe_emit_unrelated_lt_emits_everything() -> None:
         "<tool_call",
         "<tool_call>",
         "<tool_call>{partial",
+        # <tool_calling> partials and full opener (extra disambiguation chars)
+        "<tool_",
+        "<tool_c",
+        "<tool_cal",
+        "<tool_calli",
+        "<tool_calling",
+        "<tool_calling>",
+        "<tool_calling>{partial",
     ],
 )
 def test_safe_emit_holds_back_partial_or_open_tag(tail: str) -> None:
@@ -244,6 +292,38 @@ def test_reset_stream_state_clears_between_streams() -> None:
     out = p.chat_stream_to_text(_stream_event("fresh"))
     assert out == "fresh"
     assert p.flush_stream_state() == ""
+
+
+def test_stream_tool_calling_variant_split_across_chunks() -> None:
+    """The longer ``<tool_calling>`` opener must also stream correctly."""
+    p = GenericProvider()
+    p.reset_stream_state()
+    deltas = [
+        "Doing it: ",
+        "<tool_call",
+        'ing>{"name":',
+        ' "ping", "arguments": {"x": 1}}',
+        "</tool_calling>",
+        " ok",
+    ]
+    text_buf = ""
+    tool_calls: list = []
+    tool_call_ids: dict = {}
+    for d in deltas:
+        text_buf += p.chat_stream_to_text(_stream_event(d))
+        tool_calls.extend(p.process_stream_tool_calls({}, tool_call_ids))
+    text_buf += p.flush_stream_state()
+
+    assert "<tool_calling>" not in text_buf
+    assert "</tool_calling>" not in text_buf
+    assert text_buf.startswith("Doing it: ")
+    assert text_buf.endswith(" ok")
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["name"] == "ping"
+    args = tool_calls[0]["args"]
+    assert args is not None
+    assert json.loads(args) == {"x": 1}
 
 
 # ---------------------------------------------------------------------------

--- a/libs/oci/tests/unit_tests/chat_models/test_xml_tool_calls.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_xml_tool_calls.py
@@ -13,21 +13,22 @@ import json
 
 import pytest
 
-from langchain_oci.chat_models.providers.generic import (
-    GenericProvider,
-    _extract_xml_tool_calls,
-    _parse_xml_tool_call_payload,
-    _safe_emit_split,
+from langchain_oci.chat_models.providers.generic import GenericProvider
+from langchain_oci.common.xml_tool_call_parser import (
+    XmlStreamBuffer,
+    extract_xml_tool_calls,
+    parse_xml_tool_call_payload,
+    safe_emit_split,
 )
 
 # ---------------------------------------------------------------------------
-# _parse_xml_tool_call_payload
+# parse_xml_tool_call_payload
 # ---------------------------------------------------------------------------
 
 
 def test_parse_payload_happy_path() -> None:
     payload = '{"name": "add", "arguments": {"a": 1, "b": 2}}'
-    parsed = _parse_xml_tool_call_payload(payload)
+    parsed = parse_xml_tool_call_payload(payload)
     assert parsed is not None
     assert parsed["name"] == "add"
     assert json.loads(parsed["arguments"]) == {"a": 1, "b": 2}
@@ -36,13 +37,13 @@ def test_parse_payload_happy_path() -> None:
 def test_parse_payload_string_arguments_preserved() -> None:
     """Some models double-encode args; we leave the string for downstream parsers."""
     payload = '{"name": "add", "arguments": "{\\"a\\": 1}"}'
-    parsed = _parse_xml_tool_call_payload(payload)
+    parsed = parse_xml_tool_call_payload(payload)
     assert parsed is not None
     assert parsed["arguments"] == '{"a": 1}'
 
 
 def test_parse_payload_missing_arguments_defaults_to_empty_object() -> None:
-    parsed = _parse_xml_tool_call_payload('{"name": "ping"}')
+    parsed = parse_xml_tool_call_payload('{"name": "ping"}')
     assert parsed == {"name": "ping", "arguments": "{}"}
 
 
@@ -57,17 +58,17 @@ def test_parse_payload_missing_arguments_defaults_to_empty_object() -> None:
     ],
 )
 def test_parse_payload_returns_none_on_invalid(payload: str) -> None:
-    assert _parse_xml_tool_call_payload(payload) is None
+    assert parse_xml_tool_call_payload(payload) is None
 
 
 # ---------------------------------------------------------------------------
-# _extract_xml_tool_calls
+# extract_xml_tool_calls
 # ---------------------------------------------------------------------------
 
 
 def test_extract_no_markers_returns_text_unchanged() -> None:
     text = "Just a normal response with < and > characters."
-    cleaned, calls = _extract_xml_tool_calls(text)
+    cleaned, calls = extract_xml_tool_calls(text)
     assert cleaned == text
     assert calls == []
 
@@ -77,7 +78,7 @@ def test_extract_single_block() -> None:
         "Sure, calling the tool now.\n"
         '<tool_call>{"name": "add", "arguments": {"a": 1, "b": 2}}</tool_call>'
     )
-    cleaned, calls = _extract_xml_tool_calls(text)
+    cleaned, calls = extract_xml_tool_calls(text)
     assert cleaned == "Sure, calling the tool now."
     assert len(calls) == 1
     assert calls[0]["name"] == "add"
@@ -93,7 +94,7 @@ def test_extract_multiple_blocks_preserves_order_and_strips_text() -> None:
         '<tool_call>{"name": "second", "arguments": {"y": 2}}</tool_call>\n'
         "All done."
     )
-    cleaned, calls = _extract_xml_tool_calls(text)
+    cleaned, calls = extract_xml_tool_calls(text)
     assert "tool_call" not in cleaned
     assert "Step 1." in cleaned and "Step 2." in cleaned and "All done." in cleaned
     assert [c["name"] for c in calls] == ["first", "second"]
@@ -104,7 +105,7 @@ def test_extract_malformed_block_left_in_text() -> None:
         "<tool_call>not valid json</tool_call>"
         ' <tool_call>{"name": "ok", "arguments": {}}</tool_call>'
     )
-    cleaned, calls = _extract_xml_tool_calls(text)
+    cleaned, calls = extract_xml_tool_calls(text)
     assert "<tool_call>not valid json</tool_call>" in cleaned
     assert len(calls) == 1
     assert calls[0]["name"] == "ok"
@@ -112,7 +113,7 @@ def test_extract_malformed_block_left_in_text() -> None:
 
 def test_extract_handles_whitespace_around_payload() -> None:
     text = '<tool_call>\n  {"name": "ws", "arguments": {"a": 1}}\n  </tool_call>'
-    cleaned, calls = _extract_xml_tool_calls(text)
+    cleaned, calls = extract_xml_tool_calls(text)
     assert cleaned == ""
     assert len(calls) == 1
     assert calls[0]["name"] == "ws"
@@ -127,7 +128,7 @@ def test_extract_supports_tool_calling_variant() -> None:
         "Calling now.\n"
         '<tool_calling>{"name": "ping", "arguments": {"x": 1}}</tool_calling>'
     )
-    cleaned, calls = _extract_xml_tool_calls(text)
+    cleaned, calls = extract_xml_tool_calls(text)
     assert cleaned == "Calling now."
     assert len(calls) == 1
     assert calls[0]["name"] == "ping"
@@ -141,7 +142,7 @@ def test_extract_mixed_tag_variants_in_one_response() -> None:
         " then "
         '<tool_calling>{"name": "second", "arguments": {"b": 2}}</tool_calling>'
     )
-    cleaned, calls = _extract_xml_tool_calls(text)
+    cleaned, calls = extract_xml_tool_calls(text)
     assert "tool_call" not in cleaned
     assert "tool_calling" not in cleaned
     assert [c["name"] for c in calls] == ["first", "second"]
@@ -150,7 +151,7 @@ def test_extract_mixed_tag_variants_in_one_response() -> None:
 def test_extract_does_not_match_mismatched_open_close() -> None:
     """``<tool_call>...</tool_calling>`` is malformed — must NOT be parsed."""
     text = '<tool_call>{"name": "x", "arguments": {}}</tool_calling>'
-    cleaned, calls = _extract_xml_tool_calls(text)
+    cleaned, calls = extract_xml_tool_calls(text)
     assert calls == []
     # The text comes back unchanged so the caller can see what happened.
     assert "<tool_call>" in cleaned
@@ -158,18 +159,18 @@ def test_extract_does_not_match_mismatched_open_close() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _safe_emit_split
+# safe_emit_split
 # ---------------------------------------------------------------------------
 
 
 def test_safe_emit_no_lt_emits_everything() -> None:
-    safe, hold = _safe_emit_split("hello world")
+    safe, hold = safe_emit_split("hello world")
     assert safe == "hello world"
     assert hold == ""
 
 
 def test_safe_emit_unrelated_lt_emits_everything() -> None:
-    safe, hold = _safe_emit_split("use < to compare")
+    safe, hold = safe_emit_split("use < to compare")
     assert safe == "use < to compare"
     assert hold == ""
 
@@ -196,9 +197,72 @@ def test_safe_emit_unrelated_lt_emits_everything() -> None:
     ],
 )
 def test_safe_emit_holds_back_partial_or_open_tag(tail: str) -> None:
-    safe, hold = _safe_emit_split("text " + tail)
+    safe, hold = safe_emit_split("text " + tail)
     assert safe == "text "
     assert hold == tail
+
+
+# ---------------------------------------------------------------------------
+# XmlStreamBuffer (direct unit tests of the lifted class)
+# ---------------------------------------------------------------------------
+
+
+def test_xml_stream_buffer_plain_text_passes_through() -> None:
+    buf = XmlStreamBuffer()
+    assert buf.feed("hello ") == "hello "
+    assert buf.feed("world") == "world"
+    assert buf.drain_completed() == []
+    assert buf.flush() == ""
+
+
+def test_xml_stream_buffer_holds_back_partial_opener() -> None:
+    buf = XmlStreamBuffer()
+    safe = buf.feed("see <")
+    assert safe == "see "
+    safe = buf.feed("nope")
+    # '<n' is no longer a possible opener — held-back '<' is released.
+    assert safe == "<nope"
+
+
+def test_xml_stream_buffer_drains_completed_block() -> None:
+    buf = XmlStreamBuffer()
+    safe = buf.feed("Calling: ")
+    safe += buf.feed('<tool_call>{"name": "add", "arguments": {"a": 1}}</tool_call>')
+    safe += buf.feed(" done")
+    completed = buf.drain_completed()
+    assert "<tool_call>" not in safe
+    assert safe.startswith("Calling: ")
+    assert safe.endswith(" done")
+    assert len(completed) == 1
+    assert completed[0]["name"] == "add"
+    assert json.loads(completed[0]["arguments"]) == {"a": 1}
+
+
+def test_xml_stream_buffer_flush_releases_unclosed_block() -> None:
+    buf = XmlStreamBuffer()
+    buf.feed('<tool_call>{"name": "incompl')
+    flushed = buf.flush()
+    assert flushed.startswith("<tool_call>")
+    # After flush the buffer is reset.
+    assert buf.feed("fresh") == "fresh"
+
+
+def test_xml_stream_buffer_reset_clears_state() -> None:
+    buf = XmlStreamBuffer()
+    buf.feed("leftover <tool_call>{")
+    buf.reset()
+    assert buf.feed("fresh") == "fresh"
+    assert buf.drain_completed() == []
+    assert buf.flush() == ""
+
+
+def test_xml_stream_buffer_drain_completed_is_idempotent() -> None:
+    buf = XmlStreamBuffer()
+    buf.feed('<tool_call>{"name": "ping", "arguments": {}}</tool_call>')
+    first = buf.drain_completed()
+    second = buf.drain_completed()
+    assert len(first) == 1
+    assert second == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #207.

Hermes / Llama / Qwen-style fine-tunes hosted on OCI Dedicated AI Cluster (DAC) endpoints emit tool calls inline as either `<tool_call>{...}</tool_call>` or `<tool_calling>{...}</tool_calling>` blocks inside the assistant message text instead of populating the OCI structured `tool_calls` field. On current `main`:

- `chat.invoke(...)` against a DAC fine-tune with `bind_tools(...)` returns `tool_calls=[]` and the raw XML lands in `content`.
- `chat.stream(...)` against the same DAC produces no `tool_call_chunks` at all — the raw XML just streams as text.

That makes any LangChain agent loop on a DAC fine-tune impossible without subclassing `ChatOCIGenAI` and overriding `_generate` (which doesn't help streaming anyway).

This PR adds the parsing inside `GenericProvider` so both paths converge — no subclassing, both tag variants supported.

### What changes

- **`chat_response_to_text` / `chat_response_to_text_from_dict`** strip both `<tool_call>...</tool_call>` and `<tool_calling>...</tool_calling>` blocks. Sync and async non-streaming paths share the parser.
- **`chat_tool_calls`** falls back to the XML extractor when the structured field is empty, returning small `_XmlToolCall` stand-ins shaped like `oci.generative_ai_inference.models.FunctionCall` (same attributes + `attribute_map`) so `OCIUtils.convert_oci_tool_call_to_langchain` works unchanged.
- **`chat_stream_to_text`** is now an incremental parser: appends each event delta to a per-stream buffer, drains complete blocks for either tag variant, and returns only the prefix that cannot still be the start of an opener. Partial `<` is held until disambiguated; once `<n` (or any non-`tool_call`/`tool_calling` second character) arrives, the held-back text is released.
- **`process_stream_tool_calls`** first emits XML blocks that completed during the current event as `tool_call_chunk(...)`, then falls through to the existing OCI structured-tool-call path.
- **`reset_stream_state` / `flush_stream_state`** are called from `_stream` and `_astream` at start / end-of-stream so a previous stream's leftover buffer can't leak forward, and trailing characters held back as a possible-opener prefix surface as a final delta if no opener arrives.
- **Mismatched open/close pairs** (`<tool_call>...</tool_calling>`) are intentionally NOT parsed and are left in the text so the issue stays visible to the caller rather than getting silently swallowed.
- **Argument shape:** the parser accepts both object-form `arguments` (most fine-tunes) and JSON-string-form `arguments` (some double-encode). The serialised string is forwarded to the existing downstream parser, which already handles both shapes.

The change is a strict superset: responses without inline markers flow through unchanged, native `tool_calls` still take precedence over the text fallback, malformed payloads are left in the text rather than silently dropped, and CohereProvider is untouched.

### Verification

- 42 unit tests in `tests/unit_tests/chat_models/test_xml_tool_calls.py` covering payload parsing, both tag variants, mixed variants in one response, mismatched open/close, the safe-emit split, the streaming buffer (blocks split across chunks for both tags, unclosed blocks at end-of-stream, partial-prefix safe-emit for both opener variants), and the chat-level fallback hooks.
- 15 live DAC integration tests in `tests/integration_tests/chat_models/test_dac_endpoint.py` (env-gated; skip cleanly without `DAC_ENDPOINT_OCID` / `DAC_COMPARTMENT_ID` / `DAC_SERVICE_ENDPOINT`). All pass against a live UK-region DAC fine-tune in ~12s.
- Pre-existing 302 unit tests still pass — Cohere/Gemini/Meta/OpenAI provider paths are untouched.

A 17-scenario end-to-end smoke run (sanitised) is published as a gist for visibility:
https://gist.github.com/fede-kamel/2506703bea52703cc4529a3993177730

## Test plan

- [x] `make lint` (ruff + ruff format + mypy `.`) clean on 3.12
- [x] `make test` — 344 passed, 12 skipped (302 pre-existing + 42 new XML parser tests)
- [x] Live DAC integration tests — 15/15 pass against a live UK-region fine-tune
- [x] Both `<tool_call>` and `<tool_calling>` tag variants verified end-to-end
- [x] CohereProvider / GeminiProvider / MetaProvider / OpenAIProvider regression-free (existing parametrized tests untouched)
- [ ] Reviewer to confirm against their own DAC endpoint if convenient