### PR TITLE
fix(oci): attach id-less streamed tool-call argument fragments to the active tool call

### DIFF
--- a/libs/oci/langchain_oci/chat_models/async_mixin.py
+++ b/libs/oci/langchain_oci/chat_models/async_mixin.py
@@ -200,6 +200,9 @@ class ChatOCIGenAIAsyncMixin:
             messages, stop, stream=True, **kwargs
         )
         tool_call_ids: Dict[int, str] = {}
+        # Per-stream position -> logical index routing map, caller-owned so
+        # concurrent streams can't corrupt each other (see _stream's note).
+        active_tool_call_indices: Dict[int, int] = {}
 
         # Per-stream provider state, owned by this call (see _stream's note).
         # Concurrent astream calls on a shared chat-model instance interleave
@@ -256,7 +259,10 @@ class ChatOCIGenAIAsyncMixin:
                     event_data, **state_kwargs
                 )
                 tool_call_chunks = self._provider.process_stream_tool_calls(  # type: ignore[attr-defined]
-                    event_data, tool_call_ids, **state_kwargs
+                    event_data,
+                    tool_call_ids,
+                    active_tool_call_indices=active_tool_call_indices,
+                    **state_kwargs,
                 )
 
                 # Surface incremental reasoning (e.g. xAI Grok, OpenAI o-series)

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -589,6 +589,10 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         request = self._prepare_request(messages, stop=stop, stream=True, **kwargs)
         response = self._chat_with_param_retry(request)
         tool_call_ids: Dict[int, str] = {}
+        # Per-stream toolCalls position -> logical index routing map, owned
+        # here (not on the shared provider) so concurrent streams on one
+        # ChatOCIGenAI instance can't corrupt each other's tool-call routing.
+        active_tool_call_indices: Dict[int, int] = {}
 
         # Per-stream provider state (currently the GenericProvider's
         # incremental <tool_call> XML buffer used for Hermes/Llama-style DAC
@@ -613,7 +617,10 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 # Process streaming content
                 delta = self._provider.chat_stream_to_text(event_data, **state_kwargs)
                 tool_call_chunks = self._provider.process_stream_tool_calls(
-                    event_data, tool_call_ids, **state_kwargs
+                    event_data,
+                    tool_call_ids,
+                    active_tool_call_indices=active_tool_call_indices,
+                    **state_kwargs,
                 )
 
                 # Surface incremental reasoning (e.g. xAI Grok, OpenAI o-series)

--- a/libs/oci/langchain_oci/chat_models/providers/base.py
+++ b/libs/oci/langchain_oci/chat_models/providers/base.py
@@ -158,11 +158,17 @@ class Provider(ABC):
         event_data: Dict,
         tool_call_ids: Dict[int, str],
         stream_state: Optional[Any] = None,
+        active_tool_call_indices: Optional[Dict[int, int]] = None,
     ) -> List[ToolCallChunk]:
         """Process streaming tool calls from event data into chunks.
 
         ``stream_state`` is the object returned by :meth:`new_stream_state`
         for the current stream (``None`` for stateless providers).
+
+        ``tool_call_ids`` and ``active_tool_call_indices`` are per-stream
+        aggregation state owned by the caller (``_stream`` / ``_astream``),
+        never by the provider, so concurrent streams sharing one provider
+        instance can't corrupt each other's tool-call routing.
         """
         ...
 

--- a/libs/oci/langchain_oci/chat_models/providers/cohere.py
+++ b/libs/oci/langchain_oci/chat_models/providers/cohere.py
@@ -739,6 +739,7 @@ class CohereProvider(Provider):
         event_data: Dict,
         tool_call_ids: Dict[int, str],
         stream_state: Optional[Any] = None,
+        active_tool_call_indices: Optional[Dict[int, int]] = None,
     ) -> List[ToolCallChunk]:
         """
         Process Cohere stream tool calls and return them as ToolCallChunk objects.
@@ -747,6 +748,9 @@ class CohereProvider(Provider):
             event_data: The event data from the stream
             tool_call_ids: Dict mapping tool call IDs for aggregation
             stream_state: Unused — Cohere parsing is stateless per event
+            active_tool_call_indices: Accepted for signature parity with the
+                base provider; Cohere streams don't emit id-less fragments at
+                reused positions, so it is unused here.
 
         Returns:
             List of ToolCallChunk objects

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -141,6 +141,13 @@ class GenericProvider(Provider):
         # and never touch it.
         self._xml_buffer = XmlStreamBuffer()
 
+        # Per-stream map of per-event toolCalls position -> logical tool-call
+        # index. GPT models stream parallel tool calls sequentially at
+        # position 0 (id+name opens a call, then id-less argument fragments
+        # follow), so a position can point at different logical calls over the
+        # stream's lifetime. Reset by `reset_stream_state()`.
+        self._active_tool_call_indices: Dict[int, int] = {}
+
         # Chat request and message models
         self.oci_chat_request = models.GenericChatRequest
         self.oci_chat_message = {
@@ -288,6 +295,7 @@ class GenericProvider(Provider):
         caller-owned state via :meth:`new_stream_state`, which needs no reset.
         """
         self._xml_buffer.reset()
