### PR TITLE
[Workflow] onboard Macaron GitHub Actions security checks

### DIFF
--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -26,7 +26,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       name: Setup python ${{ inputs.python-version }}
       id: setup-python
       with:
@@ -41,7 +41,7 @@ runs:
       # interpreter even when matrix.python-version is older.
       run: echo "POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON=true" >> "$GITHUB_ENV"
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       id: cache-bin-poetry
       name: Cache Poetry binary - Python ${{ inputs.python-version }}
       env:
@@ -94,7 +94,7 @@ runs:
       run: pipx install "poetry==$POETRY_VERSION" --python "/usr/bin/python3" --verbose
 
     - name: Restore pip and poetry cached dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MIN: "4"
         WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:  # Allows manual triggering from GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/_codespell.yml
+++ b/.github/workflows/_codespell.yml
@@ -19,7 +19,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Dependencies
         run: |
@@ -33,7 +35,7 @@ jobs:
         id: extract_ignore_words
 
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
         with:
           skip: guide_imports.json
           ignore_words_list: ${{ steps.extract_ignore_words.outputs.ignore_words_list }}

--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.2.1"
 

--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -24,7 +24,9 @@ jobs:
           - "3.12"
     name: "poetry run pytest -m compile tests/integration_tests #${{ matrix.python-version }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }} + Poetry ${{ env.POETRY_VERSION }}
         uses: "./.github/actions/poetry_setup"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -32,7 +32,9 @@ jobs:
           - "3.9"
           - "3.12"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Free Disk Space
         run: |

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.2.1"
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -27,7 +27,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python + Poetry ${{ env.POETRY_VERSION }}
         uses: "./.github/actions/poetry_setup"
@@ -79,7 +81,9 @@ jobs:
       version: ${{ steps.check-version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python + Poetry ${{ env.POETRY_VERSION }}
         uses: "./.github/actions/poetry_setup"
@@ -94,7 +98,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Upload build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: ${{ inputs.working-directory }}/dist/
@@ -115,13 +119,13 @@ jobs:
       url: https://test.pypi.org/project/${{ needs.build.outputs.pkg-name }}/
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 
@@ -139,7 +143,9 @@ jobs:
       - test-pypi-publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python + Poetry ${{ env.POETRY_VERSION }}
         uses: "./.github/actions/poetry_setup"
@@ -147,6 +153,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           poetry-version: ${{ env.POETRY_VERSION }}
           working-directory: ${{ inputs.working-directory }}
+          cache-key: release
 
       - name: Import published package
         shell: bash
@@ -203,13 +210,13 @@ jobs:
       url: https://pypi.org/p/${{ needs.build.outputs.pkg-name }}
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -19,6 +19,9 @@ on:
         type: string
         default: 'libs/oci'
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
   POETRY_VERSION: "2.2.1"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.2.1"
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -25,7 +25,9 @@ jobs:
           - "3.13"
     name: "make test #${{ matrix.python-version }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Free Disk Space
         run: |

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "1.7.1"
   PYTHON_VERSION: "3.10"
@@ -68,6 +71,7 @@ jobs:
       - build
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # This permission is used for trusted publishing:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
       #

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -22,7 +22,9 @@ jobs:
       version: ${{ steps.check-version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python + Poetry ${{ env.POETRY_VERSION }}
         uses: "./.github/actions/poetry_setup"
@@ -48,7 +50,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Upload build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-dist
           path: ${{ inputs.working-directory }}/dist/
@@ -74,15 +76,17 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-dist
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Publish to test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: ${{ inputs.working-directory }}/dist/
           verbose: true

--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -1,0 +1,37 @@
+name: Macaron check-github-actions
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "20 15 * * 3"
+
+permissions:
+  contents: read
+
+jobs:
+  macaron-check-github-actions:
+    name: Macaron policy verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Macaron check-github-actions policy
+        uses: oracle/macaron@4ddb55e3c9ef2c77b548be55c557078c4476fd9c # v0.24.0
+        with:
+          repo_path: ./
+          policy_file: check-github-actions
+          policy_purl: "pkg:github.com/${{ github.repository }}@.*"


### PR DESCRIPTION
## Summary
Add Macaron policy verification for GitHub Actions using the `check-github-actions` policy.

## What this change does
- Adds a dedicated workflow for Macaron verification
- Checks workflow definitions and local composite actions
- Uses pinned actions and disables persisted checkout credentials
- Pins existing external GitHub Actions references to full commit SHAs

## Why this is required
This helps detect unsafe or vulnerable GitHub Actions usage and reduces risk from software supply chain attacks targeting CI/CD pipelines.

## Developer impact
The new Macaron workflow runs for changes under `.github/workflows/**` and `.github/actions/**`, supports manual validation with `workflow_dispatch`, and runs weekly on schedule. Existing workflows should retain their current behavior while using pinned action references.

## Validation
- `actionlint`
- Ruby YAML parse for 9 workflow/action YAML files
- `git diff --check`
- Mutable external `uses:` reference scan

## Required follow-up
- Enable `Macaron policy verification` as a required status check for protected branches
- Resolve any policy findings before merge if applicable
- Update the Macaron rollout tracker after the workflow is merged, has run successfully, and the required check is enabled