### PR TITLE
bump up langchain oci to 0.2.8

### DIFF
--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-oci"
-version = "0.2.7"
+version = "0.2.8"
 description = "An integration package connecting OCI and LangChain"
 readme = "README.md"
 license = "UPL-1.0"


### PR DESCRIPTION
Bumps the `langchain-oci` package version `0.2.7` → `0.2.8` so the recently merged work can be cut as a release (e.g. #237 — streaming reasoning surfaced as standard content blocks).

Version-only change to `libs/oci/pyproject.toml`, following the cadence of #232 / #222.