+        self._active_tool_call_indices.clear()
 
     def flush_stream_state(self) -> str:
         """Return held-back text from the legacy instance-level buffer.
@@ -1000,9 +1008,18 @@ class GenericProvider(Provider):
                     # Same ID at same idx - reuse idx as index
                     index = idx
                 else:
-                    # Different ID at same idx - parallel tool call (Grok pattern)
-                    # New idx - use len(tool_call_ids) as index
+                    # Different ID at same idx - parallel tool call
+                    # (Grok/GPT pattern) - use len(tool_call_ids) as index
                     index = len(tool_call_ids)
+                # This position now feeds this logical call; id-less argument
+                # fragments arriving here later belong to it.
+                self._active_tool_call_indices[idx] = index
+            elif idx in self._active_tool_call_indices:
+                # Id-less argument fragment - attach it to the call most
+                # recently opened at this position (GPT parallel pattern);
+                # for single-call streams this equals idx (gpt-oss pattern).
+                index = self._active_tool_call_indices[idx]
+                tool_id = tool_call_ids[index]
             elif idx in tool_call_ids:
                 # Subsequent chunk - reuse stored ID (gpt-oss pattern)
                 index = idx

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -141,13 +141,6 @@ class GenericProvider(Provider):
         # and never touch it.
         self._xml_buffer = XmlStreamBuffer()
 
-        # Per-stream map of per-event toolCalls position -> logical tool-call
-        # index. GPT models stream parallel tool calls sequentially at
-        # position 0 (id+name opens a call, then id-less argument fragments
-        # follow), so a position can point at different logical calls over the
-        # stream's lifetime. Reset by `reset_stream_state()`.
-        self._active_tool_call_indices: Dict[int, int] = {}
-
         # Chat request and message models
         self.oci_chat_request = models.GenericChatRequest
         self.oci_chat_message = {
@@ -295,7 +288,6 @@ class GenericProvider(Provider):
         caller-owned state via :meth:`new_stream_state`, which needs no reset.
         """
         self._xml_buffer.reset()
-        self._active_tool_call_indices.clear()
 
     def flush_stream_state(self) -> str:
         """Return held-back text from the legacy instance-level buffer.
@@ -958,6 +950,7 @@ class GenericProvider(Provider):
         event_data: Dict,
         tool_call_ids: Dict[int, str],
         stream_state: Optional[XmlStreamBuffer] = None,
+        active_tool_call_indices: Optional[Dict[int, int]] = None,
     ) -> List[ToolCallChunk]:
         """
         Process Meta stream tool calls and convert them to ToolCallChunks.
@@ -972,10 +965,22 @@ class GenericProvider(Provider):
             stream_state: Per-stream buffer from :meth:`new_stream_state`;
                 when ``None``, falls back to the legacy instance-level buffer
                 (not safe under concurrent streaming)
