### PR TITLE
Fix OCI Generic provider structured JSON schema handling

### DIFF
--- a/libs/oci/langchain_oci/chat_models/providers/cohere.py
+++ b/libs/oci/langchain_oci/chat_models/providers/cohere.py
@@ -665,6 +665,9 @@ class CohereProvider(Provider):
                     "Unsupported dict type. Tool must be a BaseTool instance, "
                     "JSON schema dict, or Pydantic model."
                 )
+            schema = OCIUtils.resolve_schema_refs(tool)
+            schema = OCIUtils.resolve_anyof(schema)
+            schema = OCIUtils.sanitize_schema(schema)
             return self.oci_tool(
                 name=tool.get("title"),
                 description=tool.get("description"),
@@ -679,12 +682,15 @@ class CohereProvider(Provider):
                         ),
                         is_required="default" not in p_def,
                     )
-                    for p_name, p_def in tool.get("properties", {}).items()
+                    for p_name, p_def in schema.get("properties", {}).items()
                 },
             )
         elif (isinstance(tool, type) and issubclass(tool, BaseModel)) or callable(tool):
             as_json_schema_function = convert_to_openai_function(tool)
             parameters = as_json_schema_function.get("parameters", {})
+            parameters = OCIUtils.resolve_schema_refs(parameters)
+            parameters = OCIUtils.resolve_anyof(parameters)
+            parameters = OCIUtils.sanitize_schema(parameters)
             properties = parameters.get("properties", {})
             fn_name = as_json_schema_function.get("name", "")
             return self.oci_tool(

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -778,12 +778,11 @@ class GenericProvider(Provider):
         self,
         tool: Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool],
     ) -> Dict[str, Any]:
-        """Convert a BaseTool instance, TypedDict or BaseModel type
-        to a OCI tool in Meta's format.
+        """Convert a tool definition to an OCI tool in Meta's format.
 
         Args:
-            tool: The tool to convert, can be a BaseTool instance, TypedDict,
-                or BaseModel type.
+            tool: The tool to convert, can be a BaseTool instance, JSON schema
+                dictionary, TypedDict, callable, or BaseModel type.
 
         Returns:
             Dict containing the tool definition in Meta's format.
@@ -814,23 +813,48 @@ class GenericProvider(Provider):
                     "required": resolved_params.get("required", []),
                 },
             )
+        if isinstance(tool, dict):
+            name = tool.get("title") or tool.get("name")
+            properties = tool.get("properties")
+            if not isinstance(name, str) or not isinstance(properties, dict):
+                raise ValueError(
+                    "Unsupported dict type. Tool must be a BaseTool instance, "
+                    "JSON schema dict, TypedDict class, or BaseModel type."
+                )
+
+            resolved_params = OCIUtils.resolve_schema_refs(tool)
+            resolved_params = OCIUtils.resolve_anyof(resolved_params)
+            resolved_params = OCIUtils.sanitize_schema(resolved_params)
+
+            return self.oci_function_definition(
+                name=name,
+                description=resolved_params.get("description") or name,
+                parameters={
+                    "type": "object",
+                    "properties": resolved_params.get("properties", {}),
+                    "required": resolved_params.get("required", []),
+                },
+            )
         if (isinstance(tool, type) and issubclass(tool, BaseModel)) or callable(tool):
             as_json_schema_function = convert_to_openai_function(tool)
             parameters = as_json_schema_function.get("parameters", {})
