### PR TITLE
fix(oracledb): keep vector index in plan with VECTOR_INDEX_TRANSFORM hint (closes #130)

### DIFF
--- a/libs/oracledb/langchain_oracledb/vectorstores/oraclevs.py
+++ b/libs/oracledb/langchain_oracledb/vectorstores/oraclevs.py
@@ -927,8 +927,13 @@ def _get_similarity_search_query(
     if filter:
         where_clause = _generate_where_clause(filter, bind_variables)
 
+    # `VECTOR_INDEX_TRANSFORM` keeps the vector index in the plan even when a
+    # JSON Search Index is also defined on the table. Without the hint, when
+    # both indexes exist the optimizer picks the JSON Search Index for the
+    # `JSON_EXISTS` filter and skips the vector index entirely, which kills
+    # similarity-search latency. See issue #130.
     query = f"""
-    SELECT 
+    SELECT /*+ VECTOR_INDEX_TRANSFORM({table_name}) */
         text,
         metadata,
         vector_distance(embedding, :embedding,

--- a/libs/oracledb/tests/unit_tests/vectorstores/test_similarity_search_query.py
+++ b/libs/oracledb/tests/unit_tests/vectorstores/test_similarity_search_query.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for the SQL emitted by ``_get_similarity_search_query``.
+
+The vector-index hint check (issue #130) keeps the vector index in the plan
+even when a JSON Search Index is also defined on the table — without the
+hint, the optimizer picks the JSON Search Index for the metadata filter and
+skips the vector index entirely, regressing similarity-search latency.
+"""
+
+from __future__ import annotations
+
+from langchain_community.vectorstores.utils import DistanceStrategy
+
+from langchain_oracledb.vectorstores.oraclevs import _get_similarity_search_query
+
+_TABLE = "ORAVS_DOCUMENTS"
+
+
+def test_query_contains_vector_index_transform_hint_unfiltered() -> None:
+    sql, _ = _get_similarity_search_query(
+        table_name=_TABLE,
+        distance_strategy=DistanceStrategy.COSINE,
+        k=8,
+    )
+    assert f"/*+ VECTOR_INDEX_TRANSFORM({_TABLE}) */" in sql
+
+
+def test_query_contains_vector_index_transform_hint_with_filter() -> None:
+    """The filter path is the actual scenario from issue #130 — once the
+    optimizer sees `JSON_EXISTS` and a JSON Search Index, it would otherwise
+    drop the vector index. The hint has to be present here too.
+    """
+    sql, _ = _get_similarity_search_query(
+        table_name=_TABLE,
+        distance_strategy=DistanceStrategy.COSINE,
+        k=8,
+        filter={"category": "research"},
+    )
+    assert f"/*+ VECTOR_INDEX_TRANSFORM({_TABLE}) */" in sql
+    assert "JSON_EXISTS" in sql
+
+
+def test_hint_uses_caller_supplied_table_identifier() -> None:
+    """Whatever identifier flows into ``FROM`` must also flow into the hint
+    so the two reference the same object — including any quoting the caller
+    chose to apply.
+    """
+    quoted = '"My Vector Table"'
+    sql, _ = _get_similarity_search_query(
+        table_name=quoted,
+        distance_strategy=DistanceStrategy.COSINE,
+        k=4,
+    )
+    assert f"/*+ VECTOR_INDEX_TRANSFORM({quoted}) */" in sql
+    assert f"FROM {quoted}" in sql


### PR DESCRIPTION
## Summary

Closes #130.

`_get_similarity_search_query` in `libs/oracledb/langchain_oracledb/vectorstores/oraclevs.py` builds a `SELECT` that filters via `JSON_EXISTS(metadata, ...)` (when a metadata `filter` is passed) and orders by `vector_distance(...)`. As @TheKoguryo described in #130:

- Without a JSON Search Index on the table, the optimizer uses the vector index ✅
- With a JSON Search Index on the table (created via `CREATE SEARCH INDEX`), the optimizer picks the JSON Search Index for the `JSON_EXISTS` predicate and **drops the vector index from the plan entirely** — so the similarity search degrades to a full vector-distance computation across the JSON-filtered subset.

Adding the Oracle hint `/*+ VECTOR_INDEX_TRANSFORM({table_name}) */` after `SELECT` keeps the vector index in the plan when both indexes exist. With no JSON Search Index defined, the hint is a no-op, so the change is backwards-safe.

```diff
+    # `VECTOR_INDEX_TRANSFORM` keeps the vector index in the plan even when a
+    # JSON Search Index is also defined on the table. Without the hint, when
+    # both indexes exist the optimizer picks the JSON Search Index for the
+    # `JSON_EXISTS` filter and skips the vector index entirely, which kills
+    # similarity-search latency. See issue #130.
     query = f"""
-    SELECT
+    SELECT /*+ VECTOR_INDEX_TRANSFORM({table_name}) */
         text,
         metadata,
         ...
```

The hint references the same `{table_name}` identifier that's already interpolated into `FROM`, so callers who pass a quoted identifier get matching quoting in the hint and both refer to the same object.

## Credit

The original one-line fix was proposed by @TheKoguryo in #131; that PR was closed without merging because the OCA wasn't signed. This PR re-lands the same change and adds test coverage so the regression can't slip back in unnoticed.

## Tests

Three new unit tests in `tests/unit_tests/vectorstores/test_similarity_search_query.py`:

| Test | Asserts |
|---|---|
| `test_query_contains_vector_index_transform_hint_unfiltered` | hint present even without a filter |
| `test_query_contains_vector_index_transform_hint_with_filter` | hint present alongside `JSON_EXISTS` — the actual scenario from the bug |
| `test_hint_uses_caller_supplied_table_identifier` | quoted identifier flows through identically into both `FROM` and the hint |

## Verification

- `make lint` — ruff + ruff format + `mypy .` clean
- `make test` — 10 passed (7 pre-existing + 3 new), 1 skipped

## Test plan

- [x] `make lint`
- [x] `make test` on Python 3.12
- [x] CI matrix on 3.9 / 3.12 / 3.13 (will run on push)
- [ ] Reviewer to confirm: against an ADB with both a JSON Search Index and a vector index defined, similarity search with a metadata filter now uses the vector index in the execution plan