+            active_tool_call_indices: Per-stream map of per-event toolCalls
+                position -> logical tool-call index, owned by the caller like
+                ``tool_call_ids`` so concurrent streams on one provider don't
+                corrupt each other's routing. GPT models stream parallel tool
+                calls sequentially at position 0 (id+name opens a call, then
+                id-less argument fragments follow), so a position can point at
+                different logical calls over the stream's lifetime. When
+                ``None``, id-less fragments fall back to positional routing
+                only (pre-#254 behavior).
 
         Returns:
             List of ToolCallChunk objects
         """
+        if active_tool_call_indices is None:
+            active_tool_call_indices = {}
+
         tool_call_chunks: List[ToolCallChunk] = []
 
         # Drain XML tool calls that completed during this event.
@@ -1021,12 +1026,12 @@ class GenericProvider(Provider):
                     index = len(tool_call_ids)
                 # This position now feeds this logical call; id-less argument
                 # fragments arriving here later belong to it.
-                self._active_tool_call_indices[idx] = index
-            elif idx in self._active_tool_call_indices:
+                active_tool_call_indices[idx] = index
+            elif idx in active_tool_call_indices:
                 # Id-less argument fragment - attach it to the call most
                 # recently opened at this position (GPT parallel pattern);
                 # for single-call streams this equals idx (gpt-oss pattern).
-                index = self._active_tool_call_indices[idx]
+                index = active_tool_call_indices[idx]
                 tool_id = tool_call_ids[index]
             elif idx in tool_call_ids:
                 # Subsequent chunk - reuse stored ID (gpt-oss pattern)

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -1003,9 +1003,17 @@ class GenericProvider(Provider):
             tool_id = tool_call.get("id")
 
             if tool_id:
-                if idx not in tool_call_ids or tool_call_ids[idx] == tool_id:
+                known_index = next(
+                    (i for i, known in tool_call_ids.items() if known == tool_id),
+                    None,
+                )
+                if known_index is not None:
+                    # Re-announced id for an already-open call (possibly at a
+                    # different position) - keep its logical index so its
+                    # arguments never split across two tool calls.
+                    index = known_index
+                elif idx not in tool_call_ids:
                     # New idx - use idx as index
-                    # Same ID at same idx - reuse idx as index
                     index = idx
                 else:
                     # Different ID at same idx - parallel tool call

--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-oci"
-version = "0.3.0"
+version = "0.3.1"
 description = "An integration package connecting OCI and LangChain"
 readme = "README.md"
 license = "UPL-1.0"

--- a/libs/oci/tests/integration_tests/chat_models/test_openai_tool_calling.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_openai_tool_calling.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Integration tests for OpenAI GPT streamed parallel tool calling (issue #253).
+
+GPT models stream parallel tool calls sequentially at ``toolCalls[0]``:
+each call opens with a chunk carrying id/name and empty arguments, then
+id-less argument fragments follow. These tests verify that every tool
+call in a multi-tool assistant turn reconstructs with its own complete,
+valid arguments — on both the sync and async streaming paths.
+
+## Environment variables
+
+- ``OCI_COMPARTMENT_ID`` — required; tests skip when unset.
+- ``OCI_REGION`` — region for the GenAI endpoint (default ``us-chicago-1``).
+- ``OCI_AUTH_TYPE`` / ``OCI_CONFIG_PROFILE`` — auth configuration
+  (defaults: ``API_KEY`` / ``API_KEY_AUTH``).
+- ``OCI_GPT_PARALLEL_MODELS`` — comma-separated GPT model ids to
+  exercise (default ``openai.gpt-4.1``, the model from issue #253).
+"""
+
+import os
+from typing import Callable, Dict, Optional
+
+import pytest
+from langchain_core.messages import AIMessageChunk, BaseMessageChunk
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from langchain_oci.chat_models import ChatOCIGenAI
+
+from .conftest import _env_list
+
+GPT_PARALLEL_MODELS = _env_list("OCI_GPT_PARALLEL_MODELS", ["openai.gpt-4.1"])
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OCI_COMPARTMENT_ID"),
+    reason="OCI_COMPARTMENT_ID not set",
+)
+
+
+# --------------- tools ---------------
+
+
+class MarketResearchInput(BaseModel):
+    idea: str = Field(description="The product idea to research")
+    market_segment: str = Field(description="Target market segment")
+
+
+class CustomerSignalInput(BaseModel):
+    idea: str = Field(description="The product idea to analyze")
+    audience: str = Field(description="Target audience")
+
+
+class RoadmapRiskInput(BaseModel):
+    product_area: str = Field(description="Product area to assess")
+    risk_focus: str = Field(description="Primary risk dimension")
+
+
+def _market_research(idea: str, market_segment: str) -> str:
+    return f"Market research for {idea} in {market_segment}: TAM $1B."
+
+
+def _customer_signal(idea: str, audience: str) -> str:
+    return f"Customer signal for {idea} among {audience}: strong interest."
+
+
+def _roadmap_risk(product_area: str, risk_focus: str) -> str:
+    return f"Roadmap risk for {product_area} on {risk_focus}: moderate."
+
+
+market_research_tool = StructuredTool.from_function(
+    func=_market_research,
+    name="market_research_tool",
+    description="Research the market for a product idea.",
+    args_schema=MarketResearchInput,
+)
+
+customer_signal_tool = StructuredTool.from_function(
+    func=_customer_signal,
+    name="customer_signal_tool",
+    description="Analyze customer signals for a product idea.",
+    args_schema=CustomerSignalInput,
+)
+
+roadmap_risk_tool = StructuredTool.from_function(
+    func=_roadmap_risk,
+    name="roadmap_risk_tool",
+    description="Assess roadmap risk for a product area.",
+    args_schema=RoadmapRiskInput,
+)
+
+ALL_TOOLS = [market_research_tool, customer_signal_tool, roadmap_risk_tool]
+
+# Typed as constructors rather than type[BaseModel]: the pydantic mypy
+# plugin synthesizes per-class __init__ signatures, making the class
+# objects mutually incompatible as types.
+ARGS_SCHEMAS: Dict[str, Callable[..., BaseModel]] = {
+    "market_research_tool": MarketResearchInput,
+    "customer_signal_tool": CustomerSignalInput,
+    "roadmap_risk_tool": RoadmapRiskInput,
+}
+
+PARALLEL_PROMPT = (
+    "Call all three tools before responding:\n"
+    "- market_research_tool for the idea 'AI meal planner' in the "
+    "'busy professionals' market segment\n"
+    "- customer_signal_tool for the idea 'AI meal planner' with the "
+    "'working parents' audience\n"
+    "- roadmap_risk_tool for the 'mobile app' product area with a "
+    "'churn' risk focus"
+)
+
+
+# --------------- helpers ---------------
+
+
+def _make_llm(model_id: str) -> ChatOCIGenAI:
+    region = os.getenv("OCI_REGION", "us-chicago-1")
+    endpoint = f"https://inference.generativeai.{region}.oci.oraclecloud.com"
+    return ChatOCIGenAI(
+        model_id=model_id,
+        service_endpoint=endpoint,
+        compartment_id=os.environ["OCI_COMPARTMENT_ID"],
+        model_kwargs={"max_tokens": 1024},
+        auth_type=os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
+        auth_profile=os.environ.get("OCI_CONFIG_PROFILE", "API_KEY_AUTH"),
+        auth_file_location=os.path.expanduser("~/.oci/config"),
+    )
+
+
+def _assert_parallel_tool_calls_reconstructed(
+    merged: Optional[BaseMessageChunk], model_id: str
+) -> None:
+    """Assert every streamed tool call carries its own complete arguments."""
+    assert merged is not None, f"{model_id}: stream produced no chunks"
+    assert isinstance(merged, AIMessageChunk)
+
+    assert not merged.invalid_tool_calls, (
+        f"{model_id}: malformed tool calls reconstructed from stream: "
+        f"{merged.invalid_tool_calls}"
+    )
+
+    if len(merged.tool_calls) < 2:
+        pytest.skip(
+            f"{model_id}: model made {len(merged.tool_calls)} tool call(s); "
+            "need 2+ in one turn to exercise parallel reconstruction"
+        )
+
+    for tc in merged.tool_calls:
+        assert tc["name"] in ARGS_SCHEMAS, f"{model_id}: unknown tool {tc['name']}"
+        assert tc["args"], (
+            f"{model_id}: {tc['name']} reconstructed with empty args "
+            "(fragments were routed to another tool call)"
+        )
+        # Args must validate against the tool's schema — catches both
+        # empty {} and cross-contaminated argument fragments.
+        ARGS_SCHEMAS[tc["name"]](**tc["args"])
+
+    ids = [tc["id"] for tc in merged.tool_calls]
+    assert len(ids) == len(set(ids)), f"{model_id}: duplicate tool call ids: {ids}"
+
+
+# --------------- tests ---------------
+
+
+@pytest.mark.parametrize("model_id", GPT_PARALLEL_MODELS)
+def test_gpt_streamed_parallel_tool_calls(model_id: str) -> None:
+    """Streamed parallel tool calls each reconstruct with their own args."""
+    llm = _make_llm(model_id).bind_tools(ALL_TOOLS)
+
+    merged: Optional[BaseMessageChunk] = None
+    for chunk in llm.stream(PARALLEL_PROMPT):
+        assert isinstance(chunk, AIMessageChunk)
+        merged = chunk if merged is None else merged + chunk
+
+    _assert_parallel_tool_calls_reconstructed(merged, model_id)
+
+
+@pytest.mark.parametrize("model_id", GPT_PARALLEL_MODELS)
+async def test_gpt_streamed_parallel_tool_calls_async(model_id: str) -> None:
+    """Async streaming path reconstructs parallel tool calls identically."""
+    llm = _make_llm(model_id).bind_tools(ALL_TOOLS)
+
+    merged: Optional[BaseMessageChunk] = None
+    async for chunk in llm.astream(PARALLEL_PROMPT):
+        assert isinstance(chunk, AIMessageChunk)
+        merged = chunk if merged is None else merged + chunk
+
+    _assert_parallel_tool_calls_reconstructed(merged, model_id)

