### PR TITLE
Fix Oracle checkpoint BLOB writes for empty and large bytes

### DIFF
--- a/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/_lob.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/_lob.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import oracledb
+
+
+def with_blob_lobs(
+    conn: oracledb.Connection, params: Sequence[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Replace byte BLOB bind values with temporary LOBs for executemany."""
+    lob_params = []
+    for param in params:
+        blob = param.get("blob")
+        if isinstance(blob, (bytes, bytearray)):
+            lob = conn.createlob(oracledb.DB_TYPE_BLOB)
+            if blob:
+                lob.write(bytes(blob))
+            param = {**param, "blob": lob}
+        lob_params.append(param)
+    return lob_params
+
+
+async def awith_blob_lobs(
+    conn: oracledb.AsyncConnection, params: Sequence[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Replace byte BLOB bind values with temporary LOBs for async executemany."""
+    lob_params = []
+    for param in params:
+        blob = param.get("blob")
+        if isinstance(blob, (bytes, bytearray)):
+            lob = await conn.createlob(oracledb.DB_TYPE_BLOB)
+            if blob:
+                await lob.write(bytes(blob))
+            param = {**param, "blob": lob}
+        lob_params.append(param)
+    return lob_params

--- a/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/aio.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/aio.py
@@ -20,6 +20,7 @@ from langgraph.checkpoint.base import (
 from langgraph.checkpoint.serde.base import SerializerProtocol
 
 from langgraph_oracledb.checkpoint.oracle import _ainternal
+from langgraph_oracledb.checkpoint.oracle._lob import awith_blob_lobs
 from langgraph_oracledb.checkpoint.oracle.base import BaseOracleSaver
 
 from .sync import _validate_conn_string
@@ -385,8 +386,10 @@ class AsyncOracleSaver(BaseOracleSaver):
                     blob_versions,
                 )
 
-                cur.setinputsizes(blob=oracledb.DB_TYPE_BLOB)
-                await cur.executemany(self.UPSERT_CHECKPOINT_BLOBS_SQL, blob_data)
+                await cur.executemany(
+                    self.UPSERT_CHECKPOINT_BLOBS_SQL,
+                    await awith_blob_lobs(cur.connection, blob_data),
+                )
 
             if "channel_versions" not in copy:
                 copy["channel_versions"] = {}
@@ -432,10 +435,10 @@ class AsyncOracleSaver(BaseOracleSaver):
             writes,
         )
         async with self._cursor() as cur:
-            # See sync.put_writes: without this hint oracledb maps b"" -> NULL
-            # and the NOT NULL `blob` column rejects the row with ORA-01400.
-            cur.setinputsizes(blob=oracledb.DB_TYPE_BLOB)
-            await cur.executemany(query, params)
+            await cur.executemany(
+                query,
+                await awith_blob_lobs(cur.connection, params),
+            )
             await cur.connection.commit()
 
     async def adelete_thread(self, thread_id: str) -> None:

--- a/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/base.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/base.py
@@ -308,8 +308,13 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
         if not blob_values:
             return {}
         return {
-            k: self.serde.loads_typed((t, v)) for k, t, v in blob_values if t != "empty"
+            k: self._load_typed_blob(t, v) for k, t, v in blob_values if t != "empty"
         }
+
+    def _load_typed_blob(self, type_: str, blob: bytes | None) -> Any:
+        if blob is None:
+            blob = b""
+        return self.serde.loads_typed((type_, blob))
 
     def _dump_blobs(
         self,
@@ -345,7 +350,7 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
                 (
                     tid,
                     channel,
-                    self.serde.loads_typed((t, v)),
+                    self._load_typed_blob(t, v),
                 )
                 for tid, channel, t, v in writes
             ]

--- a/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/sync.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/sync.py
@@ -21,6 +21,7 @@ from langgraph.checkpoint.base import (
 from langgraph.checkpoint.serde.base import SerializerProtocol
 
 from langgraph_oracledb.checkpoint.oracle import _internal
+from langgraph_oracledb.checkpoint.oracle._lob import with_blob_lobs
 from langgraph_oracledb.checkpoint.oracle.base import BaseOracleSaver
 
 Conn = _internal.Conn  # For backward compatibility
@@ -406,8 +407,10 @@ class OracleSaver(BaseOracleSaver):
                     blob_values,
                     blob_versions,
                 )
-                cur.setinputsizes(blob=oracledb.DB_TYPE_BLOB)
-                cur.executemany(self.UPSERT_CHECKPOINT_BLOBS_SQL, blob_data)
+                cur.executemany(
+                    self.UPSERT_CHECKPOINT_BLOBS_SQL,
+                    with_blob_lobs(cur.connection, blob_data),
+                )
 
             if "channel_versions" not in copy:
                 copy["channel_versions"] = {}
@@ -452,11 +455,7 @@ class OracleSaver(BaseOracleSaver):
             writes,
         )
         with self._cursor() as cur:
