### PR TITLE
feat(oci): surface streaming reasoning as standard content blocks

### DIFF
--- a/libs/oci/langchain_oci/chat_models/async_mixin.py
+++ b/libs/oci/langchain_oci/chat_models/async_mixin.py
@@ -201,9 +201,19 @@ class ChatOCIGenAIAsyncMixin:
                     event_data, tool_call_ids
                 )
 
+                # Surface incremental reasoning (e.g. xAI Grok, OpenAI o-series)
+                # so the merged message exposes a standard ``reasoning`` content
+                # block, matching the non-streaming path. Absent for models that
+                # don't emit reasoning, in which case nothing is added.
+                reasoning_delta = self._provider.chat_stream_to_reasoning(event_data)  # type: ignore[attr-defined]
+                additional_kwargs = (
+                    {"reasoning_content": reasoning_delta} if reasoning_delta else {}
+                )
+
                 chunk = ChatGenerationChunk(
                     message=AIMessageChunk(
                         content=delta,
+                        additional_kwargs=additional_kwargs,
                         tool_call_chunks=tool_call_chunks,
                     )
                 )

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -564,9 +564,19 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                     event_data, tool_call_ids
                 )
 
+                # Surface incremental reasoning (e.g. xAI Grok, OpenAI o-series)
+                # so the merged message exposes a standard ``reasoning`` content
+                # block, matching the non-streaming path. Absent for models that
+                # don't emit reasoning, in which case nothing is added.
+                reasoning_delta = self._provider.chat_stream_to_reasoning(event_data)
+                additional_kwargs = (
+                    {"reasoning_content": reasoning_delta} if reasoning_delta else {}
+                )
+
                 chunk = ChatGenerationChunk(
                     message=AIMessageChunk(
                         content=delta,
+                        additional_kwargs=additional_kwargs,
                         tool_call_chunks=tool_call_chunks,
                     )
                 )

--- a/libs/oci/langchain_oci/chat_models/providers/base.py
+++ b/libs/oci/langchain_oci/chat_models/providers/base.py
@@ -68,6 +68,21 @@ class Provider(ABC):
         """Extract generation metadata from a chat stream event."""
         ...
 
+    def chat_stream_to_reasoning(self, event_data: Dict) -> str:
+        """Extract incremental reasoning text from a streaming event.
+
+        Reasoning models (e.g. xAI Grok, OpenAI o-series) emit a separate
+        ``reasoning_content`` channel alongside the visible answer. Returning
+        it per-delta here lets ``ChatOCIGenAI._stream`` / ``_astream`` accumulate
+        it into ``AIMessageChunk.additional_kwargs["reasoning_content"]`` so the
+        merged message exposes a standard ``reasoning`` content block — at parity
+        with the non-streaming path.
+
+        The default returns ``""`` (no reasoning), so providers that do not
+        surface reasoning are unaffected.
+        """
+        return ""
+
     @abstractmethod
     def chat_tool_calls(self, response: Any) -> List[Any]:
         """Extract tool calls from a provider's response."""

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -311,6 +311,23 @@ class GenericProvider(Provider):
         """Extract generation metadata from Meta chat stream event."""
         return {"finish_reason": event_data["finishReason"]}
 