--- a/libs/oci/tests/unit_tests/chat_models/test_openai_streaming_fix.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_openai_streaming_fix.py
@@ -191,6 +191,37 @@ def test_process_stream_tool_calls_parallel_gpt_pattern():
     assert merged.tool_calls[2]["args"] == {"productArea": "auth", "riskFocus": "churn"}
 
 
+def test_process_stream_tool_calls_resent_id_keeps_logical_index():
+    """A re-announced id keeps its logical index even at a new position.
+
+    If a provider re-sends an id-bearing chunk for an already-open call at
+    a position occupied by a different call, the call must keep its
+    original logical index — otherwise its arguments split across two
+    tool calls. (Hardening ported from the approach in PR #252.)
+    """
+    provider = GenericProvider()
+    tool_call_ids: dict[int, str] = {}
+
+    def event(tool_call: dict) -> dict:
+        return {"message": {"toolCalls": [tool_call]}}
+
+    chunks = []
+    for e in [
+        event({"id": "call_A", "name": "a", "arguments": ""}),
+        event({"id": "call_B", "name": "b", "arguments": ""}),  # Grok branch -> 1
+        event({"id": "call_B", "arguments": '{"y": 2}'}),  # re-send at pos 0
+        event({"id": "call_A", "arguments": '{"x": 1}'}),  # re-send at pos 0
+    ]:
+        chunks.extend(provider.process_stream_tool_calls(e, tool_call_ids))
+
+    assert [(c["id"], c["index"]) for c in chunks] == [
+        ("call_A", 0),
+        ("call_B", 1),
+        ("call_B", 1),
+        ("call_A", 0),
+    ]
+
+
 def test_process_stream_tool_calls_position_map_resets_between_streams():
     """reset_stream_state clears the position map so a new stream starts clean."""
     provider = GenericProvider()

