### PR TITLE
Fix incorrect tool-call indices during streaming

### DIFF
--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -722,13 +722,27 @@ class GenericProvider(Provider):
         if not tool_call_response:
             return tool_call_chunks
 
-        for idx, tool_call in enumerate(
-            self.format_stream_tool_calls(tool_call_response)
-        ):
+        formatted_tool_calls = self.format_stream_tool_calls(tool_call_response)
+        single_idless_chunk = (
+            len(formatted_tool_calls) == 1 and not formatted_tool_calls[0].get("id")
+        )
+        active_index = getattr(self, "_active_stream_tool_call_index", None)
+
+        for idx, tool_call in enumerate(formatted_tool_calls):
             tool_id = tool_call.get("id")
 
             if tool_id:
-                if idx not in tool_call_ids or tool_call_ids[idx] == tool_id:
+                existing_index = next(
+                    (
+                        stored_index
+                        for stored_index, stored_id in tool_call_ids.items()
+                        if stored_id == tool_id
+                    ),
+                    None,
+                )
+                if existing_index is not None:
+                    index = existing_index
+                elif idx not in tool_call_ids or tool_call_ids[idx] == tool_id:
                     # New idx - use idx as index
                     # Same ID at same idx - reuse idx as index
                     index = idx
@@ -736,6 +750,18 @@ class GenericProvider(Provider):
                     # Different ID at same idx - parallel tool call (Grok pattern)
                     # New idx - use len(tool_call_ids) as index
                     index = len(tool_call_ids)
+                self._active_stream_tool_call_index = index
+            elif (
+                single_idless_chunk
+                and active_index is not None
+                and active_index in tool_call_ids
+            ):
+                # GPT streams a tool-call start with id/name, then sends following
+                # argument fragments without id/name as single-item events. In that
+                # shape, enumerate idx is always 0 and is not a stable tool-call
+                # identity, so attach the fragment to the active tool call.
+                index = active_index
+                tool_id = tool_call_ids[index]
             elif idx in tool_call_ids:
                 # Subsequent chunk - reuse stored ID (gpt-oss pattern)
                 index = idx


### PR DESCRIPTION
## Summary

Fix GPT streamed parallel tool-call reconstruction in `langchain-oci`.

GPT models can stream tool calls as:

1. A start chunk with `id`, `name`, and empty `arguments`
2. Many following argument chunks that contain only `arguments` fragments, without `id` or `name`

`GenericProvider.process_stream_tool_calls` was using the per-event `enumerate` index as the stable tool-call identity. That breaks when GPT emits multiple tool calls in one assistant turn, because many argument-fragment events contain only one `toolCalls[0]` item.

## Problem

With one streamed tool call, id-less argument fragments can usually be mapped back to the only open tool call.

With parallel tool calls, GPT can open tool A, stream A's argument fragments, then open tool B and stream B's argument fragments. Those B fragments are also id-less and also appear as `toolCalls[0]` in single-item stream events.

Example:

```text
event 0:  toolCalls[0] = {id: call_A, name: market_research_tool, arguments: ""}
event 1:  toolCalls[0] = {arguments: "{\"idea"}
...
event 21: toolCalls[0] = {id: call_B, name: customer_signal_tool, arguments: ""}
event 22: toolCalls[0] = {arguments: "{\"idea"}
```

The old logic could assign event 22 to `call_A` instead of `call_B`, leaving later tools with empty `{}` args and causing required-parameter validation failures.

## Fix

Track the active stream tool-call index when a chunk with an `id` opens a new tool call. When a later single id-less argument chunk arrives, attach it to the active tool call.

## Validation

Validated with a local GPT-4.1 repro using three parallel tools.