+    def chat_stream_to_reasoning(self, event_data: Dict) -> str:
+        """Extract incremental reasoning text from a Generic stream event.
+
+        Streaming events are raw JSON and use camelCase keys (``finishReason``,
+        ``toolCalls``, ``reasoningContent``) — unlike the non-streaming SDK
+        response object, whose attribute is snake_case ``reasoning_content``
+        (see :meth:`chat_generation_info`). Reasoning models (e.g. xAI Grok,
+        OpenAI o-series) emit the chain-of-thought on ``message.reasoningContent``
+        ahead of the visible ``message.content``. Returns ``""`` when absent so
+        non-reasoning models stream unchanged.
+        """
+        message = event_data.get("message")
+        if not isinstance(message, dict):
+            return ""
+        reasoning = message.get("reasoningContent")
+        return reasoning if isinstance(reasoning, str) else ""
+
     def chat_tool_calls(self, response: Any) -> List[Any]:
         """Retrieve tool calls from chat response.
 

--- a/libs/oci/tests/integration_tests/chat_models/conftest.py
+++ b/libs/oci/tests/integration_tests/chat_models/conftest.py
@@ -17,11 +17,12 @@ fresh checkout.
   Default: ``xai.grok-3-mini-fast``.
 - ``OCI_STANDARD_MODELS`` — comma-separated model ids that should
   never populate ``reasoning_content``. Default:
-  ``meta.llama-3.3-70b-instruct,cohere.command-r-08-2024,openai.gpt-oss-120b``.
-  (gpt-oss-120b is here because the OCI deployment leaves
-  reasoning_content null even with ``reasoning_effort=MEDIUM`` —
-  it advertises reasoning but currently behaves as a standard model
-  through this API.)
+  ``meta.llama-3.3-70b-instruct,cohere.command-r-08-2024``.
+
+  ``openai.gpt-oss-120b`` is intentionally in neither default list: its
+  ``reasoning_content`` is unreliable on the OCI deployment (sometimes
+  present, sometimes null, on both invoke and stream), so it can't anchor
+  either a "has reasoning" or "no reasoning" assertion. See #213 / #208.
 - ``OCI_LLAMA_MODELS``, ``OCI_COHERE_MODELS``, ``OCI_GROK_MODELS``,
   ``OCI_OPENAI_MODELS`` — comma-separated model ids for the
   per-provider matrices exercised by ``test_multi_model.py``. Defaults
@@ -48,7 +49,6 @@ _DEFAULT_REASONING_MODELS: List[str] = ["xai.grok-3-mini-fast"]
 _DEFAULT_STANDARD_MODELS: List[str] = [
     "meta.llama-3.3-70b-instruct",
     "cohere.command-r-08-2024",
-    "openai.gpt-oss-120b",
 ]
 
 

--- a/libs/oci/tests/integration_tests/chat_models/test_chat_features.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_chat_features.py
@@ -13,7 +13,7 @@ Run:
 """
 
 import os
-from typing import Union
+from typing import Any, Union
 
 import pytest
 from langchain_core.messages import (
@@ -443,6 +443,28 @@ def test_long_context_handling(llm):
 REASONING_MODELS = reasoning_models()
 STANDARD_MODELS = standard_models()
 
+# ``.content_blocks`` exists on langchain-core >= 1.0 only (the Python 3.10+
+# install); on the 3.9 / core-0.3.x matrix it is absent.
+_HAS_CONTENT_BLOCKS = hasattr(AIMessage(content=""), "content_blocks")
+
+
+def _merge_stream(chunks: list):
+    """Concatenate streamed message chunks into a single message."""
+    merged = chunks[0]
+    for chunk in chunks[1:]:
+        merged = merged + chunk
+    return merged
+
+
+def _content_blocks(message: Any) -> list:
+    """Read ``.content_blocks`` via getattr.
+
+    The property only exists on langchain-core >= 1.0; on the py3.9 / core-0.3.x
+    matrix it is absent, so a direct attribute access trips mypy's attr-defined
+    check even though these tests are skipped at runtime there.
+    """
+    return list(getattr(message, "content_blocks"))
+
 
 def _make_reasoning_llm(model_id: str) -> ChatOCIGenAI:
     """Create LLM for reasoning content tests."""
@@ -477,6 +499,68 @@ def test_reasoning_model_returns_reasoning_content(model_id: str) -> None:
     )
     assert len(reasoning) > 10, f"{model_id}: reasoning too short: {reasoning!r}"
     assert result.content, f"{model_id}: content should not be empty"
