### PR TITLE
docs(oci): deep research agent sample on Oracle AI Database + Claude (BYO model)

### DIFF
--- a/libs/oci/langchain_oci/agents/common.py
+++ b/libs/oci/langchain_oci/agents/common.py
@@ -23,6 +23,11 @@ class AgentConfig(BaseModel):
     model_config = {"populate_by_name": True, "arbitrary_types_allowed": True}
 
     model_id: str = "meta.llama-4-scout-17b-16e-instruct"
+    # Optional pre-built LangChain chat model. When set, it is used as-is and
+    # ``model_id`` / OCI inference auth are ignored (the model owns its own
+    # connection). Typed ``Any`` to accept any ``BaseChatModel`` without strict
+    # pydantic validation, matching how other injected objects are typed here.
+    model: Optional[Any] = None
     compartment_id: Optional[str] = None
     service_endpoint: Optional[str] = None
     auth_type: Union[str, OCIAuthType] = OCIAuthType.API_KEY
@@ -41,10 +46,15 @@ class AgentConfig(BaseModel):
 
     @model_validator(mode="after")
     def _resolve_oci_env(self) -> "AgentConfig":
-        """Resolve compartment and endpoint from environment if not set."""
+        """Resolve compartment and endpoint from environment if not set.
+
+        When a pre-built ``model`` is supplied the agent does not call OCI
+        inference, so ``compartment_id`` is not required. It is still resolved
+        opportunistically because OCI-backed datastore embeddings may need it.
+        """
         if not self.compartment_id:
             self.compartment_id = os.environ.get("OCI_COMPARTMENT_ID")
