### PR TITLE
feat(oci): add Chat Completions transport to ChatOCIOpenAI (closes #226)

### DIFF
--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -72,7 +72,14 @@ def _build_headers(
     conversation_store_id: Optional[str] = None,
     **kwargs: Any,
 ) -> Dict[str, str]:
-    """Build headers for OCI OpenAI API requests."""
+    """Build headers for the OCI OpenAI Responses API transport.
+
+    The Responses API path stores conversation state server-side when
+    ``store=True`` (the default), so a conversation-store OCID is required.
+    For the Chat Completions transport (``use_responses_api=False``), use
+    :func:`_build_chat_completions_headers` instead — that path has no
+    server-side state and no conversation store.
+    """
     store = kwargs.get("store", True)
 
     headers = {COMPARTMENT_ID_HEADER: compartment_id}
@@ -85,6 +92,17 @@ def _build_headers(
         headers[CONVERSATION_STORE_ID_HEADER] = conversation_store_id
 
     return headers
+
+
+def _build_chat_completions_headers(compartment_id: str) -> Dict[str, str]:
+    """Build headers for the OCI OpenAI Chat Completions transport.
+
+    Chat Completions (``/openai/v1/chat/completions``) is stateless on OCI's
+    side, so only the compartment header is required. Conversation-store
+    and ``output_version`` are Responses-API-only concepts and must not be
+    sent on this path.
+    """
+    return {COMPARTMENT_ID_HEADER: compartment_id}
 
 
 class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
@@ -706,6 +724,50 @@ class ChatOCIOpenAI(ChatOpenAI):
                 "What transport protocols does the 2025-03-26 version of the MCP "
                 "spec (modelcontextprotocol/modelcontextprotocol) support?"
             )
+
+    Chat Completions transport (``use_responses_api=False``):
+        Opt in to OCI's OpenAI Chat Completions passthrough at
+        ``/openai/v1/chat/completions`` for stateless calls and for OpenAI
+        features that are only exposed on Chat Completions (not the
+        Responses API). The most common motivator today is
+        ``input_audio`` against audio-capable models such as
+        ``openai.gpt-audio``, which neither the OCI-native chat endpoint
+        nor the OpenAI Responses passthrough accept. The same flag covers
+        any other Chat-Completions-only OpenAI feature surfaced through
+        ``langchain-openai``. ``conversation_store_id`` is not used on
+        this path.
+
+        Worked example (audio input):
+
+        .. code-block:: python
+
+            from langchain_core.messages import HumanMessage
+            from langchain_oci import ChatOCIOpenAI
+            from oci_openai import OciUserPrincipalAuth
+
+            client = ChatOCIOpenAI(
+                auth=OciUserPrincipalAuth(profile_name="DEFAULT"),
+                compartment_id=COMPARTMENT_ID,
+                region="us-chicago-1",
+                model="openai.gpt-audio",
+                use_responses_api=False,
+            )
+            response = client.invoke(
+                [
+                    HumanMessage(
+                        content=[
+                            {"type": "text", "text": "What do you hear?"},
+                            {
+                                "type": "input_audio",
+                                "input_audio": {
+                                    "data": "<base64-wav>",
+                                    "format": "wav",
+                                },
+                            },
+                        ]
+                    )
+                ]
+            )
     """
 
     @model_validator(mode="before")
@@ -728,8 +790,29 @@ class ChatOCIOpenAI(ChatOpenAI):
         region: Optional[str] = None,
         service_endpoint: Optional[str] = None,
         base_url: Optional[str] = None,
+        use_responses_api: bool = True,
         **kwargs: Any,
     ):
+        """Initialize the OCI OpenAI client.
+
+        Args:
+            use_responses_api: Selects the OCI OpenAI transport. ``True``
+                (default) targets the Responses passthrough at
+                ``/openai/v1/responses`` and preserves existing behavior —
+                this is the path for Responses-API features such as
+                conversation store, hosted MCP, and web search. ``False``
+                targets the Chat Completions passthrough at
+                ``/openai/v1/chat/completions``, which is the right
+                transport for stateless calls and for OpenAI features
+                exposed only on Chat Completions. The motivating example
+                is ``input_audio`` against audio-capable models such as
+                ``openai.gpt-audio`` — see the class docstring — but the
+                same opt-in covers any other Chat-Completions-only OpenAI
+                feature surfaced through ``langchain-openai``.
+                ``conversation_store_id`` and ``store`` are ignored when
+                ``use_responses_api=False`` because they're
+                Responses-API-only concepts.
+        """
         try:
             from oci_openai.oci_openai import _resolve_base_url
         except ImportError as e:
@@ -740,11 +823,21 @@ class ChatOCIOpenAI(ChatOpenAI):
 
         http_client = kwargs.pop("http_client", None)
         http_async_client = kwargs.pop("http_async_client", None)
-        default_headers = _build_headers(
-            compartment_id=compartment_id,
-            conversation_store_id=conversation_store_id,
-            **kwargs,
-        )
+        if use_responses_api:
+            default_headers = _build_headers(
+                compartment_id=compartment_id,
+                conversation_store_id=conversation_store_id,
+                **kwargs,
+            )
+            extra_super_kwargs: Dict[str, Any] = {"output_version": OUTPUT_VERSION}
+        else:
+            # Chat Completions transport is stateless on OCI's side, so we
+            # drop the Responses-API-only knobs: `output_version`,
+            # `conversation_store_id`, and the `store` kwarg (the
+            # /chat/completions endpoint rejects it).
+            default_headers = _build_chat_completions_headers(compartment_id)
+            kwargs.pop("store", None)
+            extra_super_kwargs = {}
 
         super().__init__(
             model=model,
@@ -762,7 +855,7 @@ class ChatOCIOpenAI(ChatOpenAI):
             base_url=_resolve_base_url(
                 region=region, service_endpoint=service_endpoint, base_url=base_url
             ),
-            use_responses_api=True,
-            output_version=OUTPUT_VERSION,
+            use_responses_api=use_responses_api,
+            **extra_super_kwargs,
             **kwargs,
         )

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -77,7 +77,14 @@ def _build_headers(
     conversation_store_id: Optional[str] = None,
     **kwargs: Any,
 ) -> Dict[str, str]:
-    """Build headers for OCI OpenAI API requests."""
+    """Build headers for the OCI OpenAI Responses API transport.
+
+    The Responses API path stores conversation state server-side when
+    ``store=True`` (the default), so a conversation-store OCID is required.
+    For the Chat Completions transport (``use_responses_api=False``), use
+    :func:`_build_chat_completions_headers` instead — that path has no
+    server-side state and no conversation store.
+    """
     store = kwargs.get("store", True)
 
     headers = {COMPARTMENT_ID_HEADER: compartment_id}
@@ -90,6 +97,17 @@ def _build_headers(
         headers[CONVERSATION_STORE_ID_HEADER] = conversation_store_id
 
     return headers
+
+
+def _build_chat_completions_headers(compartment_id: str) -> Dict[str, str]:
+    """Build headers for the OCI OpenAI Chat Completions transport.
+
+    Chat Completions (``/openai/v1/chat/completions``) is stateless on OCI's
+    side, so only the compartment header is required. Conversation-store
+    and ``output_version`` are Responses-API-only concepts and must not be
+    sent on this path.
+    """
+    return {COMPARTMENT_ID_HEADER: compartment_id}
 
 
 class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
@@ -741,6 +759,50 @@ class ChatOCIOpenAI(ChatOpenAI):
                 "What transport protocols does the 2025-03-26 version of the MCP "
                 "spec (modelcontextprotocol/modelcontextprotocol) support?"
             )
+
+    Chat Completions transport (``use_responses_api=False``):
+        Opt in to OCI's OpenAI Chat Completions passthrough at
+        ``/openai/v1/chat/completions`` for stateless calls and for OpenAI
+        features that are only exposed on Chat Completions (not the
+        Responses API). The most common motivator today is
+        ``input_audio`` against audio-capable models such as
+        ``openai.gpt-audio``, which neither the OCI-native chat endpoint
+        nor the OpenAI Responses passthrough accept. The same flag covers
+        any other Chat-Completions-only OpenAI feature surfaced through
+        ``langchain-openai``. ``conversation_store_id`` is not used on
+        this path.
+
+        Worked example (audio input):
+
+        .. code-block:: python
+
+            from langchain_core.messages import HumanMessage
+            from langchain_oci import ChatOCIOpenAI
+            from oci_openai import OciUserPrincipalAuth
+
+            client = ChatOCIOpenAI(
+                auth=OciUserPrincipalAuth(profile_name="DEFAULT"),
+                compartment_id=COMPARTMENT_ID,
+                region="us-chicago-1",
+                model="openai.gpt-audio",
+                use_responses_api=False,
+            )
+            response = client.invoke(
+                [
+                    HumanMessage(
+                        content=[
+                            {"type": "text", "text": "What do you hear?"},
+                            {
+                                "type": "input_audio",
+                                "input_audio": {
+                                    "data": "<base64-wav>",
+                                    "format": "wav",
+                                },
+                            },
+                        ]
+                    )
+                ]
+            )
     """
 
     @model_validator(mode="before")
@@ -763,8 +825,29 @@ class ChatOCIOpenAI(ChatOpenAI):
         region: Optional[str] = None,
         service_endpoint: Optional[str] = None,
         base_url: Optional[str] = None,
+        use_responses_api: bool = True,
         **kwargs: Any,
     ):