+
+
+@pytest.mark.requires("oci")
+@pytest.mark.skipif(
+    not _HAS_CONTENT_BLOCKS, reason="content_blocks requires langchain-core>=1.0"
+)
+@pytest.mark.parametrize("model_id", REASONING_MODELS)
+def test_reasoning_model_content_blocks(model_id: str) -> None:
+    """Reasoning models expose a standard ``reasoning`` content block (invoke).
+
+    Backward compatibility: ``.content`` must remain a plain string.
+    """
+    llm = _make_reasoning_llm(model_id)
+    result = llm.invoke([HumanMessage(content="What is 17 * 23?")])
+
+    assert isinstance(result.content, str), f"{model_id}: .content must stay a str"
+    blocks = _content_blocks(result)
+    assert any(b.get("type") == "reasoning" for b in blocks), (
+        f"{model_id}: expected a reasoning content block, got {blocks}"
+    )
+    assert any(b.get("type") == "text" for b in blocks), (
+        f"{model_id}: expected a text content block, got {blocks}"
+    )
+
+
+@pytest.mark.requires("oci")
+@pytest.mark.parametrize("model_id", REASONING_MODELS)
+def test_reasoning_model_streaming_reasoning_content(model_id: str) -> None:
+    """Streaming a reasoning model accumulates reasoning + a reasoning block.
+
+    Guards against the prior gap where the streaming path dropped
+    ``reasoning_content`` entirely (it surfaced only on ``invoke()``).
+    """
+    llm = _make_reasoning_llm(model_id)
+    chunks = list(llm.stream([HumanMessage(content="What is 17 * 23?")]))
+    assert chunks, f"{model_id}: stream yielded no chunks"
+    merged = _merge_stream(chunks)
+
+    assert isinstance(merged.content, str), f"{model_id}: .content must stay a str"
+    reasoning = merged.additional_kwargs.get("reasoning_content")
+    assert reasoning is not None and len(reasoning) > 10, (
+        f"{model_id}: streamed reasoning_content missing/short: {reasoning!r}"
+    )
+    if _HAS_CONTENT_BLOCKS:
+        assert any(b.get("type") == "reasoning" for b in _content_blocks(merged)), (
+            f"{model_id}: streamed message missing a reasoning content block"
+        )
+
+
+@pytest.mark.requires("oci")
+@pytest.mark.parametrize("model_id", STANDARD_MODELS)
+def test_standard_model_streaming_no_reasoning(model_id: str) -> None:
+    """Standard models stream unchanged: no ``reasoning_content`` key is added."""
+    llm = _make_reasoning_llm(model_id)
+    chunks = list(llm.stream([HumanMessage(content="What is 17 * 23?")]))
+    assert chunks, f"{model_id}: stream yielded no chunks"
+    merged = _merge_stream(chunks)
+
+    assert isinstance(merged.content, str)
+    assert merged.additional_kwargs.get("reasoning_content") is None, (
+        f"{model_id}: unexpected streamed reasoning_content"
+    )
 
 
 @pytest.mark.requires("oci")

--- a/libs/oci/tests/unit_tests/chat_models/test_async_support.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_async_support.py
@@ -204,6 +204,73 @@ class TestChatOCIGenAIAsyncMixin:
             assert content == "Hello, world!"
 
     @pytest.mark.asyncio