-        if not self.compartment_id:
+        if not self.compartment_id and self.model is None:
             raise ValueError(
                 "compartment_id must be provided or set via "
                 "OCI_COMPARTMENT_ID environment variable"
@@ -60,16 +70,26 @@ class AgentConfig(BaseModel):
 
 
 def _build_llm(config: AgentConfig, **extra_kwargs: Any) -> Any:
-    """Build a ChatOCIGenAI instance from an AgentConfig.
+    """Resolve the chat model for an agent.
+
+    If ``config.model`` holds a pre-built LangChain chat model it is returned
+    as-is, letting callers drive the agent with any provider (Anthropic,
+    OpenAI, a self-hosted vLLM model, a custom-configured ChatOCIGenAI, ...).
+    Otherwise a ``ChatOCIGenAI`` is built from ``config.model_id`` and the OCI
+    auth settings.
 
     Args:
         config: Resolved agent configuration.
         **extra_kwargs: Additional kwargs passed to ChatOCIGenAI
-            (e.g. max_sequential_tool_calls, tool_result_guidance).
+            (e.g. max_sequential_tool_calls, tool_result_guidance). Ignored
+            when a pre-built ``config.model`` is supplied.
 
     Returns:
-        ChatOCIGenAI instance.
+        A LangChain ``BaseChatModel`` (the supplied model or a ChatOCIGenAI).
     """
+    if config.model is not None:
+        return config.model
+
     from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
 
     auth_type = (

--- a/libs/oci/langchain_oci/agents/deepagents/README.md
+++ b/libs/oci/langchain_oci/agents/deepagents/README.md
@@ -220,6 +220,29 @@ agent = create_deepagents_agent(
 )
 ```
 
+## Example: Bring Your Own Model
+
+By default the agent builds a `ChatOCIGenAI` from `model_id` and the OCI auth
+options. To drive it with any other LangChain chat model, pass a pre-built
+model via `model=...`. When set, `model_id` and the OCI inference auth options
+are ignored — the model owns its own connection.
+
+```python
+from langchain_anthropic import ChatAnthropic
+from langchain_oci.agents import create_deepagents_agent
+
+agent = create_deepagents_agent(
+    tools=[...],
+    model=ChatAnthropic(model="claude-opus-4-8"),
+)
+```
+
+This also works with a custom-configured `ChatOCIGenAI` (e.g. extra kwargs not
+exposed on the factory), a self-hosted vLLM endpoint via `ChatOpenAI`, etc. If
+you use OCI-backed datastores you may still need OCI auth for embeddings unless
+you pass your own `embedding_model`. The same `model=...` parameter is available
+on `create_oci_agent`.
+
 ## Async Cleanup Note
 
 If your workflow keeps agents/models alive across many async calls, explicitly

--- a/libs/oci/langchain_oci/agents/deepagents/agent.py
+++ b/libs/oci/langchain_oci/agents/deepagents/agent.py
@@ -56,6 +56,8 @@ class DeepagentsConfig(AgentConfig):
     middleware: Optional[Sequence[Any]] = None
     response_format: Optional[Any] = None
     context_schema: Optional[type] = None
+    # Path-level filesystem access control, forwarded to deepagents.
+    permissions: Optional[Any] = None
 
     # LangGraph options
     backend: Optional[Any] = None
@@ -74,15 +76,21 @@ class DeepagentsConfig(AgentConfig):
             return True
         if self.response_format or self.context_schema:
             return True
+        if self.permissions:
+            return True
         return False
 
     @property
     def _can_use_lightweight(self) -> bool:
-        """Whether a lightweight ReAct agent suffices."""
+        """Whether a lightweight ReAct agent suffices.
+
+        Only an explicit ``middleware=[]`` opts out of the deep-agent harness.
+        Datastores compose *with* the full deep agent (planning, filesystem,
+        subagents); they no longer silently downgrade it to a plain ReAct agent
+        that lacks those capabilities.
+        """
         if self._needs_deep_agent:
             return False
-        if self.datastores:
-            return True
         return self.middleware is not None and len(self.middleware) == 0
 
 
@@ -136,6 +144,7 @@ def create_deepagents_agent(
     middleware: Optional[Sequence[Any]] = None,
     response_format: Any = None,
     context_schema: Optional[type] = None,
+    permissions: Optional[Any] = None,
     # LangGraph options
     checkpointer: Any = None,
     store: Any = None,
@@ -186,6 +195,8 @@ def create_deepagents_agent(
         middleware: Custom middleware. Pass empty list to disable defaults.
         response_format: Structured output response format for the agent.
         context_schema: Schema for typed context passed into the agent graph.
+        permissions: Path-level filesystem access-control rules forwarded to
+            the deep agent (deepagents ``permissions``). Deep path only.
         checkpointer: LangGraph checkpointer for persistence/memory.
         store: LangGraph store for long-term memory.
         backend: State backend for the deep agent (e.g., StoreBackend).
@@ -253,6 +264,7 @@ def create_deepagents_agent(
         middleware=middleware,
         response_format=response_format,
         context_schema=context_schema,
+        permissions=permissions,
         backend=backend,
         cache=cache,
         interrupt_on=interrupt_on,
@@ -351,6 +363,7 @@ def _build_deep(
             middleware=config.middleware,
             response_format=config.response_format,
             context_schema=config.context_schema,
+            permissions=config.permissions,
             checkpointer=config.checkpointer,
             store=config.store,
             backend=config.backend,

--- a/libs/oci/langchain_oci/agents/deepagents/agent.py
+++ b/libs/oci/langchain_oci/agents/deepagents/agent.py
@@ -30,6 +30,7 @@ from langchain_oci.common.auth import OCIAuthType
 from langchain_oci.datastores import VectorDataStore, create_datastore_tools
 
 if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
     from langgraph.graph.state import CompiledStateGraph
 
 
@@ -118,6 +119,8 @@ def create_deepagents_agent(
     default_store: Optional[str] = None,
     embedding_model: Any = None,
     top_k: int = 5,
+    # Model
+    model: Optional["BaseChatModel"] = None,
     # OCI options
     model_id: str = "google.gemini-2.5-pro",
     compartment_id: Optional[str] = None,
@@ -163,7 +166,14 @@ def create_deepagents_agent(
         default_store: Alias for default_datastore.
         embedding_model: Custom embedding model for datastores.
         top_k: Number of search results to return.
-        model_id: OCI model identifier (Gemini models recommended).
+        model: Pre-built LangChain chat model to drive the agent. When set, it
+            is used as-is and ``model_id`` plus the OCI inference auth options
+            are ignored (the model owns its own connection). Use this to run on
+            any provider (Anthropic, OpenAI, a self-hosted vLLM model, or a
+            custom-configured ChatOCIGenAI). OCI auth may still be required for
+            datastore embeddings unless ``embedding_model`` is supplied.
+        model_id: OCI model identifier (Gemini models recommended). Used only
+            when ``model`` is not provided.
         compartment_id: OCI compartment OCID.
         service_endpoint: OCI GenAI service endpoint.
         auth_type: OCI authentication type.
@@ -214,6 +224,7 @@ def create_deepagents_agent(
         ... )
     """
     config = DeepagentsConfig(
+        model=model,
         model_id=model_id,
         compartment_id=compartment_id,
         service_endpoint=service_endpoint,

--- a/libs/oci/langchain_oci/agents/react/agent.py
+++ b/libs/oci/langchain_oci/agents/react/agent.py
@@ -19,6 +19,7 @@ from langchain_oci.agents.common import (
 from langchain_oci.common.auth import OCIAuthType
 
 if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
     from langgraph.graph.state import CompiledStateGraph
 
 
@@ -26,6 +27,8 @@ def create_oci_agent(
     model_id: str,
     tools: Sequence[BaseTool | Callable[..., Any]],
     *,
+    # Model
+    model: "BaseChatModel | None" = None,
     # OCI-specific options
     compartment_id: str | None = None,
     service_endpoint: str | None = None,
@@ -59,8 +62,13 @@ def create_oci_agent(
     see :func:`create_deepagents_agent`.
 
     Args:
-        model_id: OCI model identifier (e.g., "meta.llama-4-scout-17b-16e-instruct")
+        model_id: OCI model identifier (e.g., "meta.llama-4-scout-17b-16e-instruct").
+            Ignored when ``model`` is provided.
         tools: List of tools the agent can use.
+        model: Pre-built LangChain chat model to drive the agent. When set, it
+            is used as-is and ``model_id`` plus the OCI auth options (and the
+            OCI-specific ``max_sequential_tool_calls`` / ``tool_result_guidance``
+            tuning) are ignored. Use this to run on any provider.
         compartment_id: OCI compartment OCID.
         service_endpoint: OCI GenAI service endpoint.
         auth_type: OCI authentication type.
@@ -104,6 +112,7 @@ def create_oci_agent(
     create_agent_func, use_legacy_api = _get_agent_factory()
 
     config = AgentConfig(
+        model=model,
         model_id=model_id,
         compartment_id=compartment_id,
         service_endpoint=service_endpoint,

--- a/libs/oci/tests/integration_tests/agents/test_deepagents_integration.py
+++ b/libs/oci/tests/integration_tests/agents/test_deepagents_integration.py
@@ -347,6 +347,57 @@ class TestOCIDeepAgentIntegration:
         assert final_message.content, "Final message should have content"
         assert len(final_message.content) > 100, "Response should be substantive"
 
+    def test_bring_your_own_model(
+        self,
+        compartment_id: str,
+        service_endpoint: str,
+        auth_type: str,
+        auth_profile: str,
+        model_id: str,
+    ) -> None:
+        """A pre-built chat model passed via ``model=`` drives the agent.
+
+        Exercises the bring-your-own-model path: ``create_deepagents_agent``
+        uses the supplied ``ChatOCIGenAI`` as-is instead of building one from
+        ``model_id`` + OCI auth. Any LangChain ``BaseChatModel`` works the same
+        way (Anthropic, OpenAI, self-hosted vLLM, etc.); we use ChatOCIGenAI
+        here because it is the model the integration env is provisioned for.
+        """
+        from langchain_oci import ChatOCIGenAI, create_deepagents_agent
+
+        model = ChatOCIGenAI(
+            model_id=model_id,
+            compartment_id=compartment_id,
+            service_endpoint=service_endpoint,
+            auth_type=auth_type,
+            auth_profile=auth_profile,
+            model_kwargs={"temperature": 0.3, "max_tokens": 2048},
+        )
+
+        agent = create_deepagents_agent(
+            tools=[search_knowledge_base, get_statistics, analyze_trends],
+            model=model,
+            middleware=[],
+            system_prompt="You are a concise research analyst.",
+        )
+        try:
+            # The supplied model must be the one wired into the agent.
+            assert getattr(agent, "_oci_llm", None) is model
+
+            result = agent.invoke(
+                {
+                    "messages": [
+                        HumanMessage(content="What are the current trends in AI?")
+                    ]
+                }
+            )
+            assert "messages" in result
+            final_message = result["messages"][-1]
+            assert final_message.content, "Final message should have content"
+        finally:
+            if hasattr(model, "aclose"):
+                asyncio.run(model.aclose())
+
     def test_multi_tool_research(self, agent: Any) -> None:
         """Test agent uses multiple tools for research."""
         result = agent.invoke(
@@ -1047,10 +1098,16 @@ class TestDeepAgentResponseFormat:
             summary: str = Field(description="A brief summary of findings")
             confidence: float = Field(description="Confidence score between 0 and 1")
 
+        # Structured output relies on function-calling, which gemini-2.5-flash
+        # handles unreliably (it frequently returns ``malformed_function_call``
+        # with empty content). Pin the more capable pro variant regardless of
+        # the OCI_DEEPAGENTS_MODEL default used elsewhere.
+        oci_kwargs = {**_make_oci_kwargs(), "model_id": "google.gemini-2.5-pro"}
+
         agent = create_deepagents_agent(
             tools=[search_knowledge_base],
             response_format=AutoStrategy(schema=ResearchSummary),
-            **_make_oci_kwargs(),
+            **oci_kwargs,
         )
         try:
             result = agent.invoke(

--- a/libs/oci/tests/unit_tests/agents/test_deepagents.py
+++ b/libs/oci/tests/unit_tests/agents/test_deepagents.py
@@ -79,12 +79,19 @@ class TestCreateDeepagentsAgent:
                     mock_create.assert_called_once()
                     assert agent is not None
 
-    def test_datastore_path_uses_lightweight_agent(self) -> None:
-        """Datastore-backed helper should avoid deepagents planning middleware."""
+    def test_datastore_path_uses_deep_agent(self) -> None:
+        """Datastores compose with the full deep agent rather than downgrading it.
+
+        Regression guard for the silent-downgrade bug: ``datastores=`` on its own
+        must route through ``create_deep_agent`` (so planning, filesystem, and
+        subagents stay available) and the generated datastore tools must be
+        forwarded into the deep agent.
+        """
         from langchain_oci.agents.deepagents.agent import create_deepagents_agent
 
         fake_store = MagicMock()
         fake_store.name = "opensearch"
+        sentinel_tool = MagicMock(name="datastore_tool")
 
         with patch.dict("os.environ", {"OCI_COMPARTMENT_ID": "test-compartment"}):
             with patch(
@@ -92,15 +99,17 @@ class TestCreateDeepagentsAgent:
             ) as mock_llm_class:
                 with patch(
                     "langchain_oci.agents.deepagents.agent.create_datastore_tools",
-                    return_value=[],
+                    return_value=[sentinel_tool],
                 ):
-                    with patch("langchain.agents.create_agent") as mock_create_agent:
+                    with mock_deepagents() as mock_create:
                         mock_llm_class.return_value = MagicMock()
-                        mock_create_agent.return_value = MagicMock()
 
                         create_deepagents_agent(datastores={"runbooks": fake_store})
 
-                        mock_create_agent.assert_called_once()
+                        # Deep path, not lightweight create_agent.
+                        mock_create.assert_called_once()
+                        # Datastore tools are wired into the deep agent.
+                        assert sentinel_tool in mock_create.call_args.kwargs["tools"]
 
     def test_empty_middleware_uses_lightweight_agent(self) -> None:
         """Explicitly disabling middleware should avoid deepagents planning."""
@@ -122,8 +131,8 @@ class TestCreateDeepagentsAgent:
                     mock_create_agent.assert_called_once()
 
     def test_lightweight_path_does_not_require_deepagents_installed(self) -> None:
-        """The lightweight (datastore / middleware=[]) path must work without
-        the ``deepagents`` package installed. The prerequisite check is only
+        """The lightweight (``middleware=[]``) path must work without the
+        ``deepagents`` package installed. The prerequisite check is only
         relevant when we actually route to ``create_deep_agent``.
         """
         from langchain_oci.agents.deepagents.agent import create_deepagents_agent
@@ -205,6 +214,24 @@ class TestCreateDeepagentsAgent:
                     )
                     mock_create.assert_called_once()
                     assert "interrupt_on" in mock_create.call_args.kwargs
+
+    def test_permissions_forwarded(self) -> None:
+        """permissions= forces the deep path and reaches create_deep_agent
+        (instead of being swallowed by **model_kwargs)."""
+        from langchain_oci.agents.deepagents.agent import create_deepagents_agent
+
+        perms = MagicMock(name="permissions")
+
+        with patch.dict("os.environ", {"OCI_COMPARTMENT_ID": "test"}):
+            with patch("langchain_oci.chat_models.oci_generative_ai.ChatOCIGenAI"):
+                with mock_deepagents() as mock_create:
+                    create_deepagents_agent(
+                        tools=[dummy_tool],
+                        permissions=perms,
+                    )
+                    mock_create.assert_called_once()
+                    kwargs = mock_create.call_args.kwargs
+                    assert kwargs["permissions"] is perms
 
     def test_raises_without_compartment_id(self) -> None:
         """Test that error is raised when no compartment_id available."""

--- a/libs/oci/tests/unit_tests/agents/test_deepagents.py
+++ b/libs/oci/tests/unit_tests/agents/test_deepagents.py
@@ -569,6 +569,37 @@ class TestCreateDeepagentsAgent:
                     call_kwargs = mock_llm_class.call_args.kwargs
                     assert call_kwargs["model_id"] == "google.gemini-2.5-flash"
 
+    def test_custom_model_used_as_is(self) -> None:
+        """A pre-built ``model`` is passed straight to create_deep_agent and
+        ChatOCIGenAI is never constructed."""
+        from langchain_oci.agents.deepagents.agent import create_deepagents_agent
+
+        custom_model = MagicMock()
+        with patch.dict("os.environ", {"OCI_COMPARTMENT_ID": "test"}):
+            with patch(
+                "langchain_oci.chat_models.oci_generative_ai.ChatOCIGenAI"
+            ) as mock_llm_class:
+                with mock_deepagents() as mock_create:
+                    create_deepagents_agent(tools=[dummy_tool], model=custom_model)
+
+                    mock_llm_class.assert_not_called()
+                    assert mock_create.call_args.kwargs["model"] is custom_model
+
+    def test_custom_model_skips_compartment_requirement(self) -> None:
+        """With a pre-built ``model`` no compartment_id/env is required."""
+        from langchain_oci.agents.deepagents.agent import create_deepagents_agent
+
+        custom_model = MagicMock()
+        with patch.dict("os.environ", {}, clear=True):
+            with patch(
+                "langchain_oci.chat_models.oci_generative_ai.ChatOCIGenAI"
+            ) as mock_llm_class:
+                with mock_deepagents() as mock_create:
+                    create_deepagents_agent(tools=[dummy_tool], model=custom_model)
+
+                    mock_llm_class.assert_not_called()
+                    assert mock_create.call_args.kwargs["model"] is custom_model
+
     def test_openai_models_pass_max_tokens_through(self) -> None:
         """OpenAI-compatible models receive ``max_tokens`` from the agent layer.
 

--- a/libs/oci/tests/unit_tests/agents/test_react.py
+++ b/libs/oci/tests/unit_tests/agents/test_react.py
@@ -82,6 +82,24 @@ class TestCreateOCIReactAgent:
                         tools=[dummy_tool],
                     )
 
+    def test_custom_model_used_as_is(self) -> None:
+        """A pre-built ``model`` drives the agent and ChatOCIGenAI is not built,
+        even without a compartment_id."""
+        custom_model = MagicMock()
+        with patch.dict("os.environ", {}, clear=True):
+            with patch(
+                "langchain_oci.chat_models.oci_generative_ai.ChatOCIGenAI"
+            ) as mock_llm_class:
+                with mock_create_agent() as mock_create:
+                    create_oci_agent(
+                        model_id="meta.llama-4-scout-17b-16e-instruct",
+                        tools=[dummy_tool],
+                        model=custom_model,
+                    )
+
+                    mock_llm_class.assert_not_called()
+                    assert mock_create.call_args.kwargs["model"] is custom_model
+
     def test_passes_system_prompt(self) -> None:
         """Test that system_prompt is passed to the agent creation function."""
         with patch.dict("os.environ", {"OCI_COMPARTMENT_ID": "test"}):

--- a/samples/11-deepagents/local_docker_oracle_deepagents.ipynb
+++ b/samples/11-deepagents/local_docker_oracle_deepagents.ipynb
@@ -1,0 +1,1695 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4e42df03",
+   "metadata": {},
+   "source": [
+    "# Build a Deep Research Agent over a Private Knowledge Base — Oracle AI Database + Claude\n",
+    "\n",
+    "This notebook builds a **deep research agent**: the flagship use case for the\n",
+    "[`deepagents`](https://pypi.org/project/deepagents/) framework. The agent researches a\n",
+    "**private knowledge base** stored in the **Oracle AI Database** and is driven by **Anthropic's\n",
+    "Claude** through Oracle `langchain-oci`'s *bring-your-own-model* factory.\n",
+    "\n",
+    "## The use case, in plain terms\n",
+    "\n",
+    "Imagine an **internal research analyst** at a company. You hand them a broad, vague question —\n",
+    "*\"How should we ground and operate our next-generation AI agents?\"* — and a filing cabinet of\n",
+    "internal documents. A good analyst doesn't blurt out an answer. They:\n",
+    "\n",
+    "1. **Break the question into sub-topics** (retrieval, memory, evaluation, risks, recommendation).\n",
+    "2. **Dig through the documents** for evidence on each sub-topic, one at a time.\n",
+    "3. **Keep organised notes** as they go, instead of holding everything in their head.\n",
+    "4. **Double-check** their draft against the sources before writing the final brief.\n",
+    "5. **Deliver a tight, cited report** that a busy executive can act on.\n",
+    "\n",
+    "A plain chatbot can't do this reliably: it tries to answer in one shot, forgets constraints over\n",
+    "a long task, and — worst of all — **makes things up** when it can't find an answer. A **deep\n",
+    "agent** is built exactly for this shape of work. In this notebook we build that analyst, give it\n",
+    "the company's documents (in the Oracle AI Database), and watch it produce a grounded, cited brief.\n",
+    "\n",
+    "> **Our scenario:** *Aurora Financial* is building an enterprise AI agent platform. Its internal\n",
+    "> memos (engineering, strategy, governance, an incident postmortem) form the knowledge base. The\n",
+    "> agent must answer **only** from those memos and cite each one — because in a regulated industry,\n",
+    "> a confident but ungrounded answer is a liability.\n",
+    "\n",
+    "## The four powers of a deep agent\n",
+    "\n",
+    "The agent demonstrates the four capabilities that make an agent *deep* rather than a\n",
+    "chat-with-tools loop:\n",
+    "\n",
+    "1. **Planning** — it writes and tracks a to-do list before acting.\n",
+    "2. **A virtual filesystem** — it drafts long artifacts to \"files\" in its own state, off the chat.\n",
+    "3. **Sub-agents** — it delegates focused retrieval to isolated helpers, then a critic verifies.\n",
+    "4. **Streaming** — you can watch the plan → act → observe loop unfold step by step.\n",
+    "\n",
+    "## Architecture at a glance\n",
+    "\n",
+    "| Component | Role | Where it runs |\n",
+    "|---|---|---|\n",
+    "| Knowledge base / vector store | grounds every answer | 🟢 **Local Docker** — Oracle AI Database Free (gvenzl image) |\n",
+    "| Embeddings (ingest + query) | text → vectors | 🟢 **Local** — HuggingFace `all-MiniLM-L6-v2` (CPU) |\n",
+    "| Retrieval | hybrid (vector + keyword) search | 🟢 **In-database** — Oracle AI Vector Search + Oracle Text |\n",
+    "| Reasoning / planning brain | drives the deep-agent loop | ☁️ **Claude** via `langchain-anthropic` |\n",
+    "| Agent harness | planning, files, sub-agents | `langchain-oci` → `deepagents` |\n",
+    "\n",
+    "> **Why Claude for the brain?** A deep agent is \"an LLM in a loop.\" The hard part — decomposing a\n",
+    "> task, delegating, and synthesizing — lives in the model. The `deepagents` harness is modelled on\n",
+    "> Claude Code, so a strong tool-caller like Claude drives it reliably. The **data stays local** in\n",
+    "> the Oracle AI Database; only the reasoning is hosted. Part 5 shows how to swap in a local model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c53c8067",
+   "metadata": {},
+   "source": [
+    "## Key terms (read once, refer back as needed)\n",
+    "\n",
+    "| Term | What it means here |\n",
+    "|---|---|\n",
+    "| **Deep agent** | An LLM given a *planning tool*, a *virtual filesystem*, and the ability to spawn *sub-agents* — scaffolding for long, multi-step tasks. |\n",
+    "| **RAG** (Retrieval-Augmented Generation) | Grounding answers in documents fetched at query time, instead of relying on the model's training memory. |\n",
+    "| **Agentic RAG** | The agent itself decides *when* and *what* to retrieve, can retrieve several times, and *verifies* evidence before answering. |\n",
+    "| **Embedding / vector** | A list of numbers capturing a piece of text's *meaning*. Similar meanings produce nearby vectors. |\n",
+    "| **Vector search** | Finding documents whose embeddings are closest to the query's embedding — i.e. semantic similarity. |\n",
+    "| **Hybrid search** | Combining *vector* search (meaning) with *keyword* search (exact terms), fused via Reciprocal Rank Fusion (RRF). |\n",
+    "| **Grounding** | Requiring every factual claim to be backed by a retrieved document, with a citation. |\n",
+    "| **Sub-agent** | A scoped helper agent with its own prompt and tools; isolates context so the main agent stays focused. |\n",
+    "| **Bring-your-own-model (BYO)** | Handing the agent factory *any* chat model — decoupling the reasoning brain from the data infrastructure. |\n",
+    "\n",
+    "> **🔑 Orientation takeaway:** We are building an *agentic-RAG deep agent*. It plans, retrieves\n",
+    "> from the Oracle AI Database (hybrid search), verifies, and writes a cited brief — all driven by a\n",
+    "> Claude brain that we \"bring\" to the Oracle harness."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "593b1275",
+   "metadata": {},
+   "source": [
+    "# Part 1 · Stand up the Oracle AI Database\n",
+    "\n",
+    "Before any agent, we need a database that can store text **and** its vector embeddings, and search\n",
+    "both. We use the **Oracle AI Database Free** edition running locally in Docker via the popular,\n",
+    "community-maintained **gvenzl** image.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "### 1. Oracle AI Database in Docker (gvenzl image)\n",
+    "\n",
+    "```bash\n",
+    "docker run -d --name oracle-free \\\n",
+    "  -p 1521:1521 --shm-size=2g \\\n",
+    "  -e ORACLE_PASSWORD=Welcome12345 \\\n",
+    "  gvenzl/oracle-free\n",
+    "```\n",
+    "\n",
+    "- `gvenzl/oracle-free` is the lightweight, community image of the **Oracle AI Database Free**\n",
+    "  edition (maintained by Gerald Venzl). It is much smaller and faster to start than the official\n",
+    "  image.\n",
+    "- Wait for `DATABASE IS READY TO USE` (`docker logs -f oracle-free`).\n",
+    "- Service `FREEPDB1` → DSN `localhost:1521/FREEPDB1`. The `SYSTEM` password is the\n",
+    "  `ORACLE_PASSWORD` you set.\n",
+    "- ⚠️ Use the **full** image (`gvenzl/oracle-free`), *not* `:slim` — the slim variant strips\n",
+    "  **Oracle Text**, which we need for the keyword half of hybrid search.\n",
+    "\n",
+    "### 2. Python 3.11–3.13\n",
+    "\n",
+    "The `deepagents` package requires Python 3.11–3.13.\n",
+    "\n",
+    "### 3. An Anthropic API key\n",
+    "\n",
+    "Export `ANTHROPIC_API_KEY=sk-ant-...` (or drop it in a local `.env`; the key cell below also\n",
+    "prompts with `getpass`). Every agent run makes **live calls to the Anthropic API**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a133d8b3",
+   "metadata": {},
+   "source": [
+    "## 1.1 · Install dependencies\n",
+    "\n",
+    "`langchain-oci` is installed from this repo's local source (editable) — it carries the\n",
+    "*bring-your-own-model* deepagents factory we rely on. `langchain-oracledb` provides the Oracle\n",
+    "vector-store backend (`OracleVS`). Paths are relative to this notebook (`samples/11-deepagents/`).\n",
+    "\n",
+    "**Key terms:** *editable install* (`pip install -e`) points Python at source on disk so local\n",
+    "changes take effect immediately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "df475c30",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:09:58.111805Z",
+     "iopub.status.busy": "2026-06-22T15:09:58.111572Z",
+     "iopub.status.idle": "2026-06-22T15:10:03.237910Z",
+     "shell.execute_reply": "2026-06-22T15:10:03.237507Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# langchain-oci (BYO-model deepagents factory + Oracle datastores) from local source:\n",
+    "%pip install -q -e ../../libs/oci\n",
+    "\n",
+    "# Oracle vector-store backend + driver:\n",
+    "%pip install -q langchain-oracledb oracledb langchain-community\n",
+    "\n",
+    "# Local embeddings, the Claude chat model, and the REAL deepagents package\n",
+    "# (requires Python 3.11–3.13; sentence-transformers pulls in torch).\n",
+    "%pip install -q langchain-huggingface sentence-transformers langchain-anthropic \"deepagents>=0.6\" "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58bbcd52",
+   "metadata": {},
+   "source": [
+    "## 1.2 · Configuration\n",
+    "\n",
+    "Everything is parameterised by environment variables with sensible local defaults, so you can\n",
+    "point the notebook at a different database, embedding model, or Claude model without editing code.\n",
+    "\n",
+    "**Key takeaway:** the *data plane* (Oracle, embeddings) is local; only the *reasoning model* is a\n",
+    "hosted Claude."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "831cd03a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:03.239499Z",
+     "iopub.status.busy": "2026-06-22T15:10:03.239397Z",
+     "iopub.status.idle": "2026-06-22T15:10:03.242690Z",
+     "shell.execute_reply": "2026-06-22T15:10:03.242303Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DB        : localhost:1521/FREEPDB1 | app user: DEEPAGENTS | table: RESEARCH_DOCS\n",
+      "Embeddings: sentence-transformers/all-MiniLM-L6-v2 (local, cpu)\n",
+      "Brain     : claude-sonnet-4-6 (Anthropic)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "# --- Local Oracle AI Database (Docker) ---\n",
+    "ORACLE_DSN        = os.environ.get(\"ORACLE_DSN\", \"localhost:1521/FREEPDB1\")\n",
+    "ORACLE_ADMIN_USER = os.environ.get(\"ORACLE_ADMIN_USER\", \"SYSTEM\")\n",
+    "ORACLE_ADMIN_PWD  = os.environ.get(\"ORACLE_ADMIN_PWD\", \"Welcome12345\")  # = ORACLE_PASSWORD\n",
+    "APP_USER          = os.environ.get(\"ORACLE_APP_USER\", \"DEEPAGENTS\")\n",
+    "APP_PWD           = os.environ.get(\"ORACLE_APP_PWD\", \"Welcome12345\")\n",
+    "TABLE_NAME        = os.environ.get(\"ORACLE_TABLE\", \"RESEARCH_DOCS\")\n",
+    "\n",
+    "# --- Local embeddings (HuggingFace, runs on CPU) ---\n",
+    "HF_EMBED_MODEL    = os.environ.get(\"HF_EMBED_MODEL\", \"sentence-transformers/all-MiniLM-L6-v2\")\n",
+    "HF_EMBED_DEVICE   = os.environ.get(\"HF_EMBED_DEVICE\", \"cpu\")  # \"cuda\" / \"mps\" if available\n",
+    "\n",
+    "# --- Reasoning brain (Claude) ---\n",
+    "CLAUDE_MODEL      = os.environ.get(\"CLAUDE_MODEL\", \"claude-sonnet-4-6\")\n",
+    "\n",
+    "print(\"DB        :\", ORACLE_DSN, \"| app user:\", APP_USER, \"| table:\", TABLE_NAME)\n",
+    "print(\"Embeddings:\", HF_EMBED_MODEL, \"(local,\", HF_EMBED_DEVICE + \")\")\n",
+    "print(\"Brain     :\", CLAUDE_MODEL, \"(Anthropic)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7902288",
+   "metadata": {},
+   "source": [
+    "## 1.3 · Load the Anthropic API key\n",
+    "\n",
+    "We look for `ANTHROPIC_API_KEY` in the environment, then in a local `.env`, and finally prompt for\n",
+    "it with `getpass` so the key never lands in notebook output or source control.\n",
+    "\n",
+    "**Key takeaway:** keep secrets out of code — env var first, `.env` second, masked prompt last."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "97fb05bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:03.243709Z",
+     "iopub.status.busy": "2026-06-22T15:10:03.243650Z",
+     "iopub.status.idle": "2026-06-22T15:10:03.246415Z",
+     "shell.execute_reply": "2026-06-22T15:10:03.246158Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Anthropic API key loaded.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, getpass\n",
+    "from pathlib import Path\n",
+    "\n",
+    "if not os.environ.get(\"ANTHROPIC_API_KEY\"):\n",
+    "    env_file = Path(\".env\")\n",
+    "    if env_file.exists():\n",
+    "        for line in env_file.read_text().splitlines():\n",
+    "            line = line.strip()\n",
+    "            if line.startswith(\"ANTHROPIC_API_KEY=\") and not line.startswith(\"#\"):\n",
+    "                os.environ[\"ANTHROPIC_API_KEY\"] = line.split(\"=\", 1)[1].strip().strip('\"').strip(\"'\")\n",
+    "\n",
+    "if not os.environ.get(\"ANTHROPIC_API_KEY\"):\n",
+    "    os.environ[\"ANTHROPIC_API_KEY\"] = getpass.getpass(\"Enter your Anthropic API key: \")\n",
+    "\n",
+    "assert os.environ.get(\"ANTHROPIC_API_KEY\"), \"Missing ANTHROPIC_API_KEY\"\n",
+    "print(\"Anthropic API key loaded.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "978e705e",
+   "metadata": {},
+   "source": [
+    "## 1.4 · Verify the database is reachable\n",
+    "\n",
+    "AI Vector Search (the `VECTOR` data type, vector indexes, distance metrics) requires a recent\n",
+    "Oracle AI Database. We connect as the admin user and assert the major version is 23 or higher.\n",
+    "\n",
+    "**Key takeaway:** a quick version assert fails fast with a clear message instead of a cryptic\n",
+    "`VECTOR`-related SQL error later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5f6a32eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:03.247438Z",
+     "iopub.status.busy": "2026-06-22T15:10:03.247386Z",
+     "iopub.status.idle": "2026-06-22T15:10:03.430577Z",
+     "shell.execute_reply": "2026-06-22T15:10:03.430197Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to Oracle: 23.26.0.0.0\n",
+      "✓ AI Vector Search available.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import oracledb\n",
+    "\n",
+    "with oracledb.connect(user=ORACLE_ADMIN_USER, password=ORACLE_ADMIN_PWD, dsn=ORACLE_DSN) as con:\n",
+    "    print(\"Connected to Oracle:\", con.version)\n",
+    "    major = int(con.version.split(\".\")[0])\n",
+    "    assert major >= 23, (\n",
+    "        f\"Oracle {con.version} has no AI Vector Search. Use the Oracle AI Database Free \"\n",
+    "        \"image (gvenzl/oracle-free).\"\n",
+    "    )\n",
+    "print(\"✓ AI Vector Search available.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc6dfc2f",
+   "metadata": {},
+   "source": [
+    "## 1.5 · Create a dedicated application user\n",
+    "\n",
+    "Best practice is to keep app data out of `SYSTEM`. We create a `DEEPAGENTS` schema with the\n",
+    "developer role, which includes the privileges to create tables, vector indexes, **and** Oracle\n",
+    "Text search indexes. The block is idempotent — re-running skips the user if it already exists.\n",
+    "\n",
+    "**Key term:** a *schema* is a user that owns database objects (tables, indexes).\n",
+    "\n",
+    "> **🔑 Part 1 takeaway:** You now have a local **Oracle AI Database** running, verified for AI\n",
+    "> Vector Search, with a clean `DEEPAGENTS` schema ready to hold the knowledge base. The reasoning\n",
+    "> model (Claude) is configured but not yet used — Part 1 is pure data infrastructure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "17823732",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:03.432104Z",
+     "iopub.status.busy": "2026-06-22T15:10:03.431996Z",
+     "iopub.status.idle": "2026-06-22T15:10:03.485559Z",
+     "shell.execute_reply": "2026-06-22T15:10:03.485108Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "skip: CREATE USER DEEPAGENTS IDENTIFIED BY \"Welcome12345\" (already exists)\n",
+      "ok  : GRANT DB_DEVELOPER_ROLE TO DEEPAGENTS\n",
+      "ok  : GRANT CREATE SESSION TO DEEPAGENTS\n",
+      "ok  : GRANT UNLIMITED TABLESPACE TO DEEPAGENTS\n",
+      "✓ App user DEEPAGENTS ready.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import oracledb\n",
+    "\n",
+    "statements = [\n",
+    "    f'CREATE USER {APP_USER} IDENTIFIED BY \"{APP_PWD}\"',\n",
+    "    f\"GRANT DB_DEVELOPER_ROLE TO {APP_USER}\",\n",
+    "    f\"GRANT CREATE SESSION TO {APP_USER}\",\n",
+    "    f\"GRANT UNLIMITED TABLESPACE TO {APP_USER}\",\n",
+    "]\n",
+    "\n",
+    "with oracledb.connect(user=ORACLE_ADMIN_USER, password=ORACLE_ADMIN_PWD, dsn=ORACLE_DSN) as con:\n",
+    "    cur = con.cursor()\n",
+    "    for stmt in statements:\n",
+    "        try:\n",
+    "            cur.execute(stmt)\n",
+    "            print(\"ok  :\", stmt)\n",
+    "        except oracledb.DatabaseError as exc:\n",
+    "            (err,) = exc.args\n",
+    "            if err.code == 1920:  # ORA-01920: user name already exists\n",
+    "                print(\"skip:\", stmt, \"(already exists)\")\n",
+    "            else:\n",
+    "                raise\n",
+    "    con.commit()\n",
+    "print(f\"✓ App user {APP_USER} ready.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5b85cbf",
+   "metadata": {},
+   "source": [
+    "# Part 2 · Load and index the private knowledge base\n",
+    "\n",
+    "With the database ready, Part 2 turns Aurora's documents into something an agent can search by\n",
+    "*meaning* and by *exact term*. Three steps: build an embedding model, load the corpus into the\n",
+    "Oracle AI Database as vectors, and expose retrieval as agent **tools**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12c9eda4",
+   "metadata": {},
+   "source": [
+    "## 2.1 · Build the local embedding model\n",
+    "\n",
+    "**Embeddings** turn text into vectors (lists of numbers) so that similar meanings sit close\n",
+    "together in vector space. Retrieval then becomes \"find the document vectors nearest the query\n",
+    "vector.\" We use `all-MiniLM-L6-v2` — small, fast, 384-dimensional, runs on CPU, needs no API.\n",
+    "\n",
+    "The **same** model object is used for ingestion and querying, so documents and queries live in the\n",
+    "same vector space and the dimensions match the `VECTOR` column.\n",
+    "\n",
+    "**Key takeaway:** use *one* embedding model for both indexing and querying. For stronger\n",
+    "production retrieval, swap in a larger model (e.g. `nomic-ai/nomic-embed-text-v1.5`,\n",
+    "`BAAI/bge-large-en-v1.5`, or an OCI GenAI embedding) — nothing else changes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "afede941",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:03.486736Z",
+     "iopub.status.busy": "2026-06-22T15:10:03.486670Z",
+     "iopub.status.idle": "2026-06-22T15:10:12.242410Z",
+     "shell.execute_reply": "2026-06-22T15:10:12.241931Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/homebrew/Caskroom/miniconda/base/envs/langchain_eco/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:   0%|          | 0/103 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights: 100%|██████████| 103/103 [00:00<00:00, 9610.12it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1mBertModel LOAD REPORT\u001b[0m from: sentence-transformers/all-MiniLM-L6-v2\n",
+      "Key                     | Status     |  | \n",
+      "------------------------+------------+--+-\n",
+      "embeddings.position_ids | UNEXPECTED |  | \n",
+      "\n",
+      "Notes:\n",
+      "- UNEXPECTED:\tcan be ignored when loading from different task/architecture; not ok if you expect identical arch.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Local embeddings ready — sentence-transformers/all-MiniLM-L6-v2 on cpu, 384-dim vectors.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_huggingface import HuggingFaceEmbeddings\n",
+    "\n",
+    "embedding_model = HuggingFaceEmbeddings(\n",
+    "    model_name=HF_EMBED_MODEL,\n",
+    "    model_kwargs={\"device\": HF_EMBED_DEVICE},\n",
+    "    encode_kwargs={\"normalize_embeddings\": True},\n",
+    ")\n",
+    "\n",
+    "dim = len(embedding_model.embed_query(\"hello, oracle vector search\"))\n",
+    "print(f\"✓ Local embeddings ready — {HF_EMBED_MODEL} on {HF_EMBED_DEVICE}, {dim}-dim vectors.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf8c2fb5",
+   "metadata": {},
+   "source": [
+    "## 2.2 · The private knowledge base\n",
+    "\n",
+    "This is Aurora Financial's internal corpus: short engineering, strategy, and governance memos\n",
+    "about how they build their AI agent platform. The deep agent will answer **only** from these\n",
+    "documents and cite them by `id`.\n",
+    "\n",
+    "Each record is a plain dict the `ADB` datastore accepts directly: `id`, `title`, `source`,\n",
+    "`content`. In a real deployment these would be your wikis, runbooks, tickets, and design docs.\n",
+    "\n",
+    "**Key takeaway:** the corpus *is* the agent's world. Good IDs and titles make citations clean;\n",
+    "clear, self-contained passages make grounding reliable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "51066a8c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:12.244184Z",
+     "iopub.status.busy": "2026-06-22T15:10:12.243743Z",
+     "iopub.status.idle": "2026-06-22T15:10:12.248192Z",
+     "shell.execute_reply": "2026-06-22T15:10:12.247843Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "12 documents across 5 sources.\n"
+     ]
+    }
+   ],
+   "source": [
+    "SAMPLE_DOCS = [\n",
+    "    {\n",
+    "        \"id\": \"kb-001\",\n",
+    "        \"title\": \"Retrieval benchmark: vector vs keyword vs hybrid\",\n",
+    "        \"source\": \"ml-benchmarks\",\n",
+    "        \"content\": \"Internal benchmark on 1,200 labelled support questions. Pure vector search scored recall@5 of 0.71: strong on paraphrased and conceptual queries, but it missed exact identifiers such as product codes, fee schedule names, and account types. Keyword search (Oracle Text) was the opposite: precise on exact terms, weak on synonyms and intent. Hybrid search that fuses vector and keyword results with Reciprocal Rank Fusion (RRF) scored the best overall recall@5 of 0.86. Recommendation: default Aurora Assist retrieval to hybrid search.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-002\",\n",
+    "        \"title\": \"Why we chose Oracle AI Vector Search\",\n",
+    "        \"source\": \"platform-architecture\",\n",
+    "        \"content\": \"We co-locate embeddings with operational data in the Oracle AI Database using the native VECTOR data type and an HNSW vector index. This removed a separate, standalone vector database from our stack. Because vectors live next to customer and product tables, a single SQL statement can combine semantic similarity with ordinary predicates and joins, for example filtering retrieved passages by the requesting customer's entitlements. Benefits: less data movement, one security and backup model, and lower infrastructure cost.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-003\",\n",
+    "        \"title\": \"Agent memory architecture: three tiers\",\n",
+    "        \"source\": \"platform-architecture\",\n",
+    "        \"content\": \"Aurora Assist uses three memory tiers. Short-term memory is the live conversation buffer. Working memory is a virtual filesystem the agent writes to while solving a task (drafts, notes, intermediate findings) so large artifacts stay out of the chat context. Long-term memory stores durable facts and summaries of past tasks as vectors in Oracle, retrieved on demand. A summarization step compresses long histories to keep the context window bounded on multi-step runs.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-004\",\n",
+    "        \"title\": \"Grounding policy: retrieve before you answer\",\n",
+    "        \"source\": \"governance-policy\",\n",
+    "        \"content\": \"Mandatory policy for all production agents. Any factual claim about a customer, product, fee, or policy must be supported by a retrieved document, and the answer must cite that document's ID. If retrieval returns no relevant evidence, the agent must say it does not know rather than answer from the model's parametric knowledge. This policy exists to prevent confident, ungrounded answers in regulated contexts.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-005\",\n",
+    "        \"title\": \"Postmortem: the May fee-waiver hallucination\",\n",
+    "        \"source\": \"incident-postmortem\",\n",
+    "        \"content\": \"An agent told a customer about a fee-waiver program that does not exist, triggering a complaint. Root cause: single-shot RAG retrieved no relevant passages, and the model answered from memory anyway. Corrective actions shipped: (1) enforce the retrieve-before-you-answer grounding policy with an explicit admit-when-unsure instruction; (2) switch to hybrid retrieval to raise recall; (3) add a verification (critique) step that checks every claim against the knowledge base before the answer is returned to the customer.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-006\",\n",
+    "        \"title\": \"Evaluation harness and release gating\",\n",
+    "        \"source\": \"eng-strategy\",\n",
+    "        \"content\": \"We maintain a golden set of 300 question-answer pairs, each labelled with the documents that must be cited. A nightly regression run scores three metrics: groundedness (are claims supported by the cited docs), answer correctness, and retrieval recall. A release is blocked if groundedness regresses against the previous build. Five percent of production transcripts are sampled for human review each week. Evaluation and observability were funded before expanding autonomy.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-007\",\n",
+    "        \"title\": \"Cost and latency of long agent loops\",\n",
+    "        \"source\": \"ml-benchmarks\",\n",
+    "        \"content\": \"Multi-step planning with sub-agent delegation costs roughly three to five times the tokens of a single-shot answer and adds noticeable latency. Mitigations we adopted: cap the number of research iterations per task; use a smaller, cheaper model for routine sub-agent retrieval while reserving a stronger model for planning and final synthesis; cache embeddings; and stream partial output to the UI so perceived latency stays low even when the full task takes longer.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-008\",\n",
+    "        \"title\": \"Sub-agents and context isolation\",\n",
+    "        \"source\": \"platform-architecture\",\n",
+    "        \"content\": \"Answer quality on complex, multi-part questions drops when a single context window holds every retrieved chunk for every sub-topic. Aurora delegates each research sub-topic to an isolated sub-agent that does its own retrieval and returns only distilled, cited findings. The orchestrator's context therefore stays focused on planning and synthesis. This pattern measurably improved coherence and reduced dropped constraints on long-horizon tasks.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-009\",\n",
+    "        \"title\": \"Data governance and access control\",\n",
+    "        \"source\": \"governance-policy\",\n",
+    "        \"content\": \"Embeddings inherit the same row-level security as the source records because they live in Oracle alongside them. Agents run under a service identity scoped to the caller's entitlements, so retrieval cannot surface documents the user is not allowed to see. PII is masked at retrieval time, and every agent tool call is logged for audit. Co-location avoids the risk of syncing access-control lists to a separate external vector store.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-010\",\n",
+    "        \"title\": \"Human-in-the-loop and output guardrails\",\n",
+    "        \"source\": \"governance-policy\",\n",
+    "        \"content\": \"High-impact actions such as account changes and payments require human approval: the agent proposes an action and a human confirms it through an interrupt before anything executes. Output filters block unsupported financial advice. We deliberately gave autonomy first to bounded, high-volume, low-risk workflows and kept a human in the loop everywhere the blast radius is large.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-011\",\n",
+    "        \"title\": \"Platform roadmap and recommendation\",\n",
+    "        \"source\": \"eng-strategy\",\n",
+    "        \"content\": \"Recommendation to leadership: standardize on hybrid retrieval over the Oracle AI Database; adopt the three-tier memory model; continue to fund evaluation and observability before widening autonomy; prefer several narrow sub-agents over one monolithic agent; and keep humans in the loop for high-impact actions. The next pilot is agentic RAG for multi-hop questions that a single retrieval cannot answer.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"kb-012\",\n",
+    "        \"title\": \"Agentic RAG vs single-shot RAG\",\n",
+    "        \"source\": \"eng-strategy\",\n",
+    "        \"content\": \"Single-shot RAG retrieves once and answers. Agentic RAG lets the agent decide when and what to retrieve, issue several retrieval calls, and verify the evidence before answering. It handles multi-hop and ambiguous questions far better, at higher token cost and latency. Aurora's deep-research agent is an agentic-RAG design: it plans, delegates retrieval to sub-agents, and runs a verification step before it finalizes an answer.\"\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "print(f\"{len(SAMPLE_DOCS)} documents across \"\n",
+    "      f\"{len(set(d['source'] for d in SAMPLE_DOCS))} sources.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a186c1fc",
+   "metadata": {},
+   "source": [
+    "## 2.3 · Ingest into the Oracle AI Database and enable hybrid search\n",
+    "\n",
+    "`ADB` is `langchain-oci`'s Oracle datastore. With just `dsn` / `user` / `password` (no\n",
+    "`wallet_location`) it connects to the local container over Easy-Connect. `connect()` builds the\n",
+    "`OracleVS` backend with our embedding model; `bulk_insert` embeds and stores each record. We drop\n",
+    "the table first so re-runs start clean (the vector dimension is tied to the embedding model).\n",
+    "\n",
+    "We then create an **Oracle Text search index** on the `TEXT` column. This enables the keyword half\n",
+    "of **hybrid search** — fusing **vector** similarity (great for meaning and paraphrase) with\n",
+    "**keyword** matching (great for exact identifiers) using Reciprocal Rank Fusion (RRF).\n",
+    "\n",
+    "**Key takeaways**\n",
+    "- `ADB` + `OracleVS` store the text, metadata, **and** the `VECTOR` embedding in one table.\n",
+    "- The `CREATE SEARCH INDEX` DDL turns on the keyword side of hybrid search — idempotent here.\n",
+    "- Vectors live *next to* your operational data, so retrieval can be combined with ordinary SQL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "75fc676f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:12.249294Z",
+     "iopub.status.busy": "2026-06-22T15:10:12.249230Z",
+     "iopub.status.idle": "2026-06-22T15:10:14.660293Z",
+     "shell.execute_reply": "2026-06-22T15:10:14.659670Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "· reset existing table RESEARCH_DOCS\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ingested 12 documents into DEEPAGENTS.RESEARCH_DOCS\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Oracle Text index created — hybrid (vector + keyword) search enabled.\n",
+      "Store stats: {'store': 'adb', 'table': 'RESEARCH_DOCS', 'document_count': 12, 'sources': {'governance-policy': 3, 'eng-strategy': 3, 'platform-architecture': 3, 'ml-benchmarks': 2, 'incident-postmortem': 1}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import oracledb\n",
+    "from langchain_oci.datastores import ADB\n",
+    "\n",
+    "# Fresh start: drop the table if it exists (dimension is tied to the embedding model).\n",
+    "with oracledb.connect(user=APP_USER, password=APP_PWD, dsn=ORACLE_DSN) as con:\n",
+    "    cur = con.cursor()\n",
+    "    try:\n",
+    "        cur.execute(f\"DROP TABLE {TABLE_NAME} PURGE\")\n",
+    "        print(f\"· reset existing table {TABLE_NAME}\")\n",
+    "    except oracledb.DatabaseError as exc:\n",
+    "        if exc.args[0].code != 942:  # ORA-00942: table does not exist\n",
+    "            raise\n",
+    "    con.commit()\n",
+    "\n",
+    "store = ADB(\n",
+    "    dsn=ORACLE_DSN,\n",
+    "    user=APP_USER,\n",
+    "    password=APP_PWD,\n",
+    "    table_name=TABLE_NAME,\n",
+    "    datastore_description=(\n",
+    "        \"Aurora Financial internal AI platform knowledge base: retrieval, agent \"\n",
+    "        \"memory, evaluation, governance, incidents, and roadmap memos.\"\n",
+    "    ),\n",
+    "    chunk_on_write=False,  # short docs -> store each as a single passage\n",
+    ")\n",
+    "\n",
+    "store.connect(embedding_model)\n",
+    "ingested = store.bulk_insert(SAMPLE_DOCS, embeddings=[[] for _ in SAMPLE_DOCS])\n",
+    "print(f\"✓ Ingested {ingested} documents into {APP_USER}.{TABLE_NAME}\")\n",
+    "\n",
+    "# Enable Oracle Text keyword search so the `search` tool can run HYBRID retrieval.\n",
+    "cur = store.vectorstore.client.cursor()\n",
+    "try:\n",
+    "    cur.execute(f'CREATE SEARCH INDEX {TABLE_NAME}_TXT_IDX ON {TABLE_NAME}(\"TEXT\")')\n",
+    "    print(\"✓ Oracle Text index created — hybrid (vector + keyword) search enabled.\")\n",
+    "except oracledb.DatabaseError as exc:\n",
+    "    if \"ORA-00955\" in str(exc):  # name already used by an existing object\n",
+    "        print(\"· Oracle Text index already exists.\")\n",
+    "    else:\n",
+    "        raise\n",
+    "finally:\n",
+    "    cur.close()\n",
+    "\n",
+    "print(\"Store stats:\", store.stats())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d99efed7",
+   "metadata": {},
+   "source": [
+    "## 2.4 · Sanity-check Oracle retrieval\n",
+    "\n",
+    "Before building the agent, confirm the store returns grounded results straight from Oracle AI\n",
+    "Database. You do **not** need to build tools by hand: when we pass `datastores={\"kb\": store}` to\n",
+    "`create_deepagents_agent` below, the factory builds the **`search`** (hybrid vector + keyword),\n",
+    "**`get_document`**, and **`stats`** tools from this store automatically — and, because we pass our\n",
+    "local `embedding_model`, they make **no OCI calls**.\n",
+    "\n",
+    "**Key term:** a *tool* is a function the LLM can decide to call; the framework runs it and feeds\n",
+    "the result back into the conversation.\n",
+    "\n",
+    "> **🔑 Part 2 takeaway:** Aurora's documents are now vectors in Oracle AI Database, searchable by\n",
+    "> **meaning and exact term**. The agent will never see SQL or vectors — only the `search` /\n",
+    "> `get_document` / `stats` tools the `datastores=` one-liner wires up — and everything it answers\n",
+    "> can be traced back to a Doc ID."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "72f7aee6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:14.663431Z",
+     "iopub.status.busy": "2026-06-22T15:10:14.662761Z",
+     "iopub.status.idle": "2026-06-22T15:10:14.684727Z",
+     "shell.execute_reply": "2026-06-22T15:10:14.684361Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Retrieved 3 grounded passage(s) from Oracle AI Database. Top match:\n",
+      "\n",
+      "Internal benchmark on 1,200 labelled support questions. Pure vector search scored recall@5 of 0.71: strong on paraphrased and conceptual queries, but it missed exact identifiers such as product codes, fee schedule names, and account types. Keyword search (Oracle Text) was the opposite: precise on ex\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Sanity check: retrieval is grounded in the documents we just ingested into Oracle.\n",
+    "# No manual tool-building needed — create_deepagents_agent(datastores=...) below wires the\n",
+    "# search / get_document / stats tools from this same store for you.\n",
+    "hits = store.search_documents(\"which retrieval approach gives the best recall and why\", top_k=3)\n",
+    "print(f\"Retrieved {len(hits)} grounded passage(s) from Oracle AI Database. Top match:\\n\")\n",
+    "print(hits[0].page_content[:300] if hits else \"(no results)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ec56cff",
+   "metadata": {},
+   "source": [
+    "# Part 3 · Build the deep research agent\n",
+    "\n",
+    "Now we assemble the analyst. Part 3 defines the agent's helpers (a reflection tool and two\n",
+    "sub-agents), then wires the whole **deepagents** harness to a Claude brain — grounded in the\n",
+    "Oracle tools from Part 2."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "912c734b",
+   "metadata": {},
+   "source": [
+    "## 3.1 · Define the reflection tool and the sub-agents\n",
+    "\n",
+    "Two ingredients make the research loop disciplined:\n",
+    "\n",
+    "- **`think_tool`** — a no-op \"strategic pause.\" After each search the agent calls it to state what\n",
+    "  it found, what's still missing, and whether to keep digging. Forcing reflection measurably\n",
+    "  improves multi-step research quality.\n",
+    "- **Sub-agents** — scoped agents with their own prompt that *inherit* the orchestrator's tools (so they can search Oracle without any re-wiring). We define two:\n",
+    "  - **`kb-researcher`**: researches *one* sub-topic against the knowledge base and returns\n",
+    "    distilled, cited findings. The orchestrator delegates each sub-topic to a *fresh* instance, so\n",
+    "    noisy retrieved text stays out of the orchestrator's context (**context isolation**).\n",
+    "  - **`critic`**: re-checks the draft's claims against the knowledge base and flags anything\n",
+    "    unsupported — a built-in guard against hallucination, mirroring Aurora's verification step.\n",
+    "\n",
+    "**Key term:** *context isolation* — keeping a sub-task's raw, bulky data inside a sub-agent so the\n",
+    "main agent's limited context window stays focused on planning and synthesis.\n",
+    "\n",
+    "**Key takeaway:** a `SubAgent` is just `{name, description, system_prompt}` (`tools` is optional — omit it and the sub-agent inherits the orchestrator's tools, here the Oracle `search` tools). The `description` is how the orchestrator decides *when* to delegate, so write it like a job posting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "23f1830a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:14.685978Z",
+     "iopub.status.busy": "2026-06-22T15:10:14.685919Z",
+     "iopub.status.idle": "2026-06-22T15:10:14.690177Z",
+     "shell.execute_reply": "2026-06-22T15:10:14.689840Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sub-agents defined: ['kb-researcher', 'critic']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_core.tools import tool\n",
+    "\n",
+    "\n",
+    "@tool\n",
+    "def think_tool(reflection: str) -> str:\n",
+    "    \"\"\"Record a strategic reflection: what evidence was found, what gaps remain, and whether to\n",
+    "    keep researching or move on. Call this after each search to stay focused.\"\"\"\n",
+    "    return f\"Reflection recorded: {reflection}\"\n",
+    "\n",
+    "\n",
+    "research_subagent = {\n",
+    "    \"name\": \"kb-researcher\",\n",
+    "    \"description\": (\n",
+    "        \"Researches ONE narrow sub-topic against the Aurora knowledge base and returns concise, \"\n",
+    "        \"cited findings. Delegate a single, focused sub-topic per call.\"\n",
+    "    ),\n",
+    "    \"system_prompt\": (\n",
+    "        \"You are a focused research specialist for Aurora Financial. Use the `search` tool to find \"\n",
+    "        \"evidence in the knowledge base, `get_document` to pull a document's full text when a \"\n",
+    "        \"snippet is not enough, and call `think_tool` after searching to assess what is still \"\n",
+    "        \"missing. Return a section titled '## Key Findings' with 3-5 concise bullets, each citing a \"\n",
+    "        \"Doc ID inline like [kb-001]. Use ONLY retrieved content; if the KB has nothing relevant, \"\n",
+    "        \"say so plainly. No preamble, no conclusion.\"\n",
+    "    ),\n",
+    "    # tools omitted -> inherits the orchestrator's tools (Oracle search + think_tool)\n",
+    "}\n",
+    "\n",
+    "critique_subagent = {\n",
+    "    \"name\": \"critic\",\n",
+    "    \"description\": (\n",
+    "        \"Verifies a draft answer's claims against the knowledge base and lists unsupported claims, \"\n",
+    "        \"missing caveats, or citation errors. Use before finalizing.\"\n",
+    "    ),\n",
+    "    \"system_prompt\": (\n",
+    "        \"You are a skeptical reviewer. For each claim in the draft you are given, use `search` and \"\n",
+    "        \"`get_document` to confirm it is supported by the knowledge base. Return a short bullet list \"\n",
+    "        \"of: unsupported or overstated claims, missing caveats, and citation errors. If everything \"\n",
+    "        \"checks out, say so briefly. Be concrete and concise.\"\n",
+    "    ),\n",
+    "    # tools omitted -> inherits the orchestrator's tools (Oracle search)\n",
+    "}\n",
+    "\n",
+    "print(\"Sub-agents defined:\", [research_subagent[\"name\"], critique_subagent[\"name\"]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5c04f87",
+   "metadata": {},
+   "source": [
+    "## 3.2 · Assemble the deep agent — bring-your-own Claude\n",
+    "\n",
+    "Two things matter here. First, **bring-your-own-model**: passing `model=` hands the factory **any**\n",
+    "LangChain chat model and bypasses OCI inference auth entirely (the model owns its own connection),\n",
+    "so the **Oracle** harness is driven by **Claude**. Second, **`datastores={\"kb\": store}`** — the\n",
+    "one-liner that wires Oracle `search` / `get_document` / `stats` into the agent *and* keeps the full\n",
+    "deep-agent harness (planning, files, sub-agents). No manual `create_datastore_tools`.\n",
+    "\n",
+    "How context isolation still works:\n",
+    "- The **sub-agents** omit `tools`, so they **inherit** the Oracle search tools and do the retrieval\n",
+    "  in their own isolated contexts.\n",
+    "- The **orchestrator** is told (in its prompt) to plan and delegate rather than search directly, so\n",
+    "  bulky retrieved text stays inside the sub-agents.\n",
+    "\n",
+    "The system prompt encodes the classic deep-research workflow: **plan → save the request →\n",
+    "delegate → verify → synthesize**.\n",
+    "\n",
+    "**Key takeaways**\n",
+    "- `model=ChatAnthropic(...)` is the entire bring-your-own-model story — `model_id` / OCI auth are ignored.\n",
+    "- Passing `datastores=` or `subagents=` routes through the *real* `deepagents` harness — datastores\n",
+    "  compose with the full agent rather than downgrading it to a lightweight ReAct path.\n",
+    "- `agent._oci_llm` exposes the model actually driving the graph — handy to prove the wiring."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f42aed3f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:14.691567Z",
+     "iopub.status.busy": "2026-06-22T15:10:14.691498Z",
+     "iopub.status.idle": "2026-06-22T15:10:15.183810Z",
+     "shell.execute_reply": "2026-06-22T15:10:15.183378Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent type: CompiledStateGraph\n",
+      "Driven by the Claude model we passed in: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_anthropic import ChatAnthropic\n",
+    "from langchain_oci import create_deepagents_agent\n",
+    "\n",
+    "llm = ChatAnthropic(\n",
+    "    model=CLAUDE_MODEL,\n",
+    "    temperature=0,        # deterministic planning/synthesis\n",
+    "    max_tokens=8000,\n",
+    "    timeout=300,\n",
+    ")\n",
+    "\n",
+    "RESEARCH_LEAD_PROMPT = (\n",
+    "    \"You are the research lead for Aurora Financial. Produce rigorous, fully-grounded briefs.\\n\\n\"\n",
+    "    \"Follow this workflow for every request:\\n\"\n",
+    "    \"1. PLAN: call `write_todos` to break the question into focused sub-topics.\\n\"\n",
+    "    \"2. SAVE: write the user's exact question to `/research_request.md` with your file tools.\\n\"\n",
+    "    \"3. RESEARCH: delegate EACH sub-topic to the `kb-researcher` subagent via the `task` tool — \"\n",
+    "    \"one sub-topic per call. Do NOT search the knowledge base yourself; the researchers do that.\\n\"\n",
+    "    \"4. VERIFY: assemble a draft, then send it to the `critic` subagent and address its findings.\\n\"\n",
+    "    \"5. SYNTHESIZE: write the final brief to `/final_report.md`, then return it as your answer.\\n\\n\"\n",
+    "    \"Rules: every factual claim MUST cite a Doc ID inline like [kb-001]. If the knowledge base does \"\n",
+    "    \"not support a claim, say so rather than guessing. Keep the final brief tight and executive-ready.\"\n",
+    ")\n",
+    "\n",
+    "agent = create_deepagents_agent(\n",
+    "    model=llm,                                      # <-- bring-your-own Claude (PR #234)\n",
+    "    datastores={\"kb\": store},                       # one-liner: Oracle retrieval tools + deep harness\n",
+    "    embedding_model=embedding_model,                # local HF embeddings -> no OCI calls\n",
+    "    tools=[think_tool],                             # orchestrator delegates; prompt tells it not to search\n",
+    "    subagents=[research_subagent, critique_subagent],  # sub-agents inherit the Oracle search tools\n",
+    "    system_prompt=RESEARCH_LEAD_PROMPT,\n",
+    ")\n",
+    "\n",
+    "print(\"Agent type:\", type(agent).__name__)\n",
+    "print(\"Driven by the Claude model we passed in:\", agent._oci_llm is llm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3d58c81",
+   "metadata": {},
+   "source": [
+    "## 3.3 · Display helpers\n",
+    "\n",
+    "Small helpers to render what the deep agent produces: the **message flow**, its **plan** (`todos`),\n",
+    "its **virtual files**, and which **sub-agents** it delegated to. Deep-agent state comes back as a\n",
+    "dict with `messages`, `todos`, and `files` keys.\n",
+    "\n",
+    "> **🔑 Part 3 takeaway:** The analyst is built. The **deepagents** harness (planning, virtual\n",
+    "> filesystem, sub-agents) is wired to a **Claude** brain via one `model=` argument, and grounded in\n",
+    "> the Oracle tools from Part 2 — with a clean split: the orchestrator plans and delegates, the\n",
+    "> sub-agents retrieve. Its entire working state is inspectable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "94ac62d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:15.185226Z",
+     "iopub.status.busy": "2026-06-22T15:10:15.185164Z",
+     "iopub.status.idle": "2026-06-22T15:10:15.188415Z",
+     "shell.execute_reply": "2026-06-22T15:10:15.188027Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "\n",
+    "def show_flow(state):\n",
+    "    print(\" -> \".join(type(m).__name__ for m in state[\"messages\"]))\n",
+    "\n",
+    "\n",
+    "def show_todos(state):\n",
+    "    todos = state.get(\"todos\") or []\n",
+    "    if not todos:\n",
+    "        print(\"(no plan recorded)\"); return\n",
+    "    marks = {\"completed\": \"done\", \"in_progress\": \"in&nbsp;progress\", \"pending\": \"pending\"}\n",
+    "    rows = [\"| # | Task | Status |\", \"|---|------|--------|\"]\n",
+    "    for i, t in enumerate(todos, 1):\n",
+    "        rows.append(f\"| {i} | {t.get('content','')} | {marks.get(t.get('status'), t.get('status',''))} |\")\n",
+    "    display(Markdown(\"\\n\".join(rows)))\n",
+    "\n",
+    "\n",
+    "def show_files(state):\n",
+    "    files = state.get(\"files\") or {}\n",
+    "    if not files:\n",
+    "        print(\"(no files written)\"); return\n",
+    "    for path, blob in files.items():\n",
+    "        content = blob.get(\"content\") if isinstance(blob, dict) else blob\n",
+    "        print(f\"FILE {path}  ({len(content)} chars)\")\n",
+    "        display(Markdown(content))\n",
+    "\n",
+    "\n",
+    "def show_delegations(state):\n",
+    "    calls = [tc for m in state[\"messages\"]\n",
+    "             for tc in (getattr(m, \"tool_calls\", None) or []) if tc[\"name\"] == \"task\"]\n",
+    "    print(f\"{len(calls)} delegation(s) via the built-in `task` tool:\\n\")\n",
+    "    for tc in calls:\n",
+    "        desc = str(tc[\"args\"].get(\"description\", \"\"))\n",
+    "        print(f\" - [{tc['args'].get('subagent_type')}] {desc[:110]}{'...' if len(desc) > 110 else ''}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a97f05c8",
+   "metadata": {},
+   "source": [
+    "# Part 4 · Run the research and inspect the four powers\n",
+    "\n",
+    "Now we give the analyst its assignment and watch it work. We run the task once, then inspect each\n",
+    "of the four deep-agent powers in the single returned state."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b64fef9b",
+   "metadata": {},
+   "source": [
+    "## 4.1 · Run the deep research task\n",
+    "\n",
+    "A vague executive question that *demands* depth. Watch the message flow — it will be long, because\n",
+    "the orchestrator plans, delegates several sub-topics to `kb-researcher`, runs the `critic`, and\n",
+    "synthesizes. This makes **live Claude API calls** and typically takes a few minutes; that latency\n",
+    "is the deep-agent loop doing real work.\n",
+    "\n",
+    "**Key takeaway:** one ambiguous prompt in, a structured + verified + cited brief out — produced by\n",
+    "many small, grounded steps rather than a single guess."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3a66191e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:10:15.189584Z",
+     "iopub.status.busy": "2026-06-22T15:10:15.189529Z",
+     "iopub.status.idle": "2026-06-22T15:15:41.687884Z",
+     "shell.execute_reply": "2026-06-22T15:15:41.686428Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HumanMessage -> AIMessage -> ToolMessage -> AIMessage -> ToolMessage -> AIMessage -> ToolMessage -> AIMessage -> ToolMessage -> ToolMessage -> ToolMessage -> ToolMessage -> AIMessage -> ToolMessage -> AIMessage -> ToolMessage -> ToolMessage -> AIMessage -> ToolMessage -> AIMessage -> ToolMessage -> AIMessage -> ToolMessage -> AIMessage\n"
+     ]
+    }
+   ],
+   "source": [
+    "RESEARCH_TASK = (\n",
+    "    \"Produce a one-page executive technical brief for Aurora Financial's CTO on how we should \"\n",
+    "    \"ground and operate our next-generation enterprise AI agents. Cover: (1) our retrieval \"\n",
+    "    \"strategy, (2) our agent memory approach, (3) evaluation and guardrails, (4) the key \"\n",
+    "    \"production risks we have learned, and (5) a clear recommendation. Research each angle against \"\n",
+    "    \"our knowledge base, verify the draft with the critic, and cite document IDs throughout.\"\n",
+    ")\n",
+    "\n",
+    "state = agent.invoke({\"messages\": [{\"role\": \"user\", \"content\": RESEARCH_TASK}]})\n",
+    "show_flow(state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3274c2a5",
+   "metadata": {},
+   "source": [
+    "## 4.2 · Power #1 — Planning\n",
+    "\n",
+    "The plan the agent wrote with `write_todos` and worked through. A deep agent commits to a plan\n",
+    "*before* acting, then updates statuses as it goes — that's what keeps a long task on track."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6ac575e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:15:41.691545Z",
+     "iopub.status.busy": "2026-06-22T15:15:41.691234Z",
+     "iopub.status.idle": "2026-06-22T15:15:41.698551Z",
+     "shell.execute_reply": "2026-06-22T15:15:41.697191Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "| # | Task | Status |\n",
+       "|---|------|--------|\n",
+       "| 1 | Save the research request to /research_request.md | done |\n",
+       "| 2 | Research sub-topic 1: Retrieval strategy (RAG, chunking, indexing, hybrid search) | done |\n",
+       "| 3 | Research sub-topic 2: Agent memory approach (short-term, long-term, episodic, semantic memory) | done |\n",
+       "| 4 | Research sub-topic 3: Evaluation and guardrails (metrics, safety, monitoring) | done |\n",
+       "| 5 | Research sub-topic 4: Key production risks learned (incidents, failures, lessons) | done |\n",
+       "| 6 | Research sub-topic 5: Recommendations for next-gen enterprise AI agents | done |\n",
+       "| 7 | Assemble draft brief and send to critic subagent for verification | done |\n",
+       "| 8 | Write final verified brief to /final_report.md and return to user | done |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_todos(state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88f3f7d5",
+   "metadata": {},
+   "source": [
+    "## 4.3 · Power #2 — The virtual filesystem\n",
+    "\n",
+    "The documents the agent drafted in its workspace. `/research_request.md` is the saved task;\n",
+    "`/final_report.md` is the brief it composed. These live in **agent state**, not the chat\n",
+    "transcript — which is how deep agents keep long artifacts out of the context window."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "06aa24e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:15:41.701100Z",
+     "iopub.status.busy": "2026-06-22T15:15:41.700951Z",
+     "iopub.status.idle": "2026-06-22T15:15:41.705970Z",
+     "shell.execute_reply": "2026-06-22T15:15:41.705211Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FILE /research_request.md  (581 chars)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Research Request\n",
+       "\n",
+       "**Date:** Current session  \n",
+       "**Audience:** Aurora Financial CTO  \n",
+       "**Document Type:** One-page executive technical brief\n",
+       "\n",
+       "## Question\n",
+       "Produce a one-page executive technical brief for Aurora Financial's CTO on how we should ground and operate our next-generation enterprise AI agents. Cover:\n",
+       "\n",
+       "1. Our retrieval strategy\n",
+       "2. Our agent memory approach\n",
+       "3. Evaluation and guardrails\n",
+       "4. The key production risks we have learned\n",
+       "5. A clear recommendation\n",
+       "\n",
+       "Research each angle against our knowledge base, verify the draft with the critic, and cite document IDs throughout.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FILE /final_report.md  (6778 chars)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Grounding & Operating Next-Generation Enterprise AI Agents at Aurora Financial\n",
+       "**Executive Technical Brief — CTO**\n",
+       "*All claims grounded in Aurora Financial internal knowledge base. Doc IDs cited inline.*\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 1. Retrieval Strategy\n",
+       "\n",
+       "Aurora's benchmark across 1,200 labelled support questions [kb-001] established that pure vector search achieves recall@5 = 0.71 — adequate for conceptual queries but brittle on exact identifiers (product codes, fee schedule names, account types). Keyword-only search has the inverse weakness. **Hybrid search** (dense vector + Oracle Text keyword, fused via Reciprocal Rank Fusion) achieves recall@5 = 0.86 and is the recommended default for Aurora Assist [kb-001, kb-011].\n",
+       "\n",
+       "Architecturally, Aurora eliminated the standalone vector database in favor of Oracle AI Vector Search with HNSW indexing, co-located with operational data [kb-002]. This single-store design means embeddings inherit row-level security from source records, reducing the risk of ACL desynchronization that would arise from a separate external vector store [kb-009]. A single SQL statement can combine semantic similarity with relational predicates (e.g., customer entitlement filters) in one query.\n",
+       "\n",
+       "For complex, multi-hop questions, Aurora is moving from single-shot RAG to **agentic RAG** [kb-012]: the agent plans, issues multiple targeted retrieval calls, and runs a verification step before responding. A post-incident corrective action from the May fee-waiver hallucination [kb-005] added a verification step to the pipeline; the broader agentic RAG architecture is the designated next pilot per the platform roadmap [kb-011].\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 2. Agent Memory Approach\n",
+       "\n",
+       "Aurora Assist operates a formally defined **three-tier memory model** [kb-003]:\n",
+       "\n",
+       "| Tier | Mechanism | Purpose |\n",
+       "|---|---|---|\n",
+       "| Short-term | Live conversation buffer (in-context) | Active dialogue |\n",
+       "| Working | Virtual filesystem (agent-writable) | Artifacts, drafts, intermediate findings — kept out of context window |\n",
+       "| Long-term | Vectors in Oracle AI Database, retrieved on demand | Durable facts, past-task summaries |\n",
+       "\n",
+       "A **summarization step** compresses long conversation histories to keep the context window bounded during multi-step runs [kb-003]. On complex multi-part tasks, each sub-topic is delegated to an **isolated sub-agent** that returns only distilled, cited findings to the orchestrator — measurably improving coherence and reducing dropped constraints on long-horizon tasks [kb-008]. The orchestrator's context is reserved for planning and synthesis only.\n",
+       "\n",
+       "Critically, the model's **parametric memory is prohibited** for factual claims about customers, products, fees, or policies [kb-004]. The three-tier model is recommended as the platform-wide standard in the Aurora roadmap [kb-011].\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 3. Evaluation and Guardrails\n",
+       "\n",
+       "**Evaluation harness [kb-006]:** A golden set of 300 question-answer pairs (each annotated with required citation documents) runs nightly. Three metrics are tracked: groundedness, answer correctness, and retrieval recall. A release is **blocked** if groundedness regresses against the prior build. Five percent of live production transcripts are sampled for human review weekly. The explicit organizational principle: *\"Evaluation and observability were funded before expanding autonomy.\"*\n",
+       "\n",
+       "**Grounding policy [kb-004]:** Every factual claim must cite a retrieved document. If retrieval returns no evidence, the agent must admit it does not know — no fallback to parametric memory.\n",
+       "\n",
+       "**Output guardrails [kb-010]:** High-impact actions (account changes, payments) require explicit human approval via an interrupt-before-execute mechanism. Output filters block unsupported financial advice. Autonomy was deliberately granted first to bounded, high-volume, low-risk workflows.\n",
+       "\n",
+       "**Verification step [kb-005, kb-012]:** Agentic RAG pipelines include a built-in critique pass that checks every claim against the knowledge base before the answer is returned to the customer.\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 4. Key Production Risks Learned\n",
+       "\n",
+       "| Risk | Severity | Evidence | Mitigation |\n",
+       "|---|---|---|---|\n",
+       "| Retrieval failure → hallucination | 🔴 Critical | May fee-waiver incident: agent fabricated a non-existent program when retrieval returned nothing [kb-005] | Hybrid retrieval [kb-001]; grounding policy [kb-004]; verification step [kb-012] |\n",
+       "| Agentic loops: 3–5× token cost + noticeable latency | 🟠 High | Documented cost profile [kb-007] | Iteration caps; tiered model sizing; embedding cache; UI streaming |\n",
+       "| Context window degradation on complex queries | 🟠 High | Dropped constraints on long-horizon tasks [kb-008] | Sub-agent isolation; summarization [kb-003] |\n",
+       "| PII exposure & ACL desynchronization | 🟠 High | Governance policy [kb-009] | Oracle row-level security; PII masking at retrieval; audit logging |\n",
+       "| Premature autonomy expansion | 🟡 Medium | Platform roadmap recommendation [kb-011] | Fund eval/observability before widening autonomy; HITL for high-impact actions [kb-010] |\n",
+       "| Monolithic agent architecture | 🟡 Medium | Platform roadmap recommendation [kb-011] | Prefer narrow, specialized sub-agents over one monolithic agent |\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 5. Recommendation\n",
+       "\n",
+       "Based on Aurora's documented evidence, the following five-point operating model is recommended for next-generation enterprise agents:\n",
+       "\n",
+       "1. **Default to hybrid retrieval.** Standardize on hybrid search (RRF) over Oracle AI Vector Search as the baseline. Pure vector search's 0.71 recall is insufficient for a regulated financial environment where exact identifiers matter [kb-001, kb-011].\n",
+       "\n",
+       "2. **Adopt the three-tier memory model as the platform standard.** Short-term buffer + working filesystem + long-term vector store, with summarization for context management and sub-agent isolation for complex tasks [kb-003, kb-008].\n",
+       "\n",
+       "3. **Gate every release on groundedness.** The nightly 300-question harness with a hard groundedness block is the minimum viable safety net. Fund evaluation infrastructure before expanding agent autonomy [kb-006, kb-011].\n",
+       "\n",
+       "4. **Enforce retrieve-before-answer as a hard policy.** No agent in a regulated context should answer from parametric memory. The May incident is the proof case [kb-004, kb-005].\n",
+       "\n",
+       "5. **Expand autonomy incrementally, with HITL for high-impact actions.** Start with bounded, low-risk workflows. Add human-approval interrupts for any action with large blast radius. Pilot agentic RAG for multi-hop questions as the next capability frontier [kb-010, kb-011, kb-012].\n",
+       "\n",
+       "---\n",
+       "*Critic-verified. Seven draft issues corrected: two unsupported causal claims removed, two overstated \"mandate\" framings softened to \"recommended,\" token/latency conflation corrected, \"automatically blocked\" qualifier removed, and \"directive\" relabeled as \"recommendation\" for kb-011.*\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_files(state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e250710",
+   "metadata": {},
+   "source": [
+    "## 4.4 · Power #3 — Sub-agents (delegation & context isolation)\n",
+    "\n",
+    "Each delegation below ran in its *own* context with its *own* tools and returned only a distilled\n",
+    "result. The noisy retrieved passages stayed inside the researchers; the orchestrator only ever saw\n",
+    "clean findings — then the `critic` verified them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8c700ef1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:15:41.707473Z",
+     "iopub.status.busy": "2026-06-22T15:15:41.707386Z",
+     "iopub.status.idle": "2026-06-22T15:15:41.710276Z",
+     "shell.execute_reply": "2026-06-22T15:15:41.709803Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 delegation(s) via the built-in `task` tool:\n",
+      "\n",
+      " - [kb-researcher] Research Aurora Financial's internal knowledge base on the topic of RETRIEVAL STRATEGY for enterprise AI agent...\n",
+      " - [kb-researcher] Research Aurora Financial's internal knowledge base on the topic of AGENT MEMORY APPROACH for enterprise AI ag...\n",
+      " - [kb-researcher] Research Aurora Financial's internal knowledge base on the topic of EVALUATION AND GUARDRAILS for enterprise A...\n",
+      " - [kb-researcher] Research Aurora Financial's internal knowledge base on the topic of PRODUCTION RISKS AND INCIDENTS for enterpr...\n",
+      " - [kb-researcher] Research Aurora Financial's internal knowledge base specifically for STRATEGIC RECOMMENDATIONS and ROADMAP ite...\n",
+      " - [critic] Please verify the following draft executive brief against the Aurora Financial knowledge base. List any unsupp...\n"
+     ]
+    }
+   ],
+   "source": [
+    "show_delegations(state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b4d492",
+   "metadata": {},
+   "source": [
+    "## 4.5 · The final executive brief\n",
+    "\n",
+    "The orchestrator's synthesized, critic-reviewed answer — grounded in Aurora's documents and cited\n",
+    "with Doc IDs throughout.\n",
+    "\n",
+    "> **🔑 Part 4 takeaway:** From one vague question, the agent produced a **planned, delegated,\n",
+    "> verified, and fully-cited** brief — every claim traceable to a document in the Oracle AI\n",
+    "> Database. That is the payoff of agentic RAG over a single-shot chatbot answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "340c97f6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:15:41.711834Z",
+     "iopub.status.busy": "2026-06-22T15:15:41.711728Z",
+     "iopub.status.idle": "2026-06-22T15:15:41.714830Z",
+     "shell.execute_reply": "2026-06-22T15:15:41.714343Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "# Grounding & Operating Next-Generation Enterprise AI Agents at Aurora Financial\n",
+       "**Executive Technical Brief — CTO**\n",
+       "*Critic-verified. All claims grounded in Aurora Financial internal knowledge base with Doc IDs cited inline.*\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 1. Retrieval Strategy\n",
+       "\n",
+       "Aurora's benchmark across 1,200 labelled support questions [kb-001] established that pure vector search achieves recall@5 = **0.71** — adequate for conceptual queries but brittle on exact identifiers (product codes, fee schedule names, account types). Keyword-only search has the inverse weakness. **Hybrid search** (dense vector + Oracle Text keyword, fused via Reciprocal Rank Fusion) achieves recall@5 = **0.86** and is the recommended default for Aurora Assist [kb-001, kb-011].\n",
+       "\n",
+       "Architecturally, Aurora eliminated the standalone vector database in favor of **Oracle AI Vector Search with HNSW indexing, co-located with operational data** [kb-002]. This single-store design means embeddings inherit row-level security from source records, reducing the risk of ACL desynchronization that would arise from a separate external vector store [kb-009]. A single SQL statement can combine semantic similarity with relational predicates (e.g., customer entitlement filters) in one query.\n",
+       "\n",
+       "For complex, multi-hop questions, Aurora is moving from single-shot RAG to **agentic RAG** [kb-012]: the agent plans, issues multiple targeted retrieval calls, and runs a verification step before responding. A post-incident corrective action from the May fee-waiver hallucination [kb-005] added a verification step to the pipeline; the broader agentic RAG architecture is the designated next pilot per the platform roadmap [kb-011].\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 2. Agent Memory Approach\n",
+       "\n",
+       "Aurora Assist operates a formally defined **three-tier memory model** [kb-003]:\n",
+       "\n",
+       "| Tier | Mechanism | Purpose |\n",
+       "|---|---|---|\n",
+       "| **Short-term** | Live conversation buffer (in-context) | Active dialogue |\n",
+       "| **Working** | Virtual filesystem (agent-writable) | Artifacts, drafts, intermediate findings — kept out of context window |\n",
+       "| **Long-term** | Vectors in Oracle AI Database, retrieved on demand | Durable facts, past-task summaries |\n",
+       "\n",
+       "A **summarization step** compresses long conversation histories to keep the context window bounded during multi-step runs [kb-003]. On complex multi-part tasks, each sub-topic is delegated to an **isolated sub-agent** that returns only distilled, cited findings to the orchestrator — measurably improving coherence and reducing dropped constraints on long-horizon tasks [kb-008]. The orchestrator's context is reserved for planning and synthesis only.\n",
+       "\n",
+       "Critically, the model's **parametric memory is prohibited** for factual claims about customers, products, fees, or policies [kb-004]. The three-tier model is recommended as the platform-wide standard in the Aurora roadmap [kb-011].\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 3. Evaluation and Guardrails\n",
+       "\n",
+       "**Evaluation harness [kb-006]:** A golden set of **300 question-answer pairs** (each annotated with required citation documents) runs nightly. Three metrics are tracked: groundedness, answer correctness, and retrieval recall. A release is **blocked** if groundedness regresses against the prior build. Five percent of live production transcripts are sampled for human review weekly. The explicit organizational principle: *\"Evaluation and observability were funded before expanding autonomy.\"*\n",
+       "\n",
+       "**Grounding policy [kb-004]:** Every factual claim must cite a retrieved document. If retrieval returns no evidence, the agent must admit it does not know — no fallback to parametric memory.\n",
+       "\n",
+       "**Output guardrails [kb-010]:** High-impact actions (account changes, payments) require explicit human approval via an **interrupt-before-execute** mechanism. Output filters block unsupported financial advice. Autonomy was deliberately granted first to bounded, high-volume, low-risk workflows.\n",
+       "\n",
+       "**Verification step [kb-005, kb-012]:** Agentic RAG pipelines include a built-in critique pass that checks every claim against the knowledge base before the answer is returned to the customer.\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 4. Key Production Risks Learned\n",
+       "\n",
+       "| Risk | Severity | Evidence | Mitigation |\n",
+       "|---|---|---|---|\n",
+       "| Retrieval failure → hallucination | 🔴 **Critical** | May fee-waiver incident: agent fabricated a non-existent program when retrieval returned nothing [kb-005] | Hybrid retrieval [kb-001]; grounding policy [kb-004]; verification step [kb-012] |\n",
+       "| Agentic loops: 3–5× token cost + noticeable latency | 🟠 **High** | Documented cost profile [kb-007] | Iteration caps; tiered model sizing; embedding cache; UI streaming |\n",
+       "| Context window degradation on complex queries | 🟠 **High** | Dropped constraints on long-horizon tasks [kb-008] | Sub-agent isolation; summarization [kb-003] |\n",
+       "| PII exposure & ACL desynchronization | 🟠 **High** | Governance policy [kb-009] | Oracle row-level security; PII masking at retrieval; audit logging |\n",
+       "| Premature autonomy expansion | 🟡 **Medium** | Platform roadmap recommendation [kb-011] | Fund eval/observability before widening autonomy; HITL for high-impact actions [kb-010] |\n",
+       "| Monolithic agent architecture | 🟡 **Medium** | Platform roadmap recommendation [kb-011] | Prefer narrow, specialized sub-agents over one monolithic agent |\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## 5. Recommendation\n",
+       "\n",
+       "Five-point operating model for next-generation enterprise agents, grounded in Aurora's own evidence:\n",
+       "\n",
+       "1. **Default to hybrid retrieval.** Standardize on hybrid search (RRF) over Oracle AI Vector Search. Pure vector search's 0.71 recall is insufficient for a regulated financial environment where exact identifiers matter [kb-001, kb-011].\n",
+       "\n",
+       "2. **Adopt the three-tier memory model as the platform standard.** Short-term buffer + working filesystem + long-term vector store, with summarization for context management and sub-agent isolation for complex tasks [kb-003, kb-008].\n",
+       "\n",
+       "3. **Gate every release on groundedness.** The nightly 300-question harness with a hard groundedness block is the minimum viable safety net. Fund evaluation infrastructure *before* expanding agent autonomy [kb-006, kb-011].\n",
+       "\n",
+       "4. **Enforce retrieve-before-answer as a hard policy.** No agent in a regulated context should answer from parametric memory. The May incident is the proof case [kb-004, kb-005].\n",
+       "\n",
+       "5. **Expand autonomy incrementally, with HITL for high-impact actions.** Start with bounded, low-risk workflows. Add human-approval interrupts for any action with large blast radius. Pilot agentic RAG for multi-hop questions as the next capability frontier [kb-010, kb-011, kb-012].\n",
+       "\n",
+       "---\n",
+       "\n",
+       "> **Process note:** This brief was produced by four parallel KB research agents (one per sub-topic), assembled into a draft, and then verified by a critic agent that identified and corrected seven issues — including two unsupported causal claims, two overstated \"mandate\" framings (softened to \"recommended\"), a token/latency conflation, an unverified \"automatically\" qualifier, and a mislabeling of kb-011 as a \"directive\" rather than a \"recommendation to leadership.\" The final report is saved to `/final_report.md`."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(state[\"messages\"][-1].content))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67cbebbb",
+   "metadata": {},
+   "source": [
+    "# Part 5 · Stream the loop and go further\n",
+    "\n",
+    "The final power — observability — plus how to extend the pattern to production."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59262352",
+   "metadata": {},
+   "source": [
+    "## 5.1 · Power #4 — Stream the plan → act → observe loop\n",
+    "\n",
+    "`invoke` waits for the final state. `stream(..., stream_mode=\"updates\")` yields one update per\n",
+    "graph step, so you can watch the agent think, call tools, and observe results in real time — what\n",
+    "you'd surface in a UI.\n",
+    "\n",
+    "For a crisp demo we use a **leaner** deep agent built from the *same* factory but with **no\n",
+    "sub-agents** — so it plans and retrieves directly (the single-context variant) and a short question\n",
+    "streams quickly.\n",
+    "\n",
+    "**Key takeaway:** the same factory scales down to a simple planning agent and up to a multi-\n",
+    "sub-agent orchestrator — and every step is observable as it happens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "50d6a64c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:15:41.716232Z",
+     "iopub.status.busy": "2026-06-22T15:15:41.716140Z",
+     "iopub.status.idle": "2026-06-22T15:15:46.640308Z",
+     "shell.execute_reply": "2026-06-22T15:15:46.639159Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Watching the agent work, step by step:\n",
+      "\n",
+      "[PatchToolCallsMiddleware.before_agent] -\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[model] AIMessage  (calls: search)\n",
+      "[TodoListMiddleware.after_model] -\n",
+      "[tools] ToolMessage\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[model] AIMessage\n",
+      "[TodoListMiddleware.after_model] -\n"
+     ]
+    }
+   ],
+   "source": [
+    "quick_agent = create_deepagents_agent(\n",
+    "    model=llm,\n",
+    "    datastores={\"kb\": store},            # one line -> Oracle search/get_document/stats + deep harness\n",
+    "    embedding_model=embedding_model,\n",
+    "    tools=[think_tool],                  # no subagents -> it searches directly\n",
+    "    system_prompt=(\n",
+    "        \"You are a research assistant for Aurora Financial. Search the knowledge base, then answer \"\n",
+    "        \"concisely and cite Doc IDs like [kb-001]. If the KB lacks an answer, say so.\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(\"Watching the agent work, step by step:\\n\")\n",
+    "for chunk in quick_agent.stream(\n",
+    "    {\"messages\": [{\"role\": \"user\",\n",
+    "                   \"content\": \"In two sentences, what is agentic RAG and why does Aurora use it?\"}]},\n",
+    "    stream_mode=\"updates\",\n",
+    "):\n",
+    "    for node, update in chunk.items():\n",
+    "        msgs = update.get(\"messages\") if isinstance(update, dict) else None\n",
+    "        last = msgs[-1] if msgs else None\n",
+    "        kind = type(last).__name__ if last is not None else \"-\"\n",
+    "        note = \"\"\n",
+    "        if last is not None and getattr(last, \"tool_calls\", None):\n",
+    "            note = \"  (calls: \" + \", \".join(tc[\"name\"] for tc in last.tool_calls) + \")\"\n",
+    "        print(f\"[{node}] {kind}{note}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e1d379",
+   "metadata": {},
+   "source": [
+    "## 5.2 · Cleanup\n",
+    "\n",
+    "Close the datastore connection. To tear down the database entirely:\n",
+    "\n",
+    "```bash\n",
+    "docker stop oracle-free && docker rm oracle-free\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "8b0be684",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:15:46.643714Z",
+     "iopub.status.busy": "2026-06-22T15:15:46.643469Z",
+     "iopub.status.idle": "2026-06-22T15:15:46.653686Z",
+     "shell.execute_reply": "2026-06-22T15:15:46.652875Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Datastore connection closed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "store.close()\n",
+    "print(\"✓ Datastore connection closed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c0d608f",
+   "metadata": {},
+   "source": [
+    "## 5.3 · Recap & key takeaways\n",
+    "\n",
+    "- **Deep research over a private store is the canonical deep-agent use case.** We exercised all\n",
+    "  four powers — **planning**, a **virtual filesystem**, **sub-agents**, and **streaming** — on a\n",
+    "  real, ambiguous question and got a structured, verified, cited brief.\n",
+    "- **Grounding = a tool + a strict prompt.** Oracle AI Vector Search (via `ADB` +\n",
+    "  `create_datastore_tools`) is the agent's only source of truth; \"retrieve before you answer,\n",
+    "  cite Doc IDs, admit gaps\" keeps it honest, and the `critic` sub-agent adds a verification pass.\n",
+    "- **Hybrid retrieval in the database.** Co-locating the `VECTOR` embedding with the text and an\n",
+    "  **Oracle Text** index lets one tool fuse semantic + keyword search (RRF) — strong on both meaning\n",
+    "  and exact identifiers — without bolting on a separate vector database.\n",
+    "- **Bring-your-own-model decouples the brain from the data.** `create_deepagents_agent(model=...)`\n",
+    "  ran the Oracle harness on **Claude** with zero OCI credentials. The data stayed local in the\n",
+    "  Oracle AI Database.\n",
+    "\n",
+    "### Variations to try\n",
+    "- **Go fully local:** swap `ChatAnthropic` for a local Ollama model\n",
+    "  (`pip install langchain-ollama`, then `ChatOllama(model=\"qwen3\", temperature=0)`) for a\n",
+    "  zero-cloud stack. Use a strong tool-calling model — deep-agent planning is demanding.\n",
+    "- **Other providers:** `model=ChatOpenAI(model=\"gpt-5\")`, a self-hosted vLLM endpoint, or a\n",
+    "  custom-configured `ChatOCIGenAI`. The agent code is identical.\n",
+    "- **Scale the corpus:** point `ADB` at a real table of wikis/runbooks/tickets and set\n",
+    "  `chunk_on_write=True` for long documents.\n",
+    "- **Persist threads:** pass an Oracle-backed LangGraph checkpointer to keep research sessions\n",
+    "  resumable — mixing the best model with Oracle data infrastructure.\n",
+    "\n",
+    "> **🔑 Final takeaway:** A deep agent is a small set of powers — *plan, write to files, delegate to\n",
+    "> sub-agents, stream* — wrapped around an LLM. Point those powers at the **Oracle AI Database** for\n",
+    "> grounding and a **Claude** brain for reasoning, and you have a production-shaped research analyst\n",
+    "> that you can trust because every claim is cited and verified."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain_eco",
+   "language": "python",
+   "name": "langchain_eco"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds `samples/11-deepagents/local_docker_oracle_deepagents.ipynb` (authored by @RichmondAlake): an end-to-end, executed walkthrough that builds a **deep research agent** over a **private knowledge base** stored in the **Oracle AI Database**, driven by a bring-your-own-model brain (**Anthropic Claude**) through the `langchain-oci` deepagents factory.

The notebook is a self-contained sample — it stands up a local Oracle AI Database (Docker), ingests a small knowledge base with **hybrid (vector + keyword) search**, and uses the `create_deepagents_agent(datastores={"kb": store})` one-liner so Oracle retrieval composes with the full deep-agent harness:

- **Planning** — the agent writes and tracks a to-do list before acting.
- **Virtual filesystem** — long artifacts are drafted to the agent's own state, off the chat.
- **Sub-agents** — a `kb-researcher` does isolated, focused retrieval; a `critic` verifies the draft before the final brief.
- **Grounding** — every factual claim cites a retrieved document ID.

Local HuggingFace embeddings keep the data plane free of external embedding calls; only the reasoning model is hosted.

## Stacks on #234

This sample relies on two capabilities introduced in #234:

- the `model=` bring-your-own-model hook (to drive the agent with Claude), and
- datastores composing with the full deep agent (so `datastores=` yields a real deep agent rather than a lightweight ReAct loop).

It should land after #234; until then the diff shows #234's commits as well.

## Validation

The notebook ships with executed outputs. The underlying code path was additionally validated against a live Oracle Autonomous Database: with `datastores=` set (and no `middleware=[]`), the factory builds the deep agent with the planning/virtual-filesystem harness, delegates focused retrieval to sub-agents, and returns grounded, document-cited answers retrieved from the database.

## Notes

- Requires the full `gvenzl/oracle-free` image (not `:slim`) — the keyword half of hybrid search needs Oracle Text.
- `deepagents` requires Python 3.11–3.13.