+        """Initialize the OCI OpenAI client.
+
+        Args:
+            use_responses_api: Selects the OCI OpenAI transport. ``True``
+                (default) targets the Responses passthrough at
+                ``/openai/v1/responses`` and preserves existing behavior —
+                this is the path for Responses-API features such as
+                conversation store, hosted MCP, and web search. ``False``
+                targets the Chat Completions passthrough at
+                ``/openai/v1/chat/completions``, which is the right
+                transport for stateless calls and for OpenAI features
+                exposed only on Chat Completions. The motivating example
+                is ``input_audio`` against audio-capable models such as
+                ``openai.gpt-audio`` — see the class docstring — but the
+                same opt-in covers any other Chat-Completions-only OpenAI
+                feature surfaced through ``langchain-openai``.
+                ``conversation_store_id`` and ``store`` are ignored when
+                ``use_responses_api=False`` because they're
+                Responses-API-only concepts.
+        """
         try:
             from oci_openai.oci_openai import _resolve_base_url
         except ImportError as e:
@@ -775,11 +858,21 @@ class ChatOCIOpenAI(ChatOpenAI):
 
         http_client = kwargs.pop("http_client", None)
         http_async_client = kwargs.pop("http_async_client", None)
-        default_headers = _build_headers(
-            compartment_id=compartment_id,
-            conversation_store_id=conversation_store_id,
-            **kwargs,
-        )
+        if use_responses_api:
+            default_headers = _build_headers(
+                compartment_id=compartment_id,
+                conversation_store_id=conversation_store_id,
+                **kwargs,
+            )
+            extra_super_kwargs: Dict[str, Any] = {"output_version": OUTPUT_VERSION}
+        else:
+            # Chat Completions transport is stateless on OCI's side, so we
+            # drop the Responses-API-only knobs: `output_version`,
+            # `conversation_store_id`, and the `store` kwarg (the
+            # /chat/completions endpoint rejects it).
+            default_headers = _build_chat_completions_headers(compartment_id)
+            kwargs.pop("store", None)
+            extra_super_kwargs = {}
 
         super().__init__(
             model=model,
@@ -797,7 +890,7 @@ class ChatOCIOpenAI(ChatOpenAI):
             base_url=_resolve_base_url(
                 region=region, service_endpoint=service_endpoint, base_url=base_url
             ),
-            use_responses_api=True,
-            output_version=OUTPUT_VERSION,
+            use_responses_api=use_responses_api,
+            **extra_super_kwargs,
             **kwargs,
         )

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -968,6 +968,18 @@ class OpenAIProvider(GenericProvider):
     - max_tokens → max_completion_tokens (OpenAI rejects max_tokens on GPT-5
       family and reasoning models; max_completion_tokens is the forward-compatible
       name).
+
+    Transport note:
+      This provider routes through OCI's native chat endpoint
+      (``/20231130/actions/chat``), whose schema for OpenAI-family models
+      only accepts ``text`` and ``image_url`` content blocks. For any
+      OpenAI feature not exposed on that schema — most notably
+      ``input_audio`` against audio-capable models such as
+      ``openai.gpt-audio``, but also any other Chat-Completions-only
+      OpenAI feature surfaced through ``langchain-openai`` — use
+      :class:`langchain_oci.ChatOCIOpenAI` with
+      ``use_responses_api=False``, which targets OCI's OpenAI Chat
+      Completions passthrough at ``/openai/v1/chat/completions``.
     """
 
     def normalize_params(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -1009,6 +1009,18 @@ class OpenAIProvider(GenericProvider):
     - max_tokens → max_completion_tokens (OpenAI rejects max_tokens on GPT-5
       family and reasoning models; max_completion_tokens is the forward-compatible
       name).
+
+    Transport note:
+      This provider routes through OCI's native chat endpoint
+      (``/20231130/actions/chat``), whose schema for OpenAI-family models
+      only accepts ``text`` and ``image_url`` content blocks. For any
+      OpenAI feature not exposed on that schema — most notably
+      ``input_audio`` against audio-capable models such as
+      ``openai.gpt-audio``, but also any other Chat-Completions-only
+      OpenAI feature surfaced through ``langchain-openai`` — use
+      :class:`langchain_oci.ChatOCIOpenAI` with
+      ``use_responses_api=False``, which targets OCI's OpenAI Chat
+      Completions passthrough at ``/openai/v1/chat/completions``.
     """
 
     def normalize_params(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/oci/tests/integration_tests/chat_models/test_oci_openai_chat_completions_api.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_oci_openai_chat_completions_api.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Integration tests for the ChatOCIOpenAI Chat Completions transport.
+
+Exercises the additive ``use_responses_api=False`` opt-in against OCI's
+``/openai/v1/chat/completions`` passthrough. The opt-in unlocks any OpenAI
+feature exposed only on Chat Completions — the motivating case is
+``input_audio`` against audio-capable models such as ``openai.gpt-audio``,
+covered by the audio test below.
+
+These tests run a real wire call and skip cleanly without OCI credentials.
+
+Prerequisites:
+    export OCI_COMPARTMENT_ID=<your-compartment-id>
+    export OCI_REGION=<region>  # optional, defaults to us-chicago-1
+    export OCI_CONFIG_PROFILE=<profile>  # optional, defaults to DEFAULT
+    export OCI_AUTH_TYPE=<API_KEY|SECURITY_TOKEN>  # optional, defaults to
+                                                   # SECURITY_TOKEN
+    # Text-only model for the smoke + stream + tools tests; any
+    # OpenAI-route model on OCI works (gpt-5, gpt-4o, gpt-oss-*, ...).
+    export OCI_OPENAI_CHAT_MODEL_ID=<model-id>  # defaults to openai.gpt-oss-20b
+    # Audio-capable model for the input_audio test; must accept
+    # `input_audio` content blocks.
+    export OCI_OPENAI_AUDIO_MODEL_ID=<model-id>  # defaults to openai.gpt-audio
+
+Run::
+
+    pytest \\
+      tests/integration_tests/chat_models/test_oci_openai_chat_completions_api.py \\
+      -v
+"""  # noqa: E501
+
+import base64
+import io
+import math
+import os
+import struct
+import wave
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from oci_openai import OciSessionAuth, OciUserPrincipalAuth
+from pydantic import BaseModel, Field
+
+from langchain_oci import ChatOCIOpenAI
+
+
+@pytest.fixture
+def oci_openai_config():
+    """Load config for the Chat Completions transport integration tests."""
+    compartment_id = os.environ.get("OCI_COMPARTMENT_ID")
+    if not compartment_id:
+        pytest.skip("OCI_COMPARTMENT_ID not set")
+
+    auth_type = os.environ.get("OCI_AUTH_TYPE", "SECURITY_TOKEN").upper()
+    auth_profile = os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT")
+    region = os.environ.get("OCI_REGION", "us-chicago-1")
+    chat_model_id = os.environ.get("OCI_OPENAI_CHAT_MODEL_ID", "openai.gpt-oss-20b")
+    audio_model_id = os.environ.get("OCI_OPENAI_AUDIO_MODEL_ID", "openai.gpt-audio")
+
+    if auth_type == "API_KEY":
+        auth = OciUserPrincipalAuth(profile_name=auth_profile)
+    elif auth_type == "SECURITY_TOKEN":
+        auth = OciSessionAuth(profile_name=auth_profile)
+    else:
+        pytest.skip(f"Unsupported OCI_AUTH_TYPE for ChatOCIOpenAI test: {auth_type}")
+
+    return {
+        "auth": auth,
+        "compartment_id": compartment_id,
+        "region": region,
+        "chat_model_id": chat_model_id,
+        "audio_model_id": audio_model_id,
+    }
+
+
+def _create_client(config: dict, *, model_key: str = "chat_model_id") -> ChatOCIOpenAI:
+    """Construct a ChatOCIOpenAI on the Chat Completions transport."""
+    return ChatOCIOpenAI(
+        auth=config["auth"],
+        compartment_id=config["compartment_id"],
+        region=config["region"],
+        model=config[model_key],
+        use_responses_api=False,
+    )
+
+
+def _make_wav_bytes(
+    seconds: float = 0.6, freq: float = 440.0, rate: int = 16000
+) -> bytes:
+    """In-memory mono 16-bit PCM WAV — a short sine tone the model can describe."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        n = int(seconds * rate)
+        frames = bytearray()
+        for i in range(n):
+            sample = int(0.3 * 32767 * math.sin(2 * math.pi * freq * i / rate))
+            frames += struct.pack("<h", sample)
+        w.writeframes(bytes(frames))
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Transport sanity — confirm /openai/v1/chat/completions is reachable end-to-end
+# under the same auth modes that the Responses-API test covers.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires("oci", "oci_openai", "langchain_openai")
+def test_chat_completions_sync_invoke(oci_openai_config: dict):
+    """Sync invoke against the Chat Completions transport with OCI auth."""
+    client = _create_client(oci_openai_config)
+    response = client.invoke([("human", "Reply with exactly: sync-ok")])
+
+    assert isinstance(response, AIMessage)
+    assert response.content is not None
+    assert len(str(response.content)) > 0
+
+
+@pytest.mark.requires("oci", "oci_openai", "langchain_openai")
+@pytest.mark.asyncio
+async def test_chat_completions_async_invoke(oci_openai_config: dict):
+    """Async invoke should reuse the per-client async http_client and signer."""
+    client = _create_client(oci_openai_config)
+    response = await client.ainvoke([("human", "Reply with exactly: async-ok")])
+
+    assert isinstance(response, AIMessage)
+    assert response.content is not None
+    assert len(str(response.content)) > 0
+
+
+@pytest.mark.requires("oci", "oci_openai", "langchain_openai")
+def test_chat_completions_stream(oci_openai_config: dict):
+    """Streaming on the Chat Completions transport must yield content chunks
+    — proves real SSE pass-through (no Responses-API output_version)."""
+    client = _create_client(oci_openai_config)
+    chunks = list(client.stream([("human", "Count from 1 to 3.")]))
+
+    assert len(chunks) > 0
+    joined = "".join(str(c.content) for c in chunks if c.content)
+    assert len(joined) > 0
+
+
+# ---------------------------------------------------------------------------
+# Tool calling — confirms the OpenAI Chat Completions tool schema is forwarded
+# correctly under the OCI signing layer.
+# ---------------------------------------------------------------------------
+
+
+class _GetWeather(BaseModel):
+    """Get the current weather in a given city."""
+
+    location: str = Field(..., description="The city, e.g. San Francisco")
+
+
+@pytest.mark.requires("oci", "oci_openai", "langchain_openai")
+def test_chat_completions_tool_call(oci_openai_config: dict):
+    """A bound function-tool should be invoked, returning a tool_calls entry."""
+    client = _create_client(oci_openai_config)
+    llm_with_tools = client.bind_tools([_GetWeather])
+    response = llm_with_tools.invoke(
+        "What's the weather like in San Francisco? Use the tool."
+    )
+
+    assert isinstance(response, AIMessage)
+    # The model should produce at least one tool call; assert defensively
+    # since some models may answer directly instead.
+    if response.tool_calls:
+        assert response.tool_calls[0]["name"] == "_GetWeather"
+        assert "location" in response.tool_calls[0]["args"]
+
+
+# ---------------------------------------------------------------------------
+# Audio input — the motivating case. Requires an audio-capable model and is
+# why the Chat Completions transport had to be added in the first place
+# (Responses API + OCI-native chat reject `input_audio` for OpenAI models).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires("oci", "oci_openai", "langchain_openai")
+def test_chat_completions_input_audio(oci_openai_config: dict):
+    """An ``input_audio`` content block should be accepted by the Chat
+    Completions transport against an audio-capable model. This call would
+    fail on the Responses transport and on OCI's native chat endpoint —
+    the assertion proves the new transport unlocks audio input."""
+    audio_b64 = base64.b64encode(_make_wav_bytes()).decode("ascii")
+    client = _create_client(oci_openai_config, model_key="audio_model_id")
+    response = client.invoke(
+        [
+            HumanMessage(
+                content=[
+                    {"type": "text", "text": "What do you hear? Be brief."},
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": audio_b64, "format": "wav"},
+                    },
+                ]
+            )
+        ]
+    )
+
+    assert isinstance(response, AIMessage)
+    assert response.content is not None
+    assert len(str(response.content)) > 0
+
+
+# NB: live-wire coverage for the default (Responses API) transport lives in
+# tests/integration_tests/chat_models/test_oci_openai_responses_api.py.
+# Backwards-compatibility on the configuration surface is locked in by the
+# unit tests in
+# tests/unit_tests/chat_models/test_oci_openai_chat_completions_transport.py
+# (default_path_* tests).

