### PR TITLE
Handle async saver misuse and store schema consistency

### DIFF
--- a/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/sync.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/sync.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Iterator, Sequence
+from collections.abc import AsyncIterator, Iterator, Sequence
 from contextlib import contextmanager
 from typing import Any
 
@@ -25,6 +25,11 @@ from langgraph_oracledb.checkpoint.oracle._lob import with_blob_lobs
 from langgraph_oracledb.checkpoint.oracle.base import BaseOracleSaver
 
 Conn = _internal.Conn  # For backward compatibility
+
+_AIO_ERROR_MSG = (
+    "OracleSaver is synchronous and does not support async checkpoint operations. "
+    "Use AsyncOracleSaver with LangGraph async APIs such as graph.ainvoke(...)."
+)
 
 
 def _validate_conn_string(conn_string: str):
@@ -457,6 +462,61 @@ class OracleSaver(BaseOracleSaver):
         with self._cursor() as cur:
             cur.executemany(query, with_blob_lobs(cur.connection, params))
             cur.connection.commit()
+
+    async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        """Get a checkpoint tuple asynchronously.
+
+        OracleSaver is synchronous; use AsyncOracleSaver for async graph execution.
+        """
+        raise NotImplementedError(_AIO_ERROR_MSG)
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        """List checkpoints asynchronously.
+
+        OracleSaver is synchronous; use AsyncOracleSaver for async graph execution.
+        """
+        raise NotImplementedError(_AIO_ERROR_MSG)
+        yield
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Save a checkpoint asynchronously.
+
+        OracleSaver is synchronous; use AsyncOracleSaver for async graph execution.
+        """
+        raise NotImplementedError(_AIO_ERROR_MSG)
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Store intermediate writes asynchronously.
+
+        OracleSaver is synchronous; use AsyncOracleSaver for async graph execution.
+        """
+        raise NotImplementedError(_AIO_ERROR_MSG)
+
+    async def adelete_thread(self, thread_id: str) -> None:
+        """Delete a thread asynchronously.
+
+        OracleSaver is synchronous; use AsyncOracleSaver for async graph execution.
+        """
+        raise NotImplementedError(_AIO_ERROR_MSG)
 
     def delete_thread(self, thread_id: str) -> None:
         """Delete all checkpoints and writes associated with a thread ID."""

--- a/libs/langgraph-oracledb/langgraph_oracledb/store/oracle/aio.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/store/oracle/aio.py
@@ -34,6 +34,7 @@ from langgraph_oracledb.store.oracle.base import (
     _normalize_existing_index_params,
     _row_to_item,
     _row_to_search_item,
+    _schema_inconsistency_error,
     _should_ignore_ttl_refresh_error,
     _validate_table_suffix,
 )
