### PR TITLE
fix(oci): make model_id optional in create_oci_agent for BYO model (+ bump to 0.3.0)

### DIFF
--- a/libs/oci/langchain_oci/agents/react/agent.py
+++ b/libs/oci/langchain_oci/agents/react/agent.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 
 
 def create_oci_agent(
-    model_id: str,
-    tools: Sequence[BaseTool | Callable[..., Any]],
+    model_id: str = "meta.llama-4-scout-17b-16e-instruct",
+    tools: Sequence[BaseTool | Callable[..., Any]] | None = None,
     *,
     # Model
     model: "BaseChatModel | None" = None,
@@ -63,8 +63,10 @@ def create_oci_agent(
 
     Args:
         model_id: OCI model identifier (e.g., "meta.llama-4-scout-17b-16e-instruct").
-            Ignored when ``model`` is provided.
-        tools: List of tools the agent can use.
+            Optional; defaults to a Llama model. Used only when ``model`` is not
+            provided, so the bring-your-own-model path does not need a
+            placeholder ``model_id``.
+        tools: List of tools the agent can use. Optional; defaults to no tools.
         model: Pre-built LangChain chat model to drive the agent. When set, it
             is used as-is and ``model_id`` plus the OCI auth options (and the
             OCI-specific ``max_sequential_tool_calls`` / ``tool_result_guidance``
@@ -140,7 +142,7 @@ def create_oci_agent(
     prompt_key = "prompt" if use_legacy_api else "system_prompt"
     agent_kwargs = {
         "model": llm,
-        "tools": list(tools),
+        "tools": list(tools) if tools else [],
         **_filter_none(
             checkpointer=config.checkpointer,
             store=config.store,

--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-oci"
-version = "0.2.7"
+version = "0.3.0"
 description = "An integration package connecting OCI and LangChain"
 readme = "README.md"
 license = "UPL-1.0"

--- a/libs/oci/tests/unit_tests/agents/test_react.py
+++ b/libs/oci/tests/unit_tests/agents/test_react.py
@@ -100,6 +100,26 @@ class TestCreateOCIReactAgent:
                     mock_llm_class.assert_not_called()
                     assert mock_create.call_args.kwargs["model"] is custom_model
 
+    def test_custom_model_without_model_id(self) -> None:
+        """The BYO-model path works without a placeholder ``model_id``.
+
+        ``model_id`` is optional, so ``create_oci_agent(tools=..., model=...)``
+        drives the agent with the pre-built model and never builds a
+        ChatOCIGenAI, even with no compartment_id set.
+        """
+        custom_model = MagicMock()
+        with patch.dict("os.environ", {}, clear=True):
+            with patch(
+                "langchain_oci.chat_models.oci_generative_ai.ChatOCIGenAI"
+            ) as mock_llm_class:
+                with mock_create_agent() as mock_create:
+                    agent = create_oci_agent(tools=[dummy_tool], model=custom_model)
+
+                    mock_llm_class.assert_not_called()
+                    assert mock_create.call_args.kwargs["model"] is custom_model
+                    assert len(mock_create.call_args.kwargs["tools"]) == 1
+                    assert agent is not None
+
     def test_passes_system_prompt(self) -> None:
         """Test that system_prompt is passed to the agent creation function."""
         with patch.dict("os.environ", {"OCI_COMPARTMENT_ID": "test"}):


### PR DESCRIPTION
## Problem

Follow-up to #234 (bring-your-own chat model, already merged). That PR added a
`model=` escape hatch to the agent factories, but `create_oci_agent` (the ReAct
factory) still required a positional `model_id` even when a pre-built `model=`
was supplied. So the advertised bring-your-own-model path did not actually work
as documented — `create_oci_agent(tools=[...], model=custom_model)` raised a
`TypeError` for the missing `model_id`.

## Fix

- Default `model_id` to `"meta.llama-4-scout-17b-16e-instruct"` (matching
  `AgentConfig` and the existing `create_deepagents_agent` signature) and make
  `tools` optional, so the BYO-model path works without a placeholder `model_id`.
- When `model=` is supplied, `model_id` is ignored — `_build_llm` returns the
  pre-built model as-is — so the default is never used to build a `ChatOCIGenAI`.
- All existing positional/keyword calls (`create_oci_agent("model", [tools])`,
  `create_oci_agent(model_id=..., tools=...)`) are unchanged.
- Updated the docstring to note `model_id`/`tools` are optional.

## Version bump

Bumps `langchain-oci` `0.2.7` → `0.3.0` (minor release) so the bring-your-own
chat model / deepagents support (#234) can be released together with this fix.
#234 did not bump the version.

## Test

Adds `test_custom_model_without_model_id`, which calls
`create_oci_agent(tools=[dummy_tool], model=custom_model)` with no `model_id`
and asserts `ChatOCIGenAI` is never built and the custom model drives the agent.

Targeted unit run: agents suite green (84 passed), `ruff check` and
`ruff format --diff` clean, `git diff --check` clean.

## Note

This was originally opened against the source branch of #234
(fede-kamel/langchain-oracle#2) before #234 merged; re-targeting directly at
`oracle:main` now that the feature has landed.
