### PR TITLE
feat(oci): support bring-your-own chat model in agent factories

### DIFF
--- a/libs/oci/langchain_oci/agents/common.py
+++ b/libs/oci/langchain_oci/agents/common.py
@@ -23,6 +23,11 @@ class AgentConfig(BaseModel):
     model_config = {"populate_by_name": True, "arbitrary_types_allowed": True}
 
     model_id: str = "meta.llama-4-scout-17b-16e-instruct"
+    # Optional pre-built LangChain chat model. When set, it is used as-is and
+    # ``model_id`` / OCI inference auth are ignored (the model owns its own
+    # connection). Typed ``Any`` to accept any ``BaseChatModel`` without strict
+    # pydantic validation, matching how other injected objects are typed here.
+    model: Optional[Any] = None
     compartment_id: Optional[str] = None
     service_endpoint: Optional[str] = None
     auth_type: Union[str, OCIAuthType] = OCIAuthType.API_KEY
@@ -41,10 +46,15 @@ class AgentConfig(BaseModel):
 
     @model_validator(mode="after")
     def _resolve_oci_env(self) -> "AgentConfig":
-        """Resolve compartment and endpoint from environment if not set."""
+        """Resolve compartment and endpoint from environment if not set.
+
+        When a pre-built ``model`` is supplied the agent does not call OCI
+        inference, so ``compartment_id`` is not required. It is still resolved
+        opportunistically because OCI-backed datastore embeddings may need it.
+        """
         if not self.compartment_id:
             self.compartment_id = os.environ.get("OCI_COMPARTMENT_ID")