+    async def test_astream_surfaces_reasoning(self, mock_oci_client, mock_signer):
+        """Async streaming accumulates reasoning deltas, at parity with sync.
+
+        Reasoning models (e.g. xAI Grok, OpenAI o-series) emit a separate
+        chain-of-thought channel on the raw stream's camelCase
+        ``message.reasoningContent``. ``_astream`` must carry each delta on
+        ``AIMessageChunk.additional_kwargs["reasoning_content"]`` so the merged
+        message exposes a standard ``reasoning`` content block — mirroring both
+        the non-streaming path and the sync ``_stream`` path. Before this change
+        the async path dropped reasoning while the sync path kept it.
+        """
+        _setup_base_client(mock_oci_client, mock_signer)
+        llm = ChatOCIGenAI(
+            model_id="xai.grok-3-mini",
+            compartment_id="test-compartment",
+            service_endpoint=(
+                "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+            ),
+            client=mock_oci_client,
+        )
+
+        # Reasoning is split across deltas, just like the live Grok stream.
+        stream_events: list[Dict[str, Any]] = [
+            {
+                "message": {
+                    "role": "ASSISTANT",
+                    "content": [{"type": "TEXT", "text": "5"}],
+                    "reasoningContent": "7 * 8 ",
+                }
+            },
+            {
+                "message": {
+                    "role": "ASSISTANT",
+                    "content": [{"type": "TEXT", "text": "6"}],
+                    "reasoningContent": "= 56.",
+                }
+            },
+            {"finishReason": "stop"},
+        ]
+
+        async def mock_chat_async(
+            *args: Any, **kwargs: Any
+        ) -> AsyncIterator[Dict[str, Any]]:
+            for event in stream_events:
+                yield event
+
+        with patch.object(OCIAsyncClient, "chat_async", side_effect=mock_chat_async):
+            chunks = [
+                chunk async for chunk in llm._astream([HumanMessage(content="7 * 8?")])
+            ]
+
+        merged = chunks[0].message
+        for chunk in chunks[1:]:
+            merged = merged + chunk.message
+
+        # Backward compat: the visible answer stays a plain string.
+        assert merged.content == "56"
+        # The streamed reasoning deltas accumulate into one reasoning string.
+        assert merged.additional_kwargs.get("reasoning_content") == "7 * 8 = 56."
+
+        # When langchain-core exposes content_blocks (>=1.0), reasoning also
+        # surfaces as a standard block — same contract as the non-streaming path.
+        blocks = getattr(merged, "content_blocks", None)
+        if blocks is not None:
+            assert {"type": "reasoning", "reasoning": "7 * 8 = 56."} in list(blocks)
+
+    @pytest.mark.asyncio
     async def test_agenerate_with_streaming_flag(self, llm):
         """Test that agenerate uses streaming when is_stream is True."""
         llm.is_stream = True

--- a/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
@@ -3,7 +3,7 @@
 
 """Test OCI Generative AI LLM service"""
 
-from typing import Optional, Union, cast
+from typing import Any, Optional, Union, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -1671,6 +1671,183 @@ class TestReasoningContentExtraction:
 
         result = llm.invoke([HumanMessage(content="What is 7 * 8?")])
         assert "reasoning_content" not in result.additional_kwargs
+
+
+# =============================================================================
+# Standard Content Blocks Contract (langchain-core v1 ``.content_blocks``)
+# =============================================================================
+
+# ``.content_blocks`` only exists on langchain-core >= 1.0 (the Python 3.10+
+# install). On the 3.9 / core-0.3.x matrix it is absent and these assertions
+# don't apply — the reasoning text still rides harmlessly in additional_kwargs.
+_HAS_CONTENT_BLOCKS = hasattr(AIMessage(content=""), "content_blocks")
+
+
+def _content_blocks(message: Any) -> list:
+    """Read ``.content_blocks`` via getattr.
+
+    The property only exists on langchain-core >= 1.0; on the py3.9 / core-0.3.x
+    matrix it is absent, so a direct attribute access trips mypy's attr-defined
+    check even though these tests are skipped at runtime there.
+    """
+    return list(getattr(message, "content_blocks"))
+
+
+def _make_generic_stream_events(
+    text_parts: list,
+    reasoning_parts: Optional[list] = None,
+    finish_reason: str = "stop",
+) -> list:
+    """Build Generic-provider streaming events (one delta per part).
+
+    Mirrors the real OCI stream schema (verified live against xai.grok-3-mini):
+    streaming events are raw JSON with camelCase keys, so reasoning rides on
+    ``message.reasoningContent`` (not snake_case). Each non-end event is
+    ``{"index", "message": {"role", "content": [{"type": "TEXT", "text"}],
+    "reasoningContent"?}}`` followed by a terminal ``{"finishReason"}`` event.
+    """
+    import json
+
+    reasoning_parts = reasoning_parts or [None] * len(text_parts)
+    events = []
+    for text, reasoning in zip(text_parts, reasoning_parts):
+        message: dict = {
+            "role": "ASSISTANT",
+            "content": [{"type": "TEXT", "text": text}],
+        }
+        if reasoning is not None:
+            message["reasoningContent"] = reasoning
+        events.append(MagicMock(data=json.dumps({"index": 0, "message": message})))
+    events.append(MagicMock(data=json.dumps({"finishReason": finish_reason})))
+    return events
+
+
+def _merge_stream(chunks: list):
+    """Concatenate streamed message chunks into a single message."""
+    merged = chunks[0]
+    for chunk in chunks[1:]:
+        merged = merged + chunk
+    return merged
+
+
+@pytest.mark.skipif(
+    not _HAS_CONTENT_BLOCKS, reason="content_blocks requires langchain-core>=1.0"
+)
+@pytest.mark.requires("oci")
+class TestStandardContentBlocks:
+    """Lock the langchain-core v1 ``.content_blocks`` contract for ChatOCIGenAI.
+
+    These tests double as the backward-compatibility guard: ``.content`` must
+    stay a plain ``str`` (never a block list), so existing code that reads
+    string content is unaffected.
+    """
+
+    def test_text_only_content_block_and_content_unchanged(self) -> None:
+        """Plain text -> single text block; ``.content`` stays a ``str``."""
+        oci_client = MagicMock()
+        llm = ChatOCIGenAI(model_id="meta.llama-3.3-70b-instruct", client=oci_client)
+        oci_client.chat.return_value = _make_reasoning_response(
+            text="Hello human!", reasoning_content=None
+        )
+
+        result = llm.invoke([HumanMessage(content="Hi")])
+
+        assert isinstance(result.content, str)
+        assert result.content == "Hello human!"
+        assert _content_blocks(result) == [{"type": "text", "text": "Hello human!"}]
+
+    def test_reasoning_block_non_streaming(self) -> None:
+        """Reasoning models -> a ``reasoning`` block precedes the ``text`` block."""
+        oci_client = MagicMock()
+        llm = ChatOCIGenAI(model_id="xai.grok-3-mini", client=oci_client)
+        oci_client.chat.return_value = _make_reasoning_response(
+            text="56", reasoning_content="7 * 8 = 56."
+        )
+
+        result = llm.invoke([HumanMessage(content="What is 7 * 8?")])
+
+        # Backward compat: visible answer is still a plain string.
+        assert isinstance(result.content, str)
+        assert result.content == "56"
+        # New: reasoning surfaces as a standard block, ahead of the answer.
+        blocks = _content_blocks(result)
+        assert {"type": "reasoning", "reasoning": "7 * 8 = 56."} in blocks
+        assert blocks[0]["type"] == "reasoning"
+        assert {"type": "text", "text": "56"} in blocks
+
+    def test_reasoning_block_streaming(self) -> None:
+        """Streamed reasoning deltas accumulate into a single reasoning block.
+
+        This is the gap the change closes: previously the streaming path dropped
+        ``reasoning_content`` entirely, so streamed ``.content_blocks`` had no
+        reasoning block while the non-streamed path did.
+        """
+        oci_client = MagicMock()
+        llm = ChatOCIGenAI(model_id="xai.grok-3-mini", client=oci_client)
+        mock_stream_response = MagicMock()
+        mock_stream_response.data.events.return_value = _make_generic_stream_events(
+            text_parts=["5", "6"],
+            reasoning_parts=["7 * 8 ", "= 56."],
+        )
+        oci_client.chat.return_value = mock_stream_response
+
+        merged = _merge_stream(list(llm.stream([HumanMessage(content="7 * 8?")])))
+
+        assert isinstance(merged.content, str)
+        assert merged.content == "56"
+        assert merged.additional_kwargs.get("reasoning_content") == "7 * 8 = 56."
+        reasoning_block = {"type": "reasoning", "reasoning": "7 * 8 = 56."}
+        assert reasoning_block in _content_blocks(merged)
+
+    def test_streaming_without_reasoning_is_unchanged(self) -> None:
+        """Non-reasoning models stream identically: no reasoning key/block added."""
+        oci_client = MagicMock()
+        llm = ChatOCIGenAI(model_id="meta.llama-3.3-70b-instruct", client=oci_client)
+        mock_stream_response = MagicMock()
+        mock_stream_response.data.events.return_value = _make_generic_stream_events(
+            text_parts=["Hello ", "world"],
+        )
+        oci_client.chat.return_value = mock_stream_response
+
+        merged = _merge_stream(list(llm.stream([HumanMessage(content="Hi")])))
+
+        assert isinstance(merged.content, str)
+        assert merged.content == "Hello world"
+        assert "reasoning_content" not in merged.additional_kwargs
+        assert all(b["type"] != "reasoning" for b in _content_blocks(merged))
+
+
+@pytest.mark.requires("oci")
+class TestStreamReasoningExtraction:
+    """Provider-level unit tests for the streaming reasoning hook."""
+
+    def test_generic_extracts_reasoning_delta(self) -> None:
+        from langchain_oci.chat_models.providers.generic import GenericProvider
+
+        event = {
+            "index": 0,
+            "message": {
+                "role": "ASSISTANT",
+                "content": [{"type": "TEXT", "text": "hi"}],
+                "reasoningContent": "thinking...",
+            },
+        }
+        assert GenericProvider().chat_stream_to_reasoning(event) == "thinking..."
+
+    def test_generic_no_reasoning_returns_empty(self) -> None:
+        from langchain_oci.chat_models.providers.generic import GenericProvider
+
+        event = {"index": 0, "message": {"content": [{"type": "TEXT", "text": "hi"}]}}
+        assert GenericProvider().chat_stream_to_reasoning(event) == ""
+        # Also tolerate end events / malformed messages.
+        end_event = {"finishReason": "stop"}
+        assert GenericProvider().chat_stream_to_reasoning(end_event) == ""
+
+    def test_base_default_returns_empty(self) -> None:
+        """The base default keeps non-overriding providers (e.g. Cohere) no-op."""
+        from langchain_oci.chat_models.providers.cohere import CohereProvider
+
+        assert CohereProvider().chat_stream_to_reasoning({"message": {}}) == ""
 
 
 @pytest.mark.requires("oci")


### PR DESCRIPTION
## Summary

`ChatOCIGenAI` already exposed model reasoning as a langchain-core v1 `reasoning`
content block on the **non-streaming** path (the `reasoning_content` rides in
`additional_kwargs`, which `AIMessage.content_blocks` lifts into a `reasoning`
block). The **streaming** path dropped it entirely — `chat_stream_generation_info`
returned only `finish_reason`, so a streamed message's `.content_blocks` had no
reasoning block even though `invoke()` did.

This PR brings streaming to parity.

## What changed

- **`Provider.chat_stream_to_reasoning`** — new hook with a base **no-op default**
  (`""`), so providers that don't override it (Cohere, data-science) are unchanged.
- **`GenericProvider`** overrides it to read the per-delta `message.reasoningContent`
  field. OCI streaming events are raw JSON with **camelCase** keys
  (`finishReason` / `toolCalls` / `reasoningContent`), unlike the **snake_case**
  non-streaming SDK object (`reasoning_content`) — verified live.
- **`_stream` / `_astream`** accumulate the delta into
  `AIMessageChunk.additional_kwargs["reasoning_content"]` (only when non-empty),
  which concatenates across chunks, so the merged message exposes a standard
  `reasoning` content block.

## Backward compatibility

Fully backward compatible:
- `.content` stays a `str` — no `output_version="v1"` / `model_provider` change.
- The `reasoning_content` key appears only when a model actually emits reasoning.
- Other providers are byte-identical via the base default.
- On langchain-core < 1.0 (py3.9 matrix) the key just sits harmlessly in
  `additional_kwargs`; the content-block tests skip.

## Testing

**Unit** (`tests/unit_tests/chat_models/`): added a content-blocks contract suite
(text / reasoning sync+stream / tool_call, plus an explicit assertion that
`.content` stays a `str`) and provider-level reasoning-extraction tests.
Full unit suite: **430 passed, 12 skipped**.

**Integration** (`tests/integration_tests/chat_models/test_chat_features.py`,
run live against OCI Generative AI, us-chicago-1): added live reasoning
content-block + streaming-reasoning assertions. Entire file: **28 passed**
across `xai.grok-3-mini-fast`, `openai.gpt-oss-120b`, `meta.llama-3.3-70b-instruct`,
`cohere.command-r-08-2024` — including all pre-existing chat features (chains,
stream/astream, tool calling, structured output), confirming no regression.

## Note: gpt-oss-120b reclassification

`conftest.py` moves `openai.gpt-oss-120b` from the standard list to the reasoning
list. The OCI deployment now surfaces reasoning on **both** `invoke` and `stream`;
it was previously null on `invoke`, which is why it had been listed as standard.
This is a test-fixture correction only — no library behavior change.

Closes #238