-            # Declare `blob` as BLOB so oracledb doesn't silently map b"" to NULL;
-            # the column is NOT NULL and empty writes (interrupts, sentinels) would
-            # otherwise raise ORA-01400. Mirrors what `put()` does for checkpoint_blobs.
-            cur.setinputsizes(blob=oracledb.DB_TYPE_BLOB)
-            cur.executemany(query, params)
+            cur.executemany(query, with_blob_lobs(cur.connection, params))
             cur.connection.commit()
 
     def delete_thread(self, thread_id: str) -> None:

--- a/libs/langgraph-oracledb/pyproject.toml
+++ b/libs/langgraph-oracledb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-oracledb"
-version = "1.0.0"
+version = "1.0.1"
 description = "An integration package connecting Oracle Database and LangGraph"
 readme = "README.md"
 license = "UPL-1.0"

--- a/libs/langgraph-oracledb/tests/test_checkpoint_async.py
+++ b/libs/langgraph-oracledb/tests/test_checkpoint_async.py
@@ -1183,6 +1183,37 @@ async def test_put_writes_basic(saver_name: str) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool"])
+async def test_put_writes_preserves_empty_and_large_bytes(saver_name: str) -> None:
+    async with _async_saver(saver_name) as saver:
+        stored = await saver.aput(
+            generate_config(str(uuid4())),
+            generate_checkpoint(),
+            generate_metadata(),
+            {},
+        )
+        task_id = str(uuid4())
+        large_bytes = b"x" * 32768
+
+        await saver.aput_writes(
+            stored,
+            [("empty_bytes", b""), ("large_bytes", large_bytes)],
+            task_id,
+        )
+
+        loaded = await saver.aget_tuple(stored)
+        assert loaded is not None
+        pending_writes = {
+            channel: value
+            for write_task_id, channel, value in (loaded.pending_writes or [])
+            if write_task_id == task_id
+        }
+        assert pending_writes == {
+            "empty_bytes": b"",
+            "large_bytes": large_bytes,
+        }
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
 async def test_put_writes_multiple_writes_same_task(saver_name: str) -> None:
     async with _async_saver(saver_name) as saver:
         stored = await saver.aput(

--- a/libs/langgraph-oracledb/tests/test_checkpoint_storage_async.py
+++ b/libs/langgraph-oracledb/tests/test_checkpoint_storage_async.py
@@ -144,6 +144,37 @@ async def test_large_json_objects_go_to_blobs(saver_name: str) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool"])
+async def test_checkpoint_blobs_preserve_empty_and_large_bytes(
+    saver_name: str,
+) -> None:
+    async with _async_saver(saver_name) as saver:
+        config = {
+            "configurable": {
+                "thread_id": "thread-byte-blob-test",
+                "checkpoint_ns": "",
+            }
+        }
+        large_bytes = b"x" * 32768
+        checkpoint = empty_checkpoint()
+        checkpoint["channel_values"] = {
+            "empty_bytes": b"",
+            "large_bytes": large_bytes,
+        }
+
+        new_config = await saver.aput(
+            config,
+            checkpoint,
+            {},
+            {"empty_bytes": "v1", "large_bytes": "v2"},
+        )
+
+        result = await saver.aget_tuple(new_config)
+        assert result is not None
+        assert result.checkpoint["channel_values"]["empty_bytes"] == b""
+        assert result.checkpoint["channel_values"]["large_bytes"] == large_bytes
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
 async def test_non_serializable_objects_go_to_blobs(saver_name: str) -> None:
     """Test that non-JSON-serializable objects always go to blobs."""
     serde = JsonPlusSerializer(pickle_fallback=True)

--- a/libs/langgraph-oracledb/tests/test_checkpoint_storage_sync.py
+++ b/libs/langgraph-oracledb/tests/test_checkpoint_storage_sync.py
@@ -142,6 +142,35 @@ def test_large_json_objects_go_to_blobs(saver_name: str) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool"])
+def test_checkpoint_blobs_preserve_empty_and_large_bytes(saver_name: str) -> None:
+    with _sync_saver(saver_name) as saver:
+        config = {
+            "configurable": {
+                "thread_id": "thread-byte-blob-test",
+                "checkpoint_ns": "",
+            }
+        }
+        large_bytes = b"x" * 32768
+        checkpoint = empty_checkpoint()
+        checkpoint["channel_values"] = {
+            "empty_bytes": b"",
+            "large_bytes": large_bytes,
+        }
+
+        new_config = saver.put(
+            config,
+            checkpoint,
+            {},
+            {"empty_bytes": "v1", "large_bytes": "v2"},
+        )
+
+        result = saver.get_tuple(new_config)
+        assert result is not None
+        assert result.checkpoint["channel_values"]["empty_bytes"] == b""
+        assert result.checkpoint["channel_values"]["large_bytes"] == large_bytes
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
 def test_non_serializable_objects_go_to_blobs(saver_name: str) -> None:
     """Test that non-JSON-serializable objects always go to blobs."""
     serde = JsonPlusSerializer(pickle_fallback=True)

--- a/libs/langgraph-oracledb/tests/test_checkpoint_sync.py
+++ b/libs/langgraph-oracledb/tests/test_checkpoint_sync.py
@@ -1098,6 +1098,37 @@ def test_put_writes_basic(saver_name: str) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool"])
+def test_put_writes_preserves_empty_and_large_bytes(saver_name: str) -> None:
+    with _sync_saver(saver_name) as saver:
+        stored = saver.put(
+            generate_config(str(uuid4())),
+            generate_checkpoint(),
+            generate_metadata(),
+            {},
+        )
+        task_id = str(uuid4())
+        large_bytes = b"x" * 32768
+
+        saver.put_writes(
+            stored,
+            [("empty_bytes", b""), ("large_bytes", large_bytes)],
+            task_id,
+        )
+
+        loaded = saver.get_tuple(stored)
+        assert loaded is not None
+        pending_writes = {
+            channel: value
+            for write_task_id, channel, value in (loaded.pending_writes or [])
+            if write_task_id == task_id
+        }
+        assert pending_writes == {
+            "empty_bytes": b"",
+            "large_bytes": large_bytes,
+        }
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
 def test_put_writes_multiple_writes_same_task(saver_name: str) -> None:
     with _sync_saver(saver_name) as saver:
         stored = saver.put(


### PR DESCRIPTION
## Summary

Fix Oracle checkpoint BLOB persistence for empty and large byte payloads.

`oracledb` async `executemany()` can bind raw Python `bytes` incorrectly for BLOB columns in the checkpoint `MERGE`
paths. Empty bytes can round-trip as `NULL`, and larger byte payloads can fail with `ORA-01461`. This affects both
pending writes and checkpoint blob storage.

This change converts byte payloads to temporary BLOB LOBs before `executemany()` and normalizes empty BLOB readback to `b""` before typed deserialization.

## Changes

- Added shared sync/async BLOB bind helpers for checkpoint writes.
- Updated `OracleSaver` and `AsyncOracleSaver` checkpoint BLOB paths to use temporary LOB binds.
- Preserved zero-length BLOB round-trips during checkpoint and pending-write loads.
- Added sync/async regression coverage for empty bytes and 32KB byte payloads.