--- a/libs/oci/tests/unit_tests/chat_models/test_oci_openai_chat_completions_transport.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_oci_openai_chat_completions_transport.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for the ChatOCIOpenAI Chat Completions transport.
+
+Covers the additive ``use_responses_api=False`` opt-in on
+:class:`ChatOCIOpenAI`, which targets OCI's
+``/openai/v1/chat/completions`` passthrough. The opt-in unlocks any OpenAI
+feature exposed only on Chat Completions — the motivating case is
+``input_audio`` against audio-capable models such as ``openai.gpt-audio``,
+but the same path applies to other Chat-Completions-only features. The
+existing default (``True``) keeps using the Responses passthrough.
+
+The tests prove two invariants — important because the change must be
+strictly additive:
+
+1. **Default (Responses) path is byte-equivalent** to the prior release —
+   same headers (compartment + conversation-store), same
+   ``use_responses_api=True``, same ``output_version="responses/v1"``.
+2. **Chat Completions path is correctly stateless** — only the compartment
+   header is sent; the Responses-only knobs (``conversation_store_id``
+   header, ``output_version``) are absent.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_oci import ChatOCIOpenAI
+from langchain_oci.chat_models.oci_generative_ai import (
+    COMPARTMENT_ID_HEADER,
+    CONVERSATION_STORE_ID_HEADER,
+    OUTPUT_VERSION,
+)
+
+COMPARTMENT_ID = "ocid1.compartment.oc1..dummy"
+CONVERSATION_STORE_ID = "ocid1.generativeaiconversationstore.oc1..dummy"
+REGION = "us-chicago-1"
+AUDIO_MODEL = "openai.gpt-audio"
+TEXT_MODEL = "openai.gpt-5"
+
+
+@pytest.fixture
+def fake_auth():
+    """Lightweight stand-in for an OciUserPrincipalAuth / SessionAuth instance."""
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatibility: default path must be byte-equivalent to pre-change.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires("langchain_openai")
+def test_default_path_uses_responses_api(fake_auth):
+    """No flag passed → Responses API (preserves prior behavior)."""
+    client = ChatOCIOpenAI(
+        auth=fake_auth,
+        compartment_id=COMPARTMENT_ID,
+        conversation_store_id=CONVERSATION_STORE_ID,
+        region=REGION,
+        model=TEXT_MODEL,
+    )
+    assert client.use_responses_api is True
+
+
+@pytest.mark.requires("langchain_openai")
+def test_default_path_sends_responses_output_version(fake_auth):
+    """The Responses API requires output_version='responses/v1'; the default
+    path must continue to set it."""
+    client = ChatOCIOpenAI(
+        auth=fake_auth,
+        compartment_id=COMPARTMENT_ID,
+        conversation_store_id=CONVERSATION_STORE_ID,
+        region=REGION,
+        model=TEXT_MODEL,
+    )
+    assert getattr(client, "output_version", None) == OUTPUT_VERSION
+
+
+@pytest.mark.requires("langchain_openai")
+def test_default_path_sends_compartment_and_conversation_store_headers(fake_auth):
+    """The Responses path's two-header invariant (compartment +
+    conversation-store) is the prior wire contract — locked in by this test
+    so future refactors can't regress it."""
+    client = ChatOCIOpenAI(
+        auth=fake_auth,
+        compartment_id=COMPARTMENT_ID,
+        conversation_store_id=CONVERSATION_STORE_ID,
+        region=REGION,
+        model=TEXT_MODEL,
+    )
+    assert client.http_client is not None
+    assert client.http_client.headers.get(COMPARTMENT_ID_HEADER) == COMPARTMENT_ID
+    assert (
+        client.http_client.headers.get(CONVERSATION_STORE_ID_HEADER)
+        == CONVERSATION_STORE_ID
+    )
+
+
+@pytest.mark.requires("langchain_openai")
+def test_default_path_still_requires_conversation_store_id_when_store_true(fake_auth):
+    """Pre-existing validation must remain — store=True without a
+    conversation-store OCID is still an error."""
+    with pytest.raises(ValueError, match="Conversation Store Id"):
+        ChatOCIOpenAI(
+            auth=fake_auth,
+            compartment_id=COMPARTMENT_ID,
+            region=REGION,
+            model=TEXT_MODEL,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Chat Completions opt-in (use_responses_api=False).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires("langchain_openai")
+def test_chat_completions_path_sets_use_responses_api_false(fake_auth):
+    client = ChatOCIOpenAI(
+        auth=fake_auth,
+        compartment_id=COMPARTMENT_ID,
+        region=REGION,
+        model=AUDIO_MODEL,
+        use_responses_api=False,
+    )
+    assert client.use_responses_api is False
+
+
+@pytest.mark.requires("langchain_openai")
+def test_chat_completions_path_omits_responses_output_version(fake_auth):
+    """``output_version='responses/v1'`` is a Responses-API-only knob; the
+    Chat Completions path must not send it."""
+    client = ChatOCIOpenAI(
+        auth=fake_auth,
+        compartment_id=COMPARTMENT_ID,
+        region=REGION,
+        model=AUDIO_MODEL,
+        use_responses_api=False,
+    )
+    assert getattr(client, "output_version", None) != OUTPUT_VERSION
+
+
+@pytest.mark.requires("langchain_openai")
+def test_chat_completions_path_sends_only_compartment_header(fake_auth):
+    """Chat Completions is stateless on OCI's side, so only the compartment
+    header is needed — the conversation-store header would be meaningless."""
+    client = ChatOCIOpenAI(
+        auth=fake_auth,
+        compartment_id=COMPARTMENT_ID,
+        region=REGION,
+        model=AUDIO_MODEL,
+        use_responses_api=False,
+    )
+    assert client.http_client is not None
+    assert client.http_client.headers.get(COMPARTMENT_ID_HEADER) == COMPARTMENT_ID
+    assert CONVERSATION_STORE_ID_HEADER not in client.http_client.headers
+
+
+@pytest.mark.requires("langchain_openai")
+def test_chat_completions_path_does_not_require_conversation_store_id(fake_auth):
+    """Inverse of the default-path validation: the Chat Completions opt-in
+    must construct cleanly without a conversation-store OCID."""
+    ChatOCIOpenAI(
+        auth=fake_auth,
+        compartment_id=COMPARTMENT_ID,
+        region=REGION,
+        model=AUDIO_MODEL,
+        use_responses_api=False,
+    )
+
+
+@pytest.mark.requires("langchain_openai")
+def test_chat_completions_path_targets_openai_v1_base_url(fake_auth):
+    """Both transports share the same ``/openai/v1`` base — ChatOpenAI then
+    appends ``/responses`` or ``/chat/completions`` based on
+    ``use_responses_api``. Locking the base URL down here so a future
+    ``_resolve_base_url`` change doesn't silently break either transport."""
+    client = ChatOCIOpenAI(
+        auth=fake_auth,
+        compartment_id=COMPARTMENT_ID,
+        region=REGION,
+        model=AUDIO_MODEL,
+        use_responses_api=False,
+    )
+    base = str(client.openai_api_base)
+    assert base.rstrip("/").endswith("/openai/v1")


### PR DESCRIPTION
## Summary

Closes #226.

OCI exposes OpenAI-family models over three transports. Today, langchain-oci can only reach two of them, and neither accepts `input_audio` content blocks against audio-capable models like `openai.gpt-audio`. This PR adds the missing third transport — the OpenAI Chat Completions passthrough at `/openai/v1/chat/completions` — to the existing `ChatOCIOpenAI` class via a `use_responses_api: bool = True` opt-in. Default behavior is unchanged.

### Transport matrix

| Path | Used by | Accepts `input_audio`? |
|---|---|---|
| `/20231130/actions/chat` (OCI-native) | `ChatOCIGenAI` + `OpenAIProvider` | ❌ 400 (schema rejects anything beyond `text` / `image_url` for OpenAI route) |
| `/openai/v1/responses` (Responses passthrough) | `ChatOCIOpenAI` (default — unchanged) | ❌ wrong API surface for `gpt-audio`-class models |
| `/openai/v1/chat/completions` (Chat Completions passthrough) | `ChatOCIOpenAI(use_responses_api=False)` — **new** | ✅ verified end-to-end against `openai.gpt-audio` |

## Why

Reported by an internal agentic-AI user trying to send WAV input to `openai.gpt-audio` through langchain-oci. The OCI 400 is correct — that endpoint genuinely cannot carry audio for OpenAI models — but the langchain-oci client offered no path to the transport that can. This PR closes that gap with the smallest possible change.

## What's in the change

- **`langchain_oci/chat_models/oci_generative_ai.py`**: `ChatOCIOpenAI.__init__` gains `use_responses_api: bool = True`. When `False`, the constructor routes the underlying `ChatOpenAI` at `/openai/v1/chat/completions` and drops the Responses-API-only knobs (`conversation_store_id` header, `output_version=\"responses/v1\"`, the `store` kwarg). Header construction is moved into a new sibling helper `_build_chat_completions_headers(compartment_id)` next to the existing `_build_headers`, so neither branch inlines header logic in `__init__`.
- **`langchain_oci/chat_models/providers/generic.py`**: `OpenAIProvider` docstring updated to route users with audio/PDF/video needs at `ChatOCIOpenAI(use_responses_api=False)`. No runtime behavior change on the OCI-native path.

## Backwards compatibility

**Strictly additive.** No removed args, no renamed args, no changed defaults, no behavior change on any pre-existing code path. Locked in by 4 dedicated `default_path_*` unit tests that assert the Responses-API path remains byte-equivalent (same compartment + conversation-store headers, `use_responses_api=True`, `output_version=\"responses/v1\"`, conversation-store-id validation under `store=True`).

## Tests

- **9 unit tests** (`tests/unit_tests/chat_models/test_oci_openai_chat_completions_transport.py`): default-path invariants + new-path invariants (no `output_version`, only compartment header, no conversation-store-id required, `/openai/v1` base URL).
- **5 integration tests** (`tests/integration_tests/chat_models/test_oci_openai_chat_completions_api.py`): sync invoke, async invoke, streaming, tool calling, and `input_audio` — all live against OCI's `/openai/v1/chat/completions`. Env-gated; skip cleanly without OCI credentials.

## Verification

- `make lint` clean. ruff `check` + `format` clean on `--target-version py311`, `py312`, `py313`, `py314` for the four files touched.
- Full unit suite: 359 passed, 12 skipped (pre-existing).
- Full integration suite: 276 passed, 26 skipped (env-gated DAC + ADB + intentional server-limitation skips), 7 failed. **All 7 failures are pre-existing and reproduce on `origin/main`** — Responses-API access in tenancies without the policy, the documented `gpt-oss-120b` reasoning_content drift (PR #208 territory), Grok rate-limits, and Wikimedia hotlink rejection (also PR #208 territory). None touch the code in this PR.
- Live E2E probe against `openai.gpt-audio` in `us-chicago-1`: a 0.6s synthetic WAV is described correctly by the model through `ChatOCIOpenAI(use_responses_api=False)`.

## Test plan
- [x] `make lint` passes on CI (Python 3.9 + 3.12 matrix)
- [x] `make test` (unit) passes on CI matrix
- [x] Reviewer can construct `ChatOCIOpenAI(use_responses_api=False, model=\"openai.gpt-audio\", ...)` in a tenancy with GenAI access in `us-chicago-1` and round-trip an `input_audio` block
- [x] Existing `ChatOCIOpenAI(...)` callers see no behavior change (default kwarg preserves Responses transport)