-        if not self.compartment_id:
+        if not self.compartment_id and self.model is None:
             raise ValueError(
                 "compartment_id must be provided or set via "
                 "OCI_COMPARTMENT_ID environment variable"
@@ -60,16 +70,26 @@ class AgentConfig(BaseModel):
 
 
 def _build_llm(config: AgentConfig, **extra_kwargs: Any) -> Any:
-    """Build a ChatOCIGenAI instance from an AgentConfig.
+    """Resolve the chat model for an agent.
+
+    If ``config.model`` holds a pre-built LangChain chat model it is returned
+    as-is, letting callers drive the agent with any provider (Anthropic,
+    OpenAI, a self-hosted vLLM model, a custom-configured ChatOCIGenAI, ...).
+    Otherwise a ``ChatOCIGenAI`` is built from ``config.model_id`` and the OCI
+    auth settings.
 
     Args:
         config: Resolved agent configuration.
         **extra_kwargs: Additional kwargs passed to ChatOCIGenAI
-            (e.g. max_sequential_tool_calls, tool_result_guidance).
+            (e.g. max_sequential_tool_calls, tool_result_guidance). Ignored
+            when a pre-built ``config.model`` is supplied.
 
     Returns:
-        ChatOCIGenAI instance.
+        A LangChain ``BaseChatModel`` (the supplied model or a ChatOCIGenAI).
     """
+    if config.model is not None:
+        return config.model
+
     from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
 
     auth_type = (

--- a/libs/oci/langchain_oci/agents/deepagents/README.md
+++ b/libs/oci/langchain_oci/agents/deepagents/README.md
@@ -220,6 +220,29 @@ agent = create_deepagents_agent(
 )
 ```
 
+## Example: Bring Your Own Model
+
+By default the agent builds a `ChatOCIGenAI` from `model_id` and the OCI auth
+options. To drive it with any other LangChain chat model, pass a pre-built
+model via `model=...`. When set, `model_id` and the OCI inference auth options
+are ignored — the model owns its own connection.
+
+```python
+from langchain_anthropic import ChatAnthropic
+from langchain_oci.agents import create_deepagents_agent
+
+agent = create_deepagents_agent(
+    tools=[...],
+    model=ChatAnthropic(model="claude-opus-4-8"),
+)
+```
+
+This also works with a custom-configured `ChatOCIGenAI` (e.g. extra kwargs not
+exposed on the factory), a self-hosted vLLM endpoint via `ChatOpenAI`, etc. If
+you use OCI-backed datastores you may still need OCI auth for embeddings unless
+you pass your own `embedding_model`. The same `model=...` parameter is available
+on `create_oci_agent`.
+
 ## Async Cleanup Note
 
 If your workflow keeps agents/models alive across many async calls, explicitly

--- a/libs/oci/langchain_oci/agents/deepagents/agent.py
+++ b/libs/oci/langchain_oci/agents/deepagents/agent.py
@@ -56,6 +56,8 @@ class DeepagentsConfig(AgentConfig):
     middleware: Optional[Sequence[Any]] = None
     response_format: Optional[Any] = None
     context_schema: Optional[type] = None
+    # Path-level filesystem access control, forwarded to deepagents.
+    permissions: Optional[Any] = None
 
     # LangGraph options
     backend: Optional[Any] = None
@@ -74,15 +76,21 @@ class DeepagentsConfig(AgentConfig):
             return True
         if self.response_format or self.context_schema:
             return True
+        if self.permissions:
+            return True
         return False
 
     @property
     def _can_use_lightweight(self) -> bool:
-        """Whether a lightweight ReAct agent suffices."""
+        """Whether a lightweight ReAct agent suffices.
+
+        Only an explicit ``middleware=[]`` opts out of the deep-agent harness.
+        Datastores compose *with* the full deep agent (planning, filesystem,
+        subagents); they no longer silently downgrade it to a plain ReAct agent
+        that lacks those capabilities.
+        """
         if self._needs_deep_agent:
             return False
-        if self.datastores:
-            return True
         return self.middleware is not None and len(self.middleware) == 0
 
 
@@ -136,6 +144,7 @@ def create_deepagents_agent(
     middleware: Optional[Sequence[Any]] = None,
     response_format: Any = None,
     context_schema: Optional[type] = None,
+    permissions: Optional[Any] = None,
     # LangGraph options
     checkpointer: Any = None,
     store: Any = None,
@@ -186,6 +195,8 @@ def create_deepagents_agent(
         middleware: Custom middleware. Pass empty list to disable defaults.
         response_format: Structured output response format for the agent.
         context_schema: Schema for typed context passed into the agent graph.
+        permissions: Path-level filesystem access-control rules forwarded to
+            the deep agent (deepagents ``permissions``). Deep path only.
         checkpointer: LangGraph checkpointer for persistence/memory.
         store: LangGraph store for long-term memory.
         backend: State backend for the deep agent (e.g., StoreBackend).
@@ -253,6 +264,7 @@ def create_deepagents_agent(
         middleware=middleware,
         response_format=response_format,
         context_schema=context_schema,
+        permissions=permissions,
         backend=backend,
         cache=cache,
         interrupt_on=interrupt_on,
@@ -351,6 +363,7 @@ def _build_deep(
             middleware=config.middleware,
             response_format=config.response_format,
             context_schema=config.context_schema,
+            permissions=config.permissions,
             checkpointer=config.checkpointer,
             store=config.store,
             backend=config.backend,

--- a/libs/oci/langchain_oci/agents/deepagents/agent.py
+++ b/libs/oci/langchain_oci/agents/deepagents/agent.py
@@ -30,6 +30,7 @@ from langchain_oci.common.auth import OCIAuthType
 from langchain_oci.datastores import VectorDataStore, create_datastore_tools
 
 if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
     from langgraph.graph.state import CompiledStateGraph
 
 
@@ -118,6 +119,8 @@ def create_deepagents_agent(
     default_store: Optional[str] = None,
     embedding_model: Any = None,
     top_k: int = 5,
+    # Model
+    model: Optional["BaseChatModel"] = None,
     # OCI options
     model_id: str = "google.gemini-2.5-pro",
     compartment_id: Optional[str] = None,
@@ -163,7 +166,14 @@ def create_deepagents_agent(
         default_store: Alias for default_datastore.
         embedding_model: Custom embedding model for datastores.
         top_k: Number of search results to return.
-        model_id: OCI model identifier (Gemini models recommended).
+        model: Pre-built LangChain chat model to drive the agent. When set, it
+            is used as-is and ``model_id`` plus the OCI inference auth options
+            are ignored (the model owns its own connection). Use this to run on
+            any provider (Anthropic, OpenAI, a self-hosted vLLM model, or a
+            custom-configured ChatOCIGenAI). OCI auth may still be required for
+            datastore embeddings unless ``embedding_model`` is supplied.
+        model_id: OCI model identifier (Gemini models recommended). Used only
+            when ``model`` is not provided.
         compartment_id: OCI compartment OCID.
         service_endpoint: OCI GenAI service endpoint.
         auth_type: OCI authentication type.
@@ -214,6 +224,7 @@ def create_deepagents_agent(
         ... )
     """
     config = DeepagentsConfig(
+        model=model,
         model_id=model_id,
         compartment_id=compartment_id,
         service_endpoint=service_endpoint,

--- a/libs/oci/langchain_oci/agents/react/agent.py
+++ b/libs/oci/langchain_oci/agents/react/agent.py
@@ -19,6 +19,7 @@ from langchain_oci.agents.common import (
 from langchain_oci.common.auth import OCIAuthType
 
 if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
     from langgraph.graph.state import CompiledStateGraph
 
 
@@ -26,6 +27,8 @@ def create_oci_agent(
     model_id: str,
     tools: Sequence[BaseTool | Callable[..., Any]],
     *,
+    # Model
+    model: "BaseChatModel | None" = None,
     # OCI-specific options
     compartment_id: str | None = None,
     service_endpoint: str | None = None,
@@ -59,8 +62,13 @@ def create_oci_agent(
     see :func:`create_deepagents_agent`.
 
     Args:
-        model_id: OCI model identifier (e.g., "meta.llama-4-scout-17b-16e-instruct")
+        model_id: OCI model identifier (e.g., "meta.llama-4-scout-17b-16e-instruct").
+            Ignored when ``model`` is provided.
         tools: List of tools the agent can use.
+        model: Pre-built LangChain chat model to drive the agent. When set, it
+            is used as-is and ``model_id`` plus the OCI auth options (and the
+            OCI-specific ``max_sequential_tool_calls`` / ``tool_result_guidance``
+            tuning) are ignored. Use this to run on any provider.
         compartment_id: OCI compartment OCID.
         service_endpoint: OCI GenAI service endpoint.
         auth_type: OCI authentication type.
@@ -104,6 +112,7 @@ def create_oci_agent(
     create_agent_func, use_legacy_api = _get_agent_factory()
 
     config = AgentConfig(
+        model=model,
         model_id=model_id,
         compartment_id=compartment_id,
         service_endpoint=service_endpoint,

--- a/libs/oci/tests/integration_tests/agents/test_deepagents_integration.py
+++ b/libs/oci/tests/integration_tests/agents/test_deepagents_integration.py
@@ -347,6 +347,57 @@ class TestOCIDeepAgentIntegration:
         assert final_message.content, "Final message should have content"
         assert len(final_message.content) > 100, "Response should be substantive"
 
+    def test_bring_your_own_model(
+        self,
+        compartment_id: str,
+        service_endpoint: str,
+        auth_type: str,
+        auth_profile: str,
+        model_id: str,
+    ) -> None:
+        """A pre-built chat model passed via ``model=`` drives the agent.
+
+        Exercises the bring-your-own-model path: ``create_deepagents_agent``
+        uses the supplied ``ChatOCIGenAI`` as-is instead of building one from
+        ``model_id`` + OCI auth. Any LangChain ``BaseChatModel`` works the same
+        way (Anthropic, OpenAI, self-hosted vLLM, etc.); we use ChatOCIGenAI
+        here because it is the model the integration env is provisioned for.
+        """
+        from langchain_oci import ChatOCIGenAI, create_deepagents_agent
+
+        model = ChatOCIGenAI(
+            model_id=model_id,
+            compartment_id=compartment_id,
+            service_endpoint=service_endpoint,
+            auth_type=auth_type,
+            auth_profile=auth_profile,
+            model_kwargs={"temperature": 0.3, "max_tokens": 2048},
+        )
+
+        agent = create_deepagents_agent(
+            tools=[search_knowledge_base, get_statistics, analyze_trends],
+            model=model,
+            middleware=[],
+            system_prompt="You are a concise research analyst.",
+        )
+        try:
+            # The supplied model must be the one wired into the agent.
+            assert getattr(agent, "_oci_llm", None) is model
+
+            result = agent.invoke(
+                {
+                    "messages": [
+                        HumanMessage(content="What are the current trends in AI?")
+                    ]
+                }
+            )
+            assert "messages" in result
+            final_message = result["messages"][-1]
+            assert final_message.content, "Final message should have content"
+        finally:
+            if hasattr(model, "aclose"):
+                asyncio.run(model.aclose())
+
     def test_multi_tool_research(self, agent: Any) -> None:
         """Test agent uses multiple tools for research."""
         result = agent.invoke(
@@ -1047,10 +1098,16 @@ class TestDeepAgentResponseFormat:
             summary: str = Field(description="A brief summary of findings")
             confidence: float = Field(description="Confidence score between 0 and 1")
 
+        # Structured output relies on function-calling, which gemini-2.5-flash
+        # handles unreliably (it frequently returns ``malformed_function_call``
+        # with empty content). Pin the more capable pro variant regardless of
+        # the OCI_DEEPAGENTS_MODEL default used elsewhere.
+        oci_kwargs = {**_make_oci_kwargs(), "model_id": "google.gemini-2.5-pro"}
+
         agent = create_deepagents_agent(
             tools=[search_knowledge_base],
             response_format=AutoStrategy(schema=ResearchSummary),
-            **_make_oci_kwargs(),
+            **oci_kwargs,
         )
         try:
             result = agent.invoke(

--- a/libs/oci/tests/unit_tests/agents/test_deepagents.py
+++ b/libs/oci/tests/unit_tests/agents/test_deepagents.py
@@ -79,12 +79,19 @@ class TestCreateDeepagentsAgent:
                     mock_create.assert_called_once()
                     assert agent is not None
 
-    def test_datastore_path_uses_lightweight_agent(self) -> None:
-        """Datastore-backed helper should avoid deepagents planning middleware."""
+    def test_datastore_path_uses_deep_agent(self) -> None:
+        """Datastores compose with the full deep agent rather than downgrading it.
+
+        Regression guard for the silent-downgrade bug: ``datastores=`` on its own
+        must route through ``create_deep_agent`` (so planning, filesystem, and
+        subagents stay available) and the generated datastore tools must be
+        forwarded into the deep agent.
+        """
         from langchain_oci.agents.deepagents.agent import create_deepagents_agent
 
         fake_store = MagicMock()
         fake_store.name = "opensearch"
+        sentinel_tool = MagicMock(name="datastore_tool")
 
         with patch.dict("os.environ", {"OCI_COMPARTMENT_ID": "test-compartment"}):
             with patch(
@@ -92,15 +99,17 @@ class TestCreateDeepagentsAgent:
             ) as mock_llm_class:
                 with patch(
                     "langchain_oci.agents.deepagents.agent.create_datastore_tools",
-                    return_value=[],
+                    return_value=[sentinel_tool],
                 ):
-                    with patch("langchain.agents.create_agent") as mock_create_agent:
+                    with mock_deepagents() as mock_create:
                         mock_llm_class.return_value = MagicMock()
-                        mock_create_agent.return_value = MagicMock()
 
                         create_deepagents_agent(datastores={"runbooks": fake_store})
 
-                        mock_create_agent.assert_called_once()
+                        # Deep path, not lightweight create_agent.
+                        mock_create.assert_called_once()
+                        # Datastore tools are wired into the deep agent.
+                        assert sentinel_tool in mock_create.call_args.kwargs["tools"]
 
     def test_empty_middleware_uses_lightweight_agent(self) -> None:
         """Explicitly disabling middleware should avoid deepagents planning."""
@@ -122,8 +131,8 @@ class TestCreateDeepagentsAgent:
                     mock_create_agent.assert_called_once()
 
     def test_lightweight_path_does_not_require_deepagents_installed(self) -> None:
-        """The lightweight (datastore / middleware=[]) path must work without
-        the ``deepagents`` package installed. The prerequisite check is only
+        """The lightweight (``middleware=[]``) path must work without the
+        ``deepagents`` package installed. The prerequisite check is only
         relevant when we actually route to ``create_deep_agent``.
         """
         from langchain_oci.agents.deepagents.agent import create_deepagents_agent
@@ -205,6 +214,24 @@ class TestCreateDeepagentsAgent:
                     )
                     mock_create.assert_called_once()
                     assert "interrupt_on" in mock_create.call_args.kwargs
+
+    def test_permissions_forwarded(self) -> None:
+        """permissions= forces the deep path and reaches create_deep_agent
+        (instead of being swallowed by **model_kwargs)."""
+        from langchain_oci.agents.deepagents.agent import create_deepagents_agent
+
+        perms = MagicMock(name="permissions")
+
+        with patch.dict("os.environ", {"OCI_COMPARTMENT_ID": "test"}):
+            with patch("langchain_oci.chat_models.oci_generative_ai.ChatOCIGenAI"):
+                with mock_deepagents() as mock_create:
+                    create_deepagents_agent(
+                        tools=[dummy_tool],
+                        permissions=perms,
+                    )
+                    mock_create.assert_called_once()
+                    kwargs = mock_create.call_args.kwargs
+                    assert kwargs["permissions"] is perms
 
     def test_raises_without_compartment_id(self) -> None:
         """Test that error is raised when no compartment_id available."""

--- a/libs/oci/tests/unit_tests/agents/test_deepagents.py
+++ b/libs/oci/tests/unit_tests/agents/test_deepagents.py
@@ -569,6 +569,37 @@ class TestCreateDeepagentsAgent:
                     call_kwargs = mock_llm_class.call_args.kwargs
                     assert call_kwargs["model_id"] == "google.gemini-2.5-flash"
 
+    def test_custom_model_used_as_is(self) -> None:
+        """A pre-built ``model`` is passed straight to create_deep_agent and
+        ChatOCIGenAI is never constructed."""
+        from langchain_oci.agents.deepagents.agent import create_deepagents_agent
+
+        custom_model = MagicMock()
+        with patch.dict("os.environ", {"OCI_COMPARTMENT_ID": "test"}):
+            with patch(
+                "langchain_oci.chat_models.oci_generative_ai.ChatOCIGenAI"
+            ) as mock_llm_class:
+                with mock_deepagents() as mock_create:
+                    create_deepagents_agent(tools=[dummy_tool], model=custom_model)
+
+                    mock_llm_class.assert_not_called()
+                    assert mock_create.call_args.kwargs["model"] is custom_model
+
+    def test_custom_model_skips_compartment_requirement(self) -> None:
+        """With a pre-built ``model`` no compartment_id/env is required."""
+        from langchain_oci.agents.deepagents.agent import create_deepagents_agent
+
+        custom_model = MagicMock()
+        with patch.dict("os.environ", {}, clear=True):
+            with patch(
+                "langchain_oci.chat_models.oci_generative_ai.ChatOCIGenAI"
+            ) as mock_llm_class:
+                with mock_deepagents() as mock_create:
+                    create_deepagents_agent(tools=[dummy_tool], model=custom_model)
+
+                    mock_llm_class.assert_not_called()
+                    assert mock_create.call_args.kwargs["model"] is custom_model
+
     def test_openai_models_pass_max_tokens_through(self) -> None:
         """OpenAI-compatible models receive ``max_tokens`` from the agent layer.
 

--- a/libs/oci/tests/unit_tests/agents/test_react.py
+++ b/libs/oci/tests/unit_tests/agents/test_react.py
@@ -82,6 +82,24 @@ class TestCreateOCIReactAgent:
                         tools=[dummy_tool],
                     )
 
+    def test_custom_model_used_as_is(self) -> None:
+        """A pre-built ``model`` drives the agent and ChatOCIGenAI is not built,
+        even without a compartment_id."""
+        custom_model = MagicMock()
+        with patch.dict("os.environ", {}, clear=True):
+            with patch(
+                "langchain_oci.chat_models.oci_generative_ai.ChatOCIGenAI"
+            ) as mock_llm_class:
+                with mock_create_agent() as mock_create:
+                    create_oci_agent(
+                        model_id="meta.llama-4-scout-17b-16e-instruct",
+                        tools=[dummy_tool],
+                        model=custom_model,
+                    )
+
+                    mock_llm_class.assert_not_called()
+                    assert mock_create.call_args.kwargs["model"] is custom_model
+
     def test_passes_system_prompt(self) -> None:
         """Test that system_prompt is passed to the agent creation function."""
         with patch.dict("os.environ", {"OCI_COMPARTMENT_ID": "test"}):


### PR DESCRIPTION
## Summary

`create_deepagents_agent` and `create_oci_agent` previously hardcoded `ChatOCIGenAI` (built internally from `model_id` + OCI auth), locking the agents to OCI GenAI inference. This adds a `model=` parameter that accepts any pre-built LangChain `BaseChatModel`.

When `model=` is supplied:
- it is used as-is; `model_id` and the OCI inference auth options are ignored (the model owns its own connection),
- `compartment_id` is no longer required — it is still resolved opportunistically for OCI-backed datastore embeddings.

This lets callers drive the agents with any provider — Anthropic, OpenAI, a self-hosted vLLM endpoint via `ChatOpenAI`, or a custom-configured `ChatOCIGenAI` — while keeping the default `model_id` path fully backward compatible.

```python
from langchain_anthropic import ChatAnthropic
from langchain_oci.agents import create_deepagents_agent

agent = create_deepagents_agent(
    tools=[...],
    model=ChatAnthropic(model="claude-opus-4-8"),
)
```

## Implementation

- The escape hatch lives in the shared `_build_llm`: when `config.model` is set it is returned directly. Both factories share it, so `create_deepagents_agent` and `create_oci_agent` gain the capability consistently.
- `AgentConfig` gains a `model` field; `_resolve_oci_env` only requires `compartment_id` when no `model` is provided.
- README example added under the deepagents docs.

## Notes / limitations

- OCI-specific tuning (`max_sequential_tool_calls`, `tool_result_guidance` on the ReAct agent) only applies to the built-in `ChatOCIGenAI` path; it is ignored when you bring your own model.
- Datastore embeddings still use OCI unless you pass your own `embedding_model`.

## Testing

- Unit: added coverage for both factories (custom model used as-is, `ChatOCIGenAI` not constructed, compartment requirement skipped).
- Integration (live OCI GenAI): added `test_bring_your_own_model` asserting the supplied model is the one wired into the agent. Full deepagents integration suite passes (24 passed, 2 xfailed).
- Also pinned the structured-output integration test to `gemini-2.5-pro`; `gemini-2.5-flash` returns `malformed_function_call` with empty content on structured-output workloads.

## Follow-up: datastore deep-agent conformance + `permissions` forwarding

Includes a follow-up commit (authored by @RichmondAlake) that fixes two conformance gaps in `create_deepagents_agent` surfaced while testing the BYO-model path:

- **Datastores now compose with the full deep agent.** Previously `create_deepagents_agent(datastores=...)` silently routed to the lightweight `langchain.agents.create_agent`, dropping planning, the virtual filesystem, and sub-agents — so the datastore-backed RAG example wasn't actually a *deep* agent. Datastores now run through `deepagents.create_deep_agent`; only an explicit `middleware=[]` opts out of the harness.
- **`permissions=` is now forwarded.** It is a documented `create_deep_agent` parameter (path-level filesystem access control) that was being captured by `**model_kwargs` and never reached deepagents. It is now exposed on the factory, forwarded, and forces the deep path so it can't be silently dropped.

### Behavior change

`create_deepagents_agent(datastores=...)` now requires the `deepagents` package to be installed (it previously worked without it via the lightweight path). Passing `middleware=[]` restores the lightweight, dependency-free path.

### Validation

- Unit tests pass, including a regression guard asserting datastores route through `create_deep_agent` and that the generated datastore tools are forwarded into the deep agent, plus coverage for `permissions` forwarding.
- Agent + datastore integration tests pass against live OCI GenAI, an Oracle Autonomous Database, and OpenSearch.
- Verified end-to-end on a free-tier Oracle Autonomous Database: with `datastores=` set and no `middleware=[]`, the agent is built with the deepagents planning/filesystem harness (not the lightweight ReAct loop) and returns grounded, document-cited answers retrieved from the database.

Closes #239