@@ -146,6 +147,36 @@ class AsyncOracleStore(
         async with _ainternal.get_connection(self.conn) as conn:
             async with conn.cursor() as cur:
                 yield cur
+
+    async def _table_exists(
+        self, cur: oracledb.AsyncCursor, table_name: str
+    ) -> bool:
+        await cur.execute(
+            """
+            SELECT 1
+            FROM user_tables
+            WHERE table_name = :1
+            """,
+            (table_name.upper(),),
+        )
+        row = await cur.fetchone()
+        return row is not None
+
+    async def _raise_if_schema_inconsistent(
+        self,
+        cur: oracledb.AsyncCursor,
+        *,
+        migration_table: str,
+        migration_version: int,
+        required_table: str,
+    ) -> None:
+        if migration_version >= 0 and not await self._table_exists(cur, required_table):
+            raise _schema_inconsistency_error(
+                table_suffix=self.table_suffix or "",
+                migration_table=migration_table,
+                migration_version=migration_version,
+                missing_table=required_table,
+            )
 
     async def _validate_configuration(
         self,
@@ -367,6 +398,19 @@ class AsyncOracleStore(
             version = await _get_version(
                 cur, table=self.table_names["store_migrations"]
             )
+            await self._raise_if_schema_inconsistent(
+                cur,
+                migration_table=self.table_names["store_migrations"],
+                migration_version=version,
+                required_table=self.table_names["store"],
+            )
+            if version >= 3:
+                await self._raise_if_schema_inconsistent(
+                    cur,
+                    migration_table=self.table_names["store_migrations"],
+                    migration_version=version,
+                    required_table="store_configs",
+                )
 
             for v, sql in enumerate(self.MIGRATIONS[version + 1 :], start=version + 1):
                 try:
@@ -386,6 +430,12 @@ class AsyncOracleStore(
             if self.index_config:
                 vector_migration_table_name = self.table_names["vector_migrations"]
                 version = await _get_version(cur, table=vector_migration_table_name)
+                await self._raise_if_schema_inconsistent(
+                    cur,
+                    migration_table=vector_migration_table_name,
+                    migration_version=version,
+                    required_table=self.table_names["store_vectors"],
+                )
 
                 for v, migration in enumerate(
                     self.VECTOR_MIGRATIONS[version + 1 :], start=version + 1

--- a/libs/langgraph-oracledb/langgraph_oracledb/store/oracle/base.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/store/oracle/base.py
@@ -389,6 +389,22 @@ def _validate_table_suffix(suffix: str) -> None:
         )
 
 
+def _schema_inconsistency_error(
+    *,
+    table_suffix: str,
+    migration_table: str,
+    migration_version: int,
+    missing_table: str,
+) -> RuntimeError:
+    return RuntimeError(
+        "OracleStore schema is inconsistent for "
+        f"table_suffix='{table_suffix}': {migration_table.upper()} records "
+        f"migration {migration_version}, but {missing_table.upper()} is missing. "
+        "Call teardown()/ateardown() on this store instance, then call setup() again, "
+        "or use a new table_suffix."
+    )
+
+
 def _validate_int_range(
     name: str,
     value: Any,
@@ -1278,6 +1294,33 @@ class OracleStore(BaseStore, BaseOracleStore[oracledb.Connection]):
             with conn.cursor() as cur:
                 yield cur
 
+    def _table_exists(self, cur: oracledb.Cursor, table_name: str) -> bool:
+        cur.execute(
+            """
+            SELECT 1
+            FROM user_tables
+            WHERE table_name = :1
+            """,
+            (table_name.upper(),),
+        )
+        return cur.fetchone() is not None
+
+    def _raise_if_schema_inconsistent(
+        self,
+        cur: oracledb.Cursor,
+        *,
+        migration_table: str,
+        migration_version: int,
+        required_table: str,
+    ) -> None:
+        if migration_version >= 0 and not self._table_exists(cur, required_table):
+            raise _schema_inconsistency_error(
+                table_suffix=self.table_suffix or "",
+                migration_table=migration_table,
+                migration_version=migration_version,
+                missing_table=required_table,
+            )
+
     def setup(self) -> None:
         """Set up the store database.
 
@@ -1328,6 +1371,19 @@ class OracleStore(BaseStore, BaseOracleStore[oracledb.Connection]):
             # First ensure global migrations are run (including store_configs table)
             # These use hardcoded table names and should only run once per database
             version = _get_version(cur, table=self.table_names["store_migrations"])
+            self._raise_if_schema_inconsistent(
+                cur,
+                migration_table=self.table_names["store_migrations"],
+                migration_version=version,
+                required_table=self.table_names["store"],
+            )
+            if version >= 3:
+                self._raise_if_schema_inconsistent(
+                    cur,
+                    migration_table=self.table_names["store_migrations"],
+                    migration_version=version,
+                    required_table="store_configs",
+                )
             for v, sql in enumerate(self.MIGRATIONS[version + 1 :], start=version + 1):
                 try:
                     sql_formatted = sql.format(**self.table_names)
@@ -1347,6 +1403,12 @@ class OracleStore(BaseStore, BaseOracleStore[oracledb.Connection]):
             if self.index_config:
                 vector_migration_table_name = self.table_names["vector_migrations"]
                 version = _get_version(cur, table=vector_migration_table_name)
+                self._raise_if_schema_inconsistent(
+                    cur,
+                    migration_table=vector_migration_table_name,
+                    migration_version=version,
+                    required_table=self.table_names["store_vectors"],
+                )
 
                 for v, migration in enumerate(
                     self.VECTOR_MIGRATIONS[version + 1 :], start=version + 1

--- a/libs/langgraph-oracledb/tests/test_checkpoint_sync_async_errors.py
+++ b/libs/langgraph-oracledb/tests/test_checkpoint_sync_async_errors.py
@@ -1,0 +1,45 @@
+import pytest
+
+from langgraph_oracledb.checkpoint.oracle import OracleSaver
+from tests._checkpoint_test_utils import generate_checkpoint, generate_config
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "args"),
+    [
+        ("aget_tuple", (generate_config("thread-1"),)),
+        ("aput", (generate_config("thread-1"), generate_checkpoint(), {}, {})),
+        (
+            "aput_writes",
+            (
+                {
+                    "configurable": {
+                        "thread_id": "thread-1",
+                        "checkpoint_ns": "",
+                        "checkpoint_id": "checkpoint-1",
+                    }
+                },
+                [("channel", "value")],
+                "task-1",
+            ),
+        ),
+        ("adelete_thread", ("thread-1",)),
+    ],
+)
+async def test_async_methods_raise_clear_error(
+    method_name: str, args: tuple[object, ...]
+) -> None:
+    saver = OracleSaver(conn=object())  # type: ignore[arg-type]
+
+    with pytest.raises(NotImplementedError, match="Use AsyncOracleSaver"):
+        await getattr(saver, method_name)(*args)
+
+
+@pytest.mark.asyncio
+async def test_async_list_raises_clear_error() -> None:
+    saver = OracleSaver(conn=object())  # type: ignore[arg-type]
+
+    with pytest.raises(NotImplementedError, match="Use AsyncOracleSaver"):
+        async for _ in saver.alist(generate_config("thread-1")):
+            pass

--- a/libs/langgraph-oracledb/tests/test_store_setup_schema_consistency.py
+++ b/libs/langgraph-oracledb/tests/test_store_setup_schema_consistency.py
@@ -1,0 +1,161 @@
+from contextlib import asynccontextmanager, contextmanager
+from re import search
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.embeddings import Embeddings
+
+from langgraph_oracledb.store.oracle import AsyncOracleStore, OracleStore
+
+
+class _MockEmbeddings(Embeddings):
+    def embed_query(self, text: str) -> list[float]:
+        return [0.1, 0.2, 0.3, 0.4]
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self.embed_query(text) for text in texts]
+
+
+class _FakeConnection:
+    def commit(self) -> None:
+        return None
+
+
+class _FakeAsyncConnection:
+    async def commit(self) -> None:
+        return None
+
+
+class _SetupCursor:
+    def __init__(self, versions: dict[str, int], existing_tables: set[str]) -> None:
+        self.versions = {name.upper(): version for name, version in versions.items()}
+        self.existing_tables = {name.upper() for name in existing_tables}
+        self.connection = _FakeConnection()
+        self._row = None
+
+    def execute(self, query: str, params: tuple[object, ...] | None = None) -> None:
+        normalized = " ".join(query.upper().split())
+        if "FROM USER_TABLES" in normalized:
+            table_name = str(params[0]).upper() if params else ""
+            self._row = (1,) if table_name in self.existing_tables else None
+            return
+
+        version_match = search(r"SELECT V FROM ([A-Z0-9_]+)", normalized)
+        if version_match:
+            table_name = version_match.group(1)
+            version = self.versions.get(table_name)
+            self._row = (version,) if version is not None else None
+            return
+
+        self._row = None
+
+    def fetchone(self):
+        return self._row
+
+
+class _AsyncSetupCursor(_SetupCursor):
+    def __init__(self, versions: dict[str, int], existing_tables: set[str]) -> None:
+        super().__init__(versions, existing_tables)
+        self.connection = _FakeAsyncConnection()
+
+    async def execute(
+        self, query: str, params: tuple[object, ...] | None = None
+    ) -> None:
+        super().execute(query, params)
+
+    async def fetchone(self):
+        return self._row
+
+
+def _vector_index_config():
+    return {
+        "dims": 4,
+        "embed": _MockEmbeddings(),
+        "index_type": {"type": "hnsw", "distance_metric": "COSINE"},
+    }
+
+
+def test_sync_setup_fails_when_store_table_missing_but_migration_recorded() -> None:
+    store = OracleStore(Mock(), table_suffix="demo")
+
+    @contextmanager
+    def fake_cursor():
+        yield _SetupCursor(
+            versions={"store_migrations_demo": 0},
+            existing_tables=set(),
+        )
+
+    store._cursor = fake_cursor
+
+    with pytest.raises(RuntimeError, match="STORE_DEMO is missing"):
+        store.setup()
+
+    assert store.table_names["store"] == "store_demo"
+
+
+def test_sync_setup_fails_when_vector_table_missing_but_migration_recorded() -> None:
+    store = OracleStore(Mock(), index=_vector_index_config(), table_suffix="demo")
+    store._validate_configuration = lambda *_args, **_kwargs: None
+
+    @contextmanager
+    def fake_cursor():
+        yield _SetupCursor(
+            versions={
+                "store_migrations_demo": 4,
+                "vector_migrations_demo": 1,
+            },
+            existing_tables={"store_demo", "store_configs"},
+        )
+
+    store._cursor = fake_cursor
+
+    with pytest.raises(RuntimeError, match="STORE_VECTORS_DEMO is missing"):
+        store.setup()
+
+    assert store.table_names["store_vectors"] == "store_vectors_demo"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_fails_when_store_table_missing_but_migration_recorded() -> None:
+    store = AsyncOracleStore(Mock(), table_suffix="demo")
+
+    @asynccontextmanager
+    async def fake_cursor():
+        yield _AsyncSetupCursor(
+            versions={"store_migrations_demo": 0},
+            existing_tables=set(),
+        )
+
+    store._cursor = fake_cursor
+
+    with pytest.raises(RuntimeError, match="STORE_DEMO is missing"):
+        await store.setup()
+
+    assert store.table_names["store"] == "store_demo"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_fails_when_vector_table_missing_but_migration_recorded() -> None:
+    store = AsyncOracleStore(Mock(), index=_vector_index_config(), table_suffix="demo")
+
+    async def validate_configuration_noop(*_args, **_kwargs) -> None:
+        return None
+
+    store._validate_configuration = validate_configuration_noop
+
+    @asynccontextmanager
+    async def fake_cursor():
+        yield _AsyncSetupCursor(
+            versions={
+                "store_migrations_demo": 4,
+                "vector_migrations_demo": 1,
+            },
+            existing_tables={"store_demo", "store_configs"},
+        )
+
+    store._cursor = fake_cursor
+
+    with pytest.raises(RuntimeError, match="STORE_VECTORS_DEMO is missing"):
+        await store.setup()
+
+    assert store.table_names["store_vectors"] == "store_vectors_demo"


### PR DESCRIPTION
This PR improves LangGraph Oracle integration behavior around async usage and store setup recovery.

- Adds explicit async method implementations on the synchronous `OracleSaver` that raise a clear `NotImplementedError`,
directing users to `AsyncOracleSaver` when using LangGraph async APIs.
- Adds schema consistency checks for `OracleStore.setup()` and `AsyncOracleStore.setup()` so setup fails clearly when
migration tables indicate prior setup but required backing tables are missing.
- Covers both sync and async paths with focused tests for checkpoint async misuse and inconsistent store/vector schema
state.

## Testing

- Added `tests/test_checkpoint_sync_async_errors.py`
- Added `tests/test_store_setup_schema_consistency.py`