+            resolved_params = OCIUtils.resolve_schema_refs(parameters)
+            resolved_params = OCIUtils.resolve_anyof(resolved_params)
+            resolved_params = OCIUtils.sanitize_schema(resolved_params)
             fn_name = as_json_schema_function.get("name", "")
             return self.oci_function_definition(
                 name=fn_name,
                 description=as_json_schema_function.get("description") or fn_name,
                 parameters={
                     "type": "object",
-                    "properties": parameters.get("properties", {}),
-                    "required": parameters.get("required", []),
+                    "properties": resolved_params.get("properties", {}),
+                    "required": resolved_params.get("required", []),
                 },
             )
         raise ValueError(
             f"Unsupported tool type {type(tool)}. "
             "Tool must be passed in as a BaseTool "
-            "instance, TypedDict class, or BaseModel type."
+            "instance, JSON schema dict, TypedDict class, or BaseModel type."
         )
 
     def process_tool_choice(

--- a/libs/oci/langchain_oci/common/utils.py
+++ b/libs/oci/langchain_oci/common/utils.py
@@ -168,9 +168,14 @@ class OCIUtils:
         if not isinstance(schema, dict):
             return schema
 
+        const_value = schema.get("const")
         sanitized: Dict[str, Any] = {}
         for key, value in schema.items():
             if key == "title":
+                continue
+            if key == "const":
+                continue
+            if isinstance(key, str) and key.startswith("x-"):
                 continue
             if key == "default" and value is None:
                 continue
@@ -185,6 +190,9 @@ class OCIUtils:
                     continue
 
             sanitized[key] = OCIUtils.sanitize_schema(value)
+
+        if isinstance(const_value, str):
+            sanitized["enum"] = [const_value]
 
         if sanitized.get("type") == "array" and "items" not in sanitized:
             sanitized["items"] = {"type": "object"}

--- a/libs/oci/langchain_oci/common/utils.py
+++ b/libs/oci/langchain_oci/common/utils.py
@@ -161,7 +161,23 @@ class OCIUtils:
 
     @staticmethod
     def sanitize_schema(schema: Any) -> Any:
-        """Recursively sanitize a schema for OCI tool compatibility."""
+        """Recursively sanitize a schema for OCI tool compatibility.
+
+        Strips JSON-Schema metadata keys (``title``, ``const``, ``x-*``,
+        ``default: None``) that the OCI tool API doesn't accept, and
+        normalises a couple of OpenAI/Pydantic conventions OCI doesn't
+        understand (``type: any`` → ``object``, ``type: ["string","null"]``
+        → ``"string"``, etc.).
+
+        ``properties`` / ``$defs`` / ``definitions`` need special handling:
+        their dict keys are *user-defined* names (field names, definition
+        names), not JSON-Schema metadata. Without the exemption, a Pydantic
+        model with a field literally called ``title`` (or ``const``, or any
+        ``x-…`` prefix) would have that field silently dropped from the
+        outgoing OCI tool definition — which leaves the LLM unable to fill
+        it and causes a Pydantic ``ValidationError`` once the response is
+        parsed back into the original model.
+        """
         if isinstance(schema, list):
             return [OCIUtils.sanitize_schema(item) for item in schema]
 
@@ -188,6 +204,20 @@ class OCIUtils:
                     non_null_types = [item for item in value if item != "null"]
                     sanitized[key] = non_null_types[0] if non_null_types else "string"
                     continue
+
+            # `properties`, `$defs`, and `definitions` are dicts whose keys
+            # are user-defined names (field names, definition names) — not
+            # JSON-Schema metadata. Recurse into each value as an independent
+            # schema, but DON'T apply the metadata-key skips above to the
+            # user-defined keys themselves.
+            if key in ("properties", "$defs", "definitions") and isinstance(
+                value, dict
+            ):
+                sanitized[key] = {
+                    name: OCIUtils.sanitize_schema(sub_schema)
+                    for name, sub_schema in value.items()
+                }
+                continue
 
             sanitized[key] = OCIUtils.sanitize_schema(value)
 

--- a/libs/oci/tests/unit_tests/chat_models/test_response_format.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_response_format.py
@@ -38,8 +38,8 @@ def test_response_format_via_bind():
     # Should not raise TypeError anymore
     llm_with_format = llm.bind(response_format={"type": "JSON_OBJECT"})
 
-    assert "response_format" in llm_with_format.kwargs
-    assert llm_with_format.kwargs["response_format"] == {"type": "JSON_OBJECT"}
+    assert "response_format" in llm_with_format.kwargs  # type: ignore
+    assert llm_with_format.kwargs["response_format"] == {"type": "JSON_OBJECT"}  # type: ignore
 
 
 @pytest.mark.requires("oci")
@@ -52,11 +52,11 @@ def test_response_format_passed_to_api_generic():
     llm_with_format = llm.bind(response_format={"type": "JSON_OBJECT"})
 
     # Prepare a request
-    request = llm_with_format._prepare_request(
+    request = llm_with_format._prepare_request(  # type: ignore
         [HumanMessage(content="Hello")],
         stop=None,
         stream=False,
-        **llm_with_format.kwargs,
+        **llm_with_format.kwargs,  # type: ignore
     )
 
     # Verify response_format is in the request
@@ -74,11 +74,11 @@ def test_response_format_passed_to_api_cohere():
     llm_with_format = llm.bind(response_format={"type": "JSON_OBJECT"})
 
     # Prepare a request
-    request = llm_with_format._prepare_request(
+    request = llm_with_format._prepare_request(  # type: ignore
         [HumanMessage(content="Hello")],
         stop=None,
         stream=False,
-        **llm_with_format.kwargs,
+        **llm_with_format.kwargs,  # type: ignore
     )
 
     # Verify response_format is in the request
@@ -286,8 +286,8 @@ def test_response_format_json_schema_object():
     llm_with_format = llm.bind(response_format=response_format_obj)
 
     # Verify it's stored in kwargs
-    assert "response_format" in llm_with_format.kwargs
-    assert llm_with_format.kwargs["response_format"] == response_format_obj
+    assert "response_format" in llm_with_format.kwargs  # type: ignore
+    assert llm_with_format.kwargs["response_format"] == response_format_obj  # type: ignore
 
 
 @pytest.mark.requires("oci")

--- a/libs/oci/tests/unit_tests/chat_models/test_response_format.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_response_format.py
@@ -1,5 +1,6 @@
 """Unit tests for response_format feature."""
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -37,8 +38,8 @@ def test_response_format_via_bind():
     # Should not raise TypeError anymore
     llm_with_format = llm.bind(response_format={"type": "JSON_OBJECT"})
 
-    assert "response_format" in llm_with_format.kwargs  # type: ignore
-    assert llm_with_format.kwargs["response_format"] == {"type": "JSON_OBJECT"}  # type: ignore
+    assert "response_format" in llm_with_format.kwargs
+    assert llm_with_format.kwargs["response_format"] == {"type": "JSON_OBJECT"}
 
 
 @pytest.mark.requires("oci")
@@ -51,11 +52,11 @@ def test_response_format_passed_to_api_generic():
     llm_with_format = llm.bind(response_format={"type": "JSON_OBJECT"})
 
     # Prepare a request
-    request = llm_with_format._prepare_request(  # type: ignore
+    request = llm_with_format._prepare_request(
         [HumanMessage(content="Hello")],
         stop=None,
         stream=False,
-        **llm_with_format.kwargs,  # type: ignore
+        **llm_with_format.kwargs,
     )
 
     # Verify response_format is in the request
@@ -73,11 +74,11 @@ def test_response_format_passed_to_api_cohere():
     llm_with_format = llm.bind(response_format={"type": "JSON_OBJECT"})
 
     # Prepare a request
-    request = llm_with_format._prepare_request(  # type: ignore
+    request = llm_with_format._prepare_request(
         [HumanMessage(content="Hello")],
         stop=None,
         stream=False,
-        **llm_with_format.kwargs,  # type: ignore
+        **llm_with_format.kwargs,
     )
 
     # Verify response_format is in the request
@@ -148,7 +149,7 @@ def test_generic_provider_converts_json_schema_dict_tool():
 
     assert getattr(tool, "name") == "ToolSelectionResponse"
     assert getattr(tool, "description") == "Tools selected for a request."
-    assert tool.parameters == {
+    assert cast(Any, tool).parameters == {
         "type": "object",
         "properties": schema["properties"],
         "required": ["selected_tool_names"],
@@ -285,8 +286,8 @@ def test_response_format_json_schema_object():
     llm_with_format = llm.bind(response_format=response_format_obj)
 
     # Verify it's stored in kwargs
-    assert "response_format" in llm_with_format.kwargs  # type: ignore
-    assert llm_with_format.kwargs["response_format"] == response_format_obj  # type: ignore
+    assert "response_format" in llm_with_format.kwargs
+    assert llm_with_format.kwargs["response_format"] == response_format_obj
 
 
 @pytest.mark.requires("oci")

--- a/libs/oci/tests/unit_tests/chat_models/test_response_format.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_response_format.py
@@ -126,6 +126,59 @@ def test_with_structured_output_json_schema():
 
 
 @pytest.mark.requires("oci")
+def test_generic_provider_converts_json_schema_dict_tool():
+    """GenericProvider should accept JSON schema dicts as tool schemas."""
+    from langchain_oci.chat_models.providers.generic import GenericProvider
+
+    provider = GenericProvider()
+    schema = {
+        "title": "ToolSelectionResponse",
+        "description": "Tools selected for a request.",
+        "type": "object",
+        "properties": {
+            "selected_tool_names": {
+                "type": "array",
+                "items": {"type": "string"},
+            }
+        },
+        "required": ["selected_tool_names"],
+    }
+
+    tool = provider.convert_to_oci_tool(schema)
+
+    assert getattr(tool, "name") == "ToolSelectionResponse"
+    assert getattr(tool, "description") == "Tools selected for a request."
+    assert tool.parameters == {
+        "type": "object",
+        "properties": schema["properties"],
+        "required": ["selected_tool_names"],
+    }
+
+
+@pytest.mark.requires("oci")
+def test_generic_structured_output_accepts_json_schema_dict_default_method():
+    """Generic structured output should accept middleware-style JSON schemas."""
+    oci_gen_ai_client = MagicMock()
+    llm = ChatOCIGenAI(model_id="meta.llama-3.3-70b-instruct", client=oci_gen_ai_client)
+    schema = {
+        "title": "ToolSelectionResponse",
+        "description": "Tools selected for a request.",
+        "type": "object",
+        "properties": {
+            "selected_tool_names": {
+                "type": "array",
+                "items": {"type": "string"},
+            }
+        },
+        "required": ["selected_tool_names"],
+    }
+
+    structured_llm = llm.with_structured_output(schema)
+
+    assert structured_llm is not None
+
+
+@pytest.mark.requires("oci")
 def test_with_structured_output_json_schema_nested_refs():
     """Test with_structured_output with json_schema method and nested refs."""
     oci_gen_ai_client = MagicMock()

--- a/libs/oci/tests/unit_tests/chat_models/test_tool_schema_constraints.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_tool_schema_constraints.py
@@ -468,6 +468,92 @@ def test_sanitize_schema_removes_title_and_null_defaults_recursively():
     assert sanitized["properties"]["child"]["properties"]["age"]["type"] == "integer"
 
 
+def test_sanitize_schema_preserves_user_fields_named_title():
+    """A property literally named ``title`` (or other JSON-Schema metadata
+    keys) must survive sanitization. Without this guarantee, a Pydantic
+    model with a ``title: str`` field would be silently stripped of that
+    field before being sent to the OCI tool API — the LLM never sees it,
+    the response comes back without it, and the original Pydantic class
+    raises ``ValidationError`` because ``title`` is still ``required``.
+    Regression for ``test_structured_output_no_docstring[*]`` which
+    parametrizes over 8 models and uses a ``BugReport`` model whose first
+    field is ``title``.
+    """
+    schema = {
+        "type": "object",
+        "title": "BugReport",  # JSON-Schema metadata — should be stripped
+        "properties": {
+            # Field literally named "title" — must survive.
+            "title": {
+                "type": "string",
+                "title": "Bug Title",  # nested metadata — should be stripped
+                "description": "Short bug title",
+            },
+            # Field literally named "const" — must also survive.
+            "const": {
+                "type": "string",
+                "description": "Whether the value is constant",
+            },
+            # Field with an x-prefix name — must also survive.
+            "x-flag": {
+                "type": "boolean",
+                "description": "A custom flag",
+            },
+            "severity": {
+                "type": "string",
+                "description": "low, medium, high, or critical",
+            },
+        },
+        "required": ["title", "const", "x-flag", "severity"],
+    }
+
+    sanitized = OCIUtils.sanitize_schema(schema)
+
+    # User-defined properties survive (they're keys inside `properties`,
+    # not JSON-Schema metadata on the schema itself).
+    assert set(sanitized["properties"].keys()) == {
+        "title",
+        "const",
+        "x-flag",
+        "severity",
+    }
+    assert sanitized["properties"]["title"]["type"] == "string"
+    assert sanitized["properties"]["title"]["description"] == "Short bug title"
+
+    # JSON-Schema metadata `title` inside the property's value still gets
+    # stripped — it's metadata there, not a user-defined key.
+    assert "title" not in sanitized["properties"]["title"]
+
+    # Top-level JSON-Schema metadata `title` is stripped.
+    assert sanitized.get("title") != "BugReport"
+
+    # `required` is preserved for all properties that survived.
+    assert set(sanitized["required"]) == {"title", "const", "x-flag", "severity"}
+
+
+def test_sanitize_schema_preserves_user_defined_definition_names():
+    """Definitions / $defs keyed by user-defined names must survive
+    sanitization — same logic as `properties` keys."""
+    schema = {
+        "type": "object",
+        "$defs": {
+            "title": {"type": "string"},  # user-defined definition name
+            "const": {"type": "string"},  # user-defined definition name
+        },
+        "definitions": {
+            "x-thing": {"type": "object"},  # user-defined definition name
+        },
+        "properties": {
+            "ref_a": {"$ref": "#/$defs/title"},
+        },
+    }
+
+    sanitized = OCIUtils.sanitize_schema(schema)
+
+    assert set(sanitized["$defs"].keys()) == {"title", "const"}
+    assert set(sanitized["definitions"].keys()) == {"x-thing"}
+
+
 def test_sanitize_schema_adds_default_array_items():
     """Arrays without items should get a default object items schema."""
     schema = {

--- a/libs/oci/tests/unit_tests/chat_models/test_tool_schema_constraints.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_tool_schema_constraints.py
@@ -416,9 +416,10 @@ def test_13_multi_optional():
 
 @pytest.mark.requires("oci")
 def test_14_const_extra():
-    """json_schema_extra const must be preserved."""
+    """String const should be lowered to enum for OCI compatibility."""
     p = _props(const_tool)
-    assert p["version"]["const"] == "v1"
+    assert "const" not in p["version"]
+    assert p["version"]["enum"] == ["v1"]
 
 
 def test_sanitize_schema_prunes_missing_required_fields():
@@ -479,6 +480,98 @@ def test_sanitize_schema_adds_default_array_items():
     sanitized = OCIUtils.sanitize_schema(schema)
 
     assert sanitized["properties"]["tags"]["items"] == {"type": "object"}
+
+
+def test_sanitize_schema_removes_extensions_and_const_recursively():
+    """OCI-incompatible x-* keys and non-string const should be stripped."""
+    schema = {
+        "type": "object",
+        "x-visible": True,
+        "properties": {
+            "version": {
+                "type": "string",
+                "const": "v1",
+                "x-in": "header",
+            },
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "const": True,
+                            "x-visible": False,
+                        }
+                    },
+                },
+            },
+        },
+    }
+
+    sanitized = OCIUtils.sanitize_schema(schema)
+
+    assert "x-visible" not in sanitized
+    assert "const" not in sanitized["properties"]["version"]
+    assert sanitized["properties"]["version"]["enum"] == ["v1"]
+    assert "x-in" not in sanitized["properties"]["version"]
+    enabled = sanitized["properties"]["items"]["items"]["properties"]["enabled"]
+    assert "const" not in enabled
+    assert "enum" not in enabled
+    assert "x-visible" not in enabled
+
+
+@pytest.mark.requires("oci")
+def test_generic_json_schema_dict_strips_extensions_and_const():
+    """GenericProvider dict schemas should preserve string const as enum."""
+    provider = GenericProvider()
+    schema = {
+        "title": "Request",
+        "description": "Request schema",
+        "type": "object",
+        "x-visible": True,
+        "properties": {
+            "version": {
+                "type": "string",
+                "const": "v1",
+                "x-in": "header",
+            }
+        },
+        "required": ["version"],
+    }
+
+    result = provider.convert_to_oci_tool(schema)
+    version = result.parameters["properties"]["version"]  # type: ignore[attr-defined]
+
+    assert "const" not in version
+    assert version["enum"] == ["v1"]
+    assert "x-in" not in version
+    assert "x-visible" not in str(result.parameters)  # type: ignore[attr-defined]
+
+
+@pytest.mark.requires("oci")
+def test_cohere_json_schema_dict_strips_extensions_and_const():
+    """CohereProvider dict schemas should preserve string const as enum."""
+    provider = CohereProvider()
+    schema = {
+        "title": "Request",
+        "description": "Request schema",
+        "type": "object",
+        "x-visible": True,
+        "properties": {
+            "version": {
+                "type": "string",
+                "const": "v1",
+                "x-in": "header",
+            }
+        },
+    }
+
+    result = provider.convert_to_oci_tool(schema)
+    version = result.parameter_definitions["version"]  # type: ignore[attr-defined]
+
+    assert "Allowed values: ['v1']" in version.description
+    assert "x-in" not in version.description
 
 
 def test_resolve_schema_refs_handles_circular_refs():


### PR DESCRIPTION
## Summary

Fixes OCI Generic provider handling for LangChain structured-output schemas created as raw JSON Schema dictionaries.

This specifically unblocks LangChain middleware such as [LLMToolSelectorMiddleware](https://reference.langchain.com/python/langchain/agents/middleware/tool_selection/LLMToolSelectorMiddleware), which builds an internal JSON Schema dict and calls `model.with_structured_output(schema)` without passing `method="json_schema"`.

## Changes

- Allow `GenericProvider.convert_to_oci_tool()` to accept JSON Schema dicts, matching the behavior already supported by the Cohere provider path.
- Route Generic dict, Pydantic, callable, and BaseTool schemas through the same schema normalization pipeline:
  - resolve `$ref` / `$defs`
  - resolve `anyOf`
  - sanitize OCI-incompatible schema fields
- Extend Cohere dict and Pydantic/callable conversion paths to use the same sanitizer.
- Update schema sanitization to:
  - remove `x-*` extension keys recursively
  - lower string `const` values to `enum: ["value"]`
  - strip non-string `const` values to avoid OCI enum type errors
- Add regression tests for Generic structured-output dict schemas and sanitizer behavior.
