### PR TITLE
fix(oci): bump oci SDK floor to 2.173.0 (closes #165)

### DIFF
--- a/libs/oci/poetry.lock
+++ b/libs/oci/poetry.lock
@@ -1975,7 +1975,7 @@ description = "Standard tests for LangChain implementations"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["test"]
-markers = "python_version >= \"3.10\""
+markers = "python_version >= \"3.10\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "langchain_tests-1.0.2-py3-none-any.whl", hash = "sha256:713936d9e474ba39eeade95ee8e9d2e237b15a74d4896cae66ef1a9bd0a44d48"},
     {file = "langchain_tests-1.0.2.tar.gz", hash = "sha256:7e96d82499ee32ab141e93bdeb122c942db41ff326bcc87ca27290ede92f0f78"},
@@ -1996,6 +1996,35 @@ pytest-recording = "*"
 pytest-socket = ">=0.7.0,<1.0.0"
 syrupy = ">=4.0.0,<5.0.0"
 vcrpy = ">=7.0.0,<8.0.0"
+
+[[package]]
+name = "langchain-tests"
+version = "1.1.6"
+description = "Standard tests for LangChain implementations"
+optional = false
+python-versions = "<4.0.0,>=3.10.0"
+groups = ["test"]
+markers = "python_version >= \"3.10\" and platform_python_implementation == \"PyPy\""
+files = [
+    {file = "langchain_tests-1.1.6-py3-none-any.whl", hash = "sha256:de622079e7dfa2b23ab65ef612f7bb340c29e75dc5458e6ea2ddc2ad229447a6"},
+    {file = "langchain_tests-1.1.6.tar.gz", hash = "sha256:e352106cf8176da9bd040effa090601bddf375d5b616b98d1c74b2c99b2cb47b"},
+]
+
+[package.dependencies]
+httpx = ">=0.28.1,<1.0.0"
+langchain-core = ">=1.2.27,<2.0.0"
+numpy = [
+    {version = ">=1.26.2", markers = "python_version < \"3.13\""},
+    {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
+]
+pytest = ">=7.0.0,<10.0.0"
+pytest-asyncio = ">=0.20.0,<2.0.0"
+pytest-benchmark = "*"
+pytest-codspeed = "*"
+pytest-recording = "*"
+pytest-socket = ">=0.7.0,<1.0.0"
+syrupy = ">=4.0.0,<6.0.0"
+vcrpy = ">=8.0.0,<9.0.0"
 
 [[package]]
 name = "langchain-text-splitters"
@@ -2431,7 +2460,7 @@ files = [
     {file = "multidict-6.7.0-py3-none-any.whl", hash = "sha256:394fc5c42a333c9ffc3e421a4c85e08580d990e08b99f6bf35b4132114c5dcb3"},
     {file = "multidict-6.7.0.tar.gz", hash = "sha256:c6e99d9a65ca282e578dfea819cfa9c0a62b2499d8677392e09feaf305e9e6f5"},
 ]
-markers = {test = "python_version >= \"3.10\""}
+markers = {test = "python_version >= \"3.10\" and platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
 typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
@@ -2719,23 +2748,27 @@ markers = {main = "python_version >= \"3.13\" and extra == \"deep-research\"", t
 
 [[package]]
 name = "oci"
-version = "2.167.0"
+version = "2.173.0"
 description = "Oracle Cloud Infrastructure Python SDK"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "oci-2.167.0-py3-none-any.whl", hash = "sha256:78f81d332a06b4ee5956d0e73c37e23e2f89183afc4ccafefe700f6d96320f6f"},
-    {file = "oci-2.167.0.tar.gz", hash = "sha256:66136f0af4bfef3a7234d900dae877affade9a541d10c1c264e920a5db78b7f4"},
+    {file = "oci-2.173.0-py3-none-any.whl", hash = "sha256:b50fe600d460c2643fc38e94a359e5d84c6411e6e111fa133485bdf1883a9628"},
+    {file = "oci-2.173.0.tar.gz", hash = "sha256:83ef55ef8aa22cabd6c5e7847d2fa7c45316a6f1133c999a7661edee91bc19a5"},
 ]
 
 [package.dependencies]
 certifi = "*"
 circuitbreaker = {version = ">=1.3.1,<3.0.0", markers = "python_version >= \"3.7\""}
-cryptography = ">=3.2.1,<46.0.0"
-pyOpenSSL = ">=17.5.0,<=25.1.0"
+cryptography = ">=3.2.1,<47.0.0"
+pyOpenSSL = ">=17.5.0,<27.0.0"
 python-dateutil = ">=2.5.3,<3.0.0"
 pytz = ">=2016.10"
+urllib3 = [
+    {version = "1.26.20", markers = "python_version < \"3.10.0\""},
+    {version = ">=2.6.3", markers = "python_version >= \"3.10.0\""},
+]
 
 [package.extras]
 adk = ["docstring-parser (>=0.16) ; python_version >= \"3.10\" and python_version < \"4\"", "mcp (>=1.6.0) ; python_version >= \"3.10\" and python_version < \"4\"", "pydantic (>=2.10.6) ; python_version >= \"3.10\" and python_version < \"4\"", "rich (>=13.9.4) ; python_version >= \"3.10\" and python_version < \"4\""]
@@ -3403,7 +3436,7 @@ files = [
     {file = "propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237"},
     {file = "propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d"},
 ]
-markers = {test = "python_version >= \"3.10\""}
+markers = {test = "python_version >= \"3.10\" and platform_python_implementation != \"PyPy\""}
 
 [[package]]
 name = "protobuf"
@@ -4634,7 +4667,7 @@ description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.7"
 groups = ["typing"]
-markers = "python_version >= \"3.10\" and platform_python_implementation == \"PyPy\""
+markers = "python_version == \"3.9\""
 files = [
     {file = "types-requests-2.31.0.6.tar.gz", hash = "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0"},
     {file = "types_requests-2.31.0.6-py3-none-any.whl", hash = "sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9"},
@@ -4650,7 +4683,7 @@ description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.9"
 groups = ["typing"]
-markers = "platform_python_implementation != \"PyPy\" or python_version == \"3.9\""
+markers = "python_version >= \"3.10\""
 files = [
     {file = "types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1"},
     {file = "types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d"},
@@ -4666,7 +4699,7 @@ description = "Typing stubs for urllib3"
 optional = false
 python-versions = "*"
 groups = ["typing"]
-markers = "python_version >= \"3.10\" and platform_python_implementation == \"PyPy\""
+markers = "python_version == \"3.9\""
 files = [
     {file = "types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f"},
     {file = "types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"},
@@ -4723,7 +4756,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 groups = ["main", "test", "test-integration"]
-markers = "python_version >= \"3.10\" and platform_python_implementation == \"PyPy\""
+markers = "python_version == \"3.9\""
 files = [
     {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
     {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
@@ -4741,7 +4774,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "test", "test-integration", "typing"]
-markers = "platform_python_implementation != \"PyPy\" or python_version == \"3.9\""
+markers = "python_version >= \"3.10\""
 files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
@@ -4793,7 +4826,7 @@ description = "Automatically mock your HTTP interactions to simplify and speed u
 optional = false
 python-versions = ">=3.9"
 groups = ["test"]
-markers = "python_version >= \"3.10\""
+markers = "python_version >= \"3.10\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "vcrpy-7.0.0-py2.py3-none-any.whl", hash = "sha256:55791e26c18daa363435054d8b35bd41a4ac441b6676167635d1b37a71dbe124"},
     {file = "vcrpy-7.0.0.tar.gz", hash = "sha256:176391ad0425edde1680c5b20738ea3dc7fb942520a48d2993448050986b3a50"},
@@ -4801,15 +4834,32 @@ files = [
 
 [package.dependencies]
 PyYAML = "*"
-urllib3 = [
-    {version = "<2", markers = "platform_python_implementation == \"PyPy\""},
-    {version = "*", markers = "platform_python_implementation != \"PyPy\" and python_version >= \"3.10\""},
-]
+urllib3 = {version = "*", markers = "platform_python_implementation != \"PyPy\" and python_version >= \"3.10\""}
 wrapt = "*"
 yarl = "*"
 
 [package.extras]
 tests = ["Werkzeug (==2.0.3)", "aiohttp", "boto3", "httplib2", "httpx", "pytest", "pytest-aiohttp", "pytest-asyncio", "pytest-cov", "pytest-httpbin", "requests (>=2.22.0)", "tornado", "urllib3"]
+
+[[package]]
+name = "vcrpy"
+version = "8.1.1"
+description = "Automatically mock your HTTP interactions to simplify and speed up testing"
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+markers = "python_version >= \"3.10\" and platform_python_implementation == \"PyPy\""
+files = [
+    {file = "vcrpy-8.1.1-py3-none-any.whl", hash = "sha256:2d16f31ad56493efb6165182dd99767207031b0da3f68b18f975545ede8ac4b9"},
+    {file = "vcrpy-8.1.1.tar.gz", hash = "sha256:58e3053e33b423f3594031cb758c3f4d1df931307f1e67928e30cf352df7709f"},
+]
+
+[package.dependencies]
+PyYAML = "*"
+wrapt = "*"
+
+[package.extras]
+tests = ["aiohttp", "boto3", "cryptography", "httpbin", "httpcore", "httplib2", "httpx", "pycurl ; platform_python_implementation != \"PyPy\"", "pytest", "pytest-aiohttp", "pytest-asyncio", "pytest-cov", "pytest-httpbin", "requests (>=2.22.0)", "tornado", "urllib3", "werkzeug (==2.0.3)"]
 
 [[package]]
 name = "watchdog"
@@ -5352,7 +5402,7 @@ files = [
     {file = "yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff"},
     {file = "yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71"},
 ]
-markers = {test = "python_version >= \"3.10\""}
+markers = {test = "python_version >= \"3.10\" and platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
 idna = ">=2.0"
@@ -5477,4 +5527,4 @@ deep-research = ["deepagents", "langchain-oracledb", "opensearch-py"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "cff835764b9ff19fa4996629e6639313bda8231ecccf058798a5c1484818549f"
+content-hash = "94e46206a6d40a55c0cfbe0d7708267ac741d885c663a49a8c7a93a079da6d3b"

--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "langchain-core>=1.1.0,<2.0.0; python_version >= '3.10'",
     "langchain>=0.3.20,<1.0.0; python_version < '3.10'",
     "langchain>=1.0.0,<2.0.0; python_version >= '3.10'",
-    "oci>=2.161.0",
+    "oci>=2.173.0",
     "pydantic>=2,<3",
     "aiohttp>=3.12.14",
     "openai>=2.6.1",


### PR DESCRIPTION
## Summary

Closes #165.

`libs/oci/pyproject.toml` declares `oci>=2.161.0`, which lets pip resolve to versions that pre-date `oci.generative_ai_inference.models.DocumentContent`. The provider class references that symbol unconditionally at import time:

```python
# langchain_oci/chat_models/providers/generic.py:148
self.oci_chat_message_document_content = models.DocumentContent
```

So even the simplest example from `samples/01-getting-started` (`ChatOCIGenAI(...).invoke("What is the capital of France?")`) crashes the moment the provider is instantiated:

```
AttributeError: module 'oci.generative_ai_inference.models'
has no attribute 'DocumentContent'
```

`DocumentContent` (and `DocumentUrl` / `VideoContent` / `VideoUrl` / `AudioContent` / `AudioUrl` referenced alongside it on lines 148–157) shipped in **oci-python-sdk 2.165.1** — the same version @TheKoguryo identified as resolving the issue.

This PR bumps the floor straight to the current latest release, `2.173.0`, so:
- the original `AttributeError` is cleared, and
- 12 minor releases of SDK churn that have landed since the previous floor are absorbed in one go.

`poetry.lock` is regenerated to match.

## Direct verification

```python
$ python -c "import oci; print(oci.__version__)"
2.173.0

$ python -c "from oci.generative_ai_inference import models; print(hasattr(models, 'DocumentContent'))"
True
```

## CI coverage (Python matrix)

All 12/12 checks green on this branch:

| Job | 3.9 | 3.12 | 3.13 |
|---|:---:|:---:|:---:|
| `libs/oci` / make lint | ✅ | ✅ | — (lint matrix is min+max only) |
| `libs/oci` / make test | ✅ | ✅ | ✅ |
| `libs/oracledb` / make lint | ✅ | ✅ | — |
| `libs/oracledb` / make test | ✅ | ✅ | ✅ |
| CI Success | — | ✅ | — |
| oca/oracle | — | ✅ | — |

## Local verification (Python 3.12 + `oci==2.173.0`)

### Lint / unit

- `make lint` (ruff + ruff format + `mypy .`) clean
- `make test` — **302 passed, 12 skipped** in 1.5s

### Full integration suite — default skip-gates

```
266 passed, 17 skipped, 3 failed in 411s
```

The 3 failures are pre-existing environmental flakes — they reproduce identically on `main` with `oci==2.161.0`, so **not caused by this bump**:
- `test_vision_real_images.py::test_landmark_identification` — Wikimedia rejects urllib `User-Agent` with HTTP 400 (covered by #208)
- `test_vision_real_images.py::test_animal_identification` — same Wikimedia hotlink rejection (covered by #208)
- `test_chat_features.py::test_reasoning_model_returns_reasoning_content[openai.gpt-oss-120b]` — model no longer returns `reasoning_content` field (covered by #208)

The 17 skips break down as:
- 6 in `test_gemini_provider.py` — gated on `OCI_RUN_GEMINI_INTEGRATION=1`
- 7 in `test_multimodal_integration.py` — gated on `OCI_RUN_MULTIMODAL_INTEGRATION=1`
- 4 in `test_vision.py::test_multiple_images_comparison` — hard-skipped (`"OCI GenAI currently only supports one image per message"`, service limitation)

### Full integration suite — both env-var gates flipped to `1`

```
273 passed, 5 skipped, 8 failed in 488s
```

The 13 previously-gated tests run; 8 of them pass (7 multimodal PDF/video/audio + 1 Gemini), 5 fail. Diagnosis of every failure:

| Failure | Root cause | Caused by this PR? |
|---|---|:---:|
| `test_vision_real_images.py::test_landmark_identification` | Wikimedia hotlink rejection | No (pre-existing, #208) |
| `test_vision_real_images.py::test_animal_identification` | Wikimedia hotlink rejection | No (pre-existing, #208) |
| `test_chat_features.py::test_reasoning_model_returns_reasoning_content[openai.gpt-oss-120b]` | `reasoning_content` provider drift | No (pre-existing, #208) |
| `test_gemini_provider.py::test_gemini_basic_invoke` | Hardcoded `model_id="google.gemini-2.0-flash-001"` decommissioned upstream — service returns `404 NOT_FOUND: Publisher Model 'gemini-2.0-flash-001' was not found` | No (model retired by Google; needs separate test-fixture update) |
| `test_gemini_provider.py::test_gemini_max_output_tokens_mapping` | same | No |
| `test_gemini_provider.py::test_gemini_both_tokens_params` | same | No |
| `test_gemini_provider.py::test_gemini_streaming` | same | No |
| `test_gemini_provider.py::test_gemini_streaming_with_max_output_tokens` | same | No |

The 5 remaining hard-skips are all `test_vision.py::test_multiple_images_comparison` × 4 models plus the Gemini truncation diagnostic — all genuinely service-side limitations.

**Net signal: zero failures attributable to this PR. The bump is safe.**

## Test plan

- [x] `make lint`
- [x] `make test` on Python 3.9, 3.12, 3.13 via CI matrix
- [x] Full integration suite against live OCI GenAI / OpenSearch / ADB on 3.12 (default gates)
- [x] Full integration suite with `OCI_RUN_GEMINI_INTEGRATION=1` and `OCI_RUN_MULTIMODAL_INTEGRATION=1` (273 passing, 0 SDK-attributable failures)
- [x] `DocumentContent` symbol verified present on the new floor
- [ ] Reviewer to merge