--- a/libs/oci/tests/unit_tests/chat_models/test_openai_streaming_fix.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_openai_streaming_fix.py
@@ -8,7 +8,12 @@ correctly and don't cause API errors when messages are sent back.
 """
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessageChunk,
+    HumanMessage,
+)
 
 from langchain_oci.chat_models.providers import GenericProvider
 
@@ -125,6 +130,84 @@ def test_process_stream_tool_calls_handles_none_values():
     assert chunks_2[0]["id"] == "call_123"
     assert chunks_2[0]["name"] is None
     assert chunks_2[0]["args"] == '{"query": "test", "version": "9.3.0"}'
+
+
+def test_process_stream_tool_calls_parallel_gpt_pattern():
+    """Parallel tool calls streamed sequentially at position 0 (issue #253).
+
+    GPT models open each tool call with a chunk carrying id/name and empty
+    arguments, then stream id-less argument fragments — all at toolCalls[0].
+    Fragments arriving after a second call opens must attach to that call,
+    not to the first one.
+    """
+    provider = GenericProvider()
+    tool_call_ids: dict[int, str] = {}
+
+    def event(tool_call: dict) -> dict:
+        return {"message": {"toolCalls": [{"type": "FUNCTION", **tool_call}]}}
+
+    events = [
+        event({"id": "call_A", "name": "market_research_tool", "arguments": ""}),
+        event({"arguments": '{"idea": "app",'}),
+        event({"arguments": ' "marketSegment": "smb"}'}),
+        event({"id": "call_B", "name": "customer_signal_tool", "arguments": ""}),
+        event({"arguments": '{"idea": "app",'}),
+        event({"arguments": ' "audience": "devs"}'}),
+        event({"id": "call_C", "name": "roadmap_risk_tool", "arguments": ""}),
+        event({"arguments": '{"productArea": "auth",'}),
+        event({"arguments": ' "riskFocus": "churn"}'}),
+    ]
+
+    chunks = []
+    for e in events:
+        chunks.extend(provider.process_stream_tool_calls(e, tool_call_ids))
+
+    # Each call's argument fragments must carry that call's logical index.
+    assert [(c["id"], c["index"]) for c in chunks] == [
+        ("call_A", 0),
+        ("call_A", 0),
+        ("call_A", 0),
+        ("call_B", 1),
+        ("call_B", 1),
+        ("call_B", 1),
+        ("call_C", 2),
+        ("call_C", 2),
+        ("call_C", 2),
+    ]
+
+    # Merge the chunks the way LangChain does during streaming and verify
+    # each tool call reconstructs with its own complete arguments.
+    merged: BaseMessageChunk = AIMessageChunk(content="")
+    for c in chunks:
+        merged = merged + AIMessageChunk(content="", tool_call_chunks=[c])
+
+    assert isinstance(merged, AIMessageChunk)
+    assert len(merged.tool_calls) == 3
+    assert merged.tool_calls[0]["name"] == "market_research_tool"
+    assert merged.tool_calls[0]["args"] == {"idea": "app", "marketSegment": "smb"}
+    assert merged.tool_calls[1]["name"] == "customer_signal_tool"
+    assert merged.tool_calls[1]["args"] == {"idea": "app", "audience": "devs"}
+    assert merged.tool_calls[2]["name"] == "roadmap_risk_tool"
+    assert merged.tool_calls[2]["args"] == {"productArea": "auth", "riskFocus": "churn"}
+
+
+def test_process_stream_tool_calls_position_map_resets_between_streams():
+    """reset_stream_state clears the position map so a new stream starts clean."""
+    provider = GenericProvider()
+    tool_call_ids: dict[int, str] = {}
+
+    provider.process_stream_tool_calls(
+        {"message": {"toolCalls": [{"id": "call_A", "name": "t", "arguments": ""}]}},
+        tool_call_ids,
+    )
+    provider.process_stream_tool_calls(
+        {"message": {"toolCalls": [{"id": "call_B", "name": "u", "arguments": ""}]}},
+        tool_call_ids,
+    )
+    assert provider._active_tool_call_indices == {0: 1}
+
+    provider.reset_stream_state()
+    assert provider._active_tool_call_indices == {}
 
 
 if __name__ == "__main__":

--- a/libs/oci/tests/unit_tests/chat_models/test_openai_streaming_fix.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_openai_streaming_fix.py
@@ -142,6 +142,7 @@ def test_process_stream_tool_calls_parallel_gpt_pattern():
     """
     provider = GenericProvider()
     tool_call_ids: dict[int, str] = {}
+    active_tool_call_indices: dict[int, int] = {}
 
     def event(tool_call: dict) -> dict:
         return {"message": {"toolCalls": [{"type": "FUNCTION", **tool_call}]}}
@@ -160,7 +161,11 @@ def test_process_stream_tool_calls_parallel_gpt_pattern():
 
     chunks = []
     for e in events:
-        chunks.extend(provider.process_stream_tool_calls(e, tool_call_ids))
+        chunks.extend(
+            provider.process_stream_tool_calls(
+                e, tool_call_ids, active_tool_call_indices=active_tool_call_indices
+            )
+        )
 
     # Each call's argument fragments must carry that call's logical index.
     assert [(c["id"], c["index"]) for c in chunks] == [
@@ -201,6 +206,7 @@ def test_process_stream_tool_calls_resent_id_keeps_logical_index():
     """
     provider = GenericProvider()
     tool_call_ids: dict[int, str] = {}
+    active_tool_call_indices: dict[int, int] = {}
 
     def event(tool_call: dict) -> dict:
         return {"message": {"toolCalls": [tool_call]}}
@@ -212,7 +218,11 @@ def test_process_stream_tool_calls_resent_id_keeps_logical_index():
         event({"id": "call_B", "arguments": '{"y": 2}'}),  # re-send at pos 0
         event({"id": "call_A", "arguments": '{"x": 1}'}),  # re-send at pos 0
     ]:
-        chunks.extend(provider.process_stream_tool_calls(e, tool_call_ids))
+        chunks.extend(
+            provider.process_stream_tool_calls(
+                e, tool_call_ids, active_tool_call_indices=active_tool_call_indices
+            )
+        )
 
     assert [(c["id"], c["index"]) for c in chunks] == [
         ("call_A", 0),
@@ -222,23 +232,51 @@ def test_process_stream_tool_calls_resent_id_keeps_logical_index():
     ]
 
 
-def test_process_stream_tool_calls_position_map_resets_between_streams():
-    """reset_stream_state clears the position map so a new stream starts clean."""
+def test_process_stream_tool_calls_routing_state_is_per_stream():
+    """Concurrent streams on one provider don't corrupt each other's routing.
+
+    The position -> logical-index map is caller-owned per-stream state (like
+    ``tool_call_ids``), not provider state. Interleaving two streams must not
+    reroute one stream's id-less fragments to the wrong call:
+
+    1. Stream A opens calls A and B at position 0; its active index is 1.
+    2. Stream B starts and sets its own position 0 to index 0.
+    3. Stream A receives call B's next id-less argument fragment.
+    4. The fragment must stay attached to call B (index 1), not call A.
+    """
     provider = GenericProvider()
-    tool_call_ids: dict[int, str] = {}
+    ids_a: dict[int, str] = {}
+    indices_a: dict[int, int] = {}
+    ids_b: dict[int, str] = {}
+    indices_b: dict[int, int] = {}
+
+    def event(tool_call: dict) -> dict:
+        return {"message": {"toolCalls": [{"type": "FUNCTION", **tool_call}]}}
 
     provider.process_stream_tool_calls(
-        {"message": {"toolCalls": [{"id": "call_A", "name": "t", "arguments": ""}]}},
-        tool_call_ids,
+        event({"id": "call_A", "name": "a", "arguments": ""}),
+        ids_a,
+        active_tool_call_indices=indices_a,
     )
     provider.process_stream_tool_calls(
-        {"message": {"toolCalls": [{"id": "call_B", "name": "u", "arguments": ""}]}},
-        tool_call_ids,
+        event({"id": "call_B", "name": "b", "arguments": ""}),
+        ids_a,
+        active_tool_call_indices=indices_a,
     )
-    assert provider._active_tool_call_indices == {0: 1}
+    # Stream B starts on the same provider instance.
+    provider.process_stream_tool_calls(
+        event({"id": "call_X", "name": "x", "arguments": ""}),
+        ids_b,
+        active_tool_call_indices=indices_b,
+    )
+    # Stream A's id-less fragment for call_B must still route to index 1.
+    chunks = provider.process_stream_tool_calls(
+        event({"arguments": '{"y": 2}'}), ids_a, active_tool_call_indices=indices_a
+    )
 
-    provider.reset_stream_state()
-    assert provider._active_tool_call_indices == {}
+    assert [(c["id"], c["index"]) for c in chunks] == [("call_B", 1)]
+    assert indices_a == {0: 1}
+    assert indices_b == {0: 0}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #253 — GPT streamed parallel tool-call argument fragments can be assigned to the wrong tool call.

GPT models served via OCI GenAI stream parallel tool calls **sequentially at `toolCalls[0]`**: each call is opened by a chunk carrying `id`/`name` and empty `arguments`, followed by argument fragments that carry neither `id` nor `name`:

```text
event 0:  toolCalls[0] = {id: call_A, name: market_research_tool, arguments: ""}
event 1:  toolCalls[0] = {arguments: "{\"idea"}
...
event 21: toolCalls[0] = {id: call_B, name: customer_signal_tool, arguments: ""}
event 22: toolCalls[0] = {arguments: "{\"idea"}      <-- belongs to call_B
```

## Root cause

`GenericProvider.process_stream_tool_calls` routed id-less fragments by their per-event array position (`enumerate` index):

- Event 21 (`call_B` at position 0, different id than `call_A`) was correctly detected as a parallel call and assigned logical index 1.
- But event 22's id-less fragment — still arriving at position 0 — matched the `elif idx in tool_call_ids` branch and was routed back to **logical index 0 (`call_A`)**.

Result: the first tool call accumulated both tools' argument fragments concatenated (malformed JSON), and later tool calls finished with empty `{}` args, failing tool validation downstream even though the model produced complete arguments.

The OCI stream payload carries no `index` field on tool calls (the `FunctionCall` model has only `id`, `name`, `arguments`, `type`), so array position alone cannot identify the logical call.

## Fix

Track, per stream, which logical tool-call index each array position currently feeds (`_active_tool_call_indices: Dict[int, int]` on the provider):

- When a chunk with an `id` opens (or re-opens) a call at position `idx`, record `position → logical index`.
- Id-less argument fragments at `idx` route through that map — i.e. they attach to the call most recently opened at that position — instead of assuming position equals identity.

The map is cleared by `reset_stream_state()`, the same per-stream lifecycle as the existing `_xml_buffer`, so both `_stream` and `_astream` get the fix and the reset automatically.

### Why this works — state trace over the #253 stream

Walking the fixed algorithm over the reported stream, with the two pieces of state: `tool_call_ids` (logical index → id, unchanged) and the new `_active_tool_call_indices` (array position → logical index):

| Event | Chunk at `toolCalls[0]` | Branch taken | position map | `tool_call_ids` | Emitted `(id, index)` |
|---|---|---|---|---|---|
| 0 | `id=call_A, name, args=""` | new id at new position → index 0 | `{0: 0}` | `{0: call_A}` | `(call_A, 0)` ✅ |
| 1..n | `args` fragment (no id) | position 0 → active index **0** | `{0: 0}` | `{0: call_A}` | `(call_A, 0)` ✅ |
| 21 | `id=call_B, name, args=""` | different id at used position → parallel call, index `len(tool_call_ids)` = 1 | `{0: 1}` | `{0: call_A, 1: call_B}` | `(call_B, 1)` ✅ |
| 22.. | `args` fragment (no id) | position 0 → active index **1** | `{0: 1}` | `{0: call_A, 1: call_B}` | `(call_B, 1)` ✅ **(was `(call_A, 0)` ❌ before)** |

The single divergence from the old logic is the fragment-routing step (event 22+): the old code looked up `tool_call_ids` by array position and always resolved position 0 to `call_A`; the new code looks up the position map, which event 21 repointed at `call_B`. Everything downstream is untouched — LangChain merges `ToolCallChunk`s by `index`, so once every fragment carries the right logical index, each tool call's arguments concatenate into complete, parseable JSON.

Correctness of the invariant: a fragment with no `id` can only belong to a call that was previously opened by an id-bearing chunk **at the same array position** — the API gives no other association. The map records exactly that (most recent id-bearing open per position), so fragments follow their opener by construction. For streams where positions never get reused (gpt-oss, Gemini), the map is the identity mapping and behavior is bit-for-bit identical to before.

### Compatibility with existing stream shapes

| Provider pattern | Stream shape | Behavior |
|---|---|---|
| GPT parallel (#253) | sequential opens at position 0, id-less fragments between | **fixed** — fragments follow the active call |
| gpt-oss fragmented | single call, id in first chunk only | unchanged — position maps to itself |
| Grok parallel | complete call per event, same position, different ids | unchanged — new logical index per new id |
| Gemini | id-less complete calls | unchanged — generated UUID per position |

## Proof

Two independent lines of evidence, one synthetic and one against the live service:

1. **Unit-level**: the new regression test replays the exact #253 stream shape (three calls opened sequentially at position 0 with id-less fragments between). Against the old code it fails — `call_A` receives all three tools' fragments and `call_B`/`call_C` merge with empty args; against this fix every chunk carries the right `(id, index)` and the merged message has three complete tool calls.
2. **Live A/B**: the new integration test was run against OCI GenAI with `openai.gpt-4.1` twice — once with `generic.py` from `main` (pre-fix) and once with this branch. Pre-fix it fails with the exact reported symptom; with the fix it passes on both sync and async paths:

```text
# generic.py from main (pre-fix):
AssertionError: openai.gpt-4.1: customer_signal_tool reconstructed with
empty args (fragments were routed to another tool call)
1 failed in 5.29s

# this branch:
2 passed in 5.00s
```

## Testing

### Unit

- New regression test reproducing the exact #253 stream shape with three parallel tool calls (`call_A`/`call_B`/`call_C` opened sequentially at position 0 with id-less fragments between): asserts per-chunk `(id, index)` routing and the final LangChain-merged message — three tool calls, each with its own complete, parseable arguments.
- New test that `reset_stream_state()` clears the position map between streams.
- Full `tests/unit_tests` suite: **456 passed, 12 skipped**. ruff + mypy clean on 3.9 (langchain-core 0.3.x) and 3.10+ (langchain-core 1.x).

### Integration (live against OCI GenAI)

Added `tests/integration_tests/chat_models/test_openai_tool_calling.py`:

- Binds three `StructuredTool`s with required params (`market_research_tool`, `customer_signal_tool`, `roadmap_risk_tool` — mirroring the #253 repro) to a GPT model.
- Streams a single assistant turn that calls all three, merges chunks the way LangChain does, and asserts: no `invalid_tool_calls`, every tool call has non-empty args that validate against its tool's schema, and all tool-call ids are unique.
- Covers **both the sync (`stream`) and async (`astream`) paths**.
- Fully env-driven (`OCI_COMPARTMENT_ID`, `OCI_REGION`, `OCI_AUTH_TYPE`, `OCI_CONFIG_PROFILE`, `OCI_GPT_PARALLEL_MODELS` — default `openai.gpt-4.1`); skips when no compartment is configured.

Live results with `openai.gpt-4.1` are in the **Proof** section above: pre-fix code fails with the exact #253 symptom; this branch passes on both paths.

## Release

Also bumps `langchain-oci` to **0.3.1** for this bugfix release (0.3.0 is the current PyPI release).
