### PR TITLE
fix(oci): per-stream <tool_call> parser state — fix concurrent streaming races on shared ChatOCIGenAI instances

### DIFF
--- a/libs/oci/langchain_oci/chat_models/async_mixin.py
+++ b/libs/oci/langchain_oci/chat_models/async_mixin.py
@@ -201,10 +201,20 @@ class ChatOCIGenAIAsyncMixin:
         )
         tool_call_ids: Dict[int, str] = {}
 
-        # Reset per-stream provider state (see _stream's note).
-        reset = getattr(self._provider, "reset_stream_state", None)  # type: ignore[attr-defined]
-        if reset is not None:
-            reset()
+        # Per-stream provider state, owned by this call (see _stream's note).
+        # Concurrent astream calls on a shared chat-model instance interleave
+        # at every await, so provider-instance state would cross-contaminate:
+        # one stream could wipe another's partial <tool_call> block or drain
+        # its completed tool calls.
+        new_state = getattr(self._provider, "new_stream_state", None)  # type: ignore[attr-defined]
+        stream_state = new_state() if new_state is not None else None
+        state_kwargs: Dict[str, Any] = (
+            {"stream_state": stream_state} if stream_state is not None else {}
+        )
+        if stream_state is None:
+            reset = getattr(self._provider, "reset_stream_state", None)  # type: ignore[attr-defined]
+            if reset is not None:
+                reset()
 
         async def _events_with_param_retry() -> AsyncIterator[Dict[str, Any]]:
             """Open the stream, retrying after fixable 400 parameter errors.
@@ -242,9 +252,11 @@ class ChatOCIGenAIAsyncMixin:
         async for event_data in _events_with_param_retry():
             if not self._provider.is_chat_stream_end(event_data):  # type: ignore[attr-defined]
                 # Process streaming content
-                delta = self._provider.chat_stream_to_text(event_data)  # type: ignore[attr-defined]
+                delta = self._provider.chat_stream_to_text(  # type: ignore[attr-defined]
+                    event_data, **state_kwargs
+                )
                 tool_call_chunks = self._provider.process_stream_tool_calls(  # type: ignore[attr-defined]
-                    event_data, tool_call_ids
+                    event_data, tool_call_ids, **state_kwargs
                 )
 
                 # Surface incremental reasoning (e.g. xAI Grok, OpenAI o-series)
@@ -267,10 +279,13 @@ class ChatOCIGenAIAsyncMixin:
                     await run_manager.on_llm_new_token(delta, chunk=chunk)
                 yield chunk
             else:
-                # Flush any held-back text from the provider's <tool_call>
+                # Flush any held-back text from the per-stream <tool_call>
                 # buffer so trailing characters don't disappear.
-                flush = getattr(self._provider, "flush_stream_state", None)  # type: ignore[attr-defined]
-                tail = flush() if flush is not None else ""
+                if stream_state is not None:
+                    tail = stream_state.flush()
+                else:
+                    flush = getattr(self._provider, "flush_stream_state", None)  # type: ignore[attr-defined]
+                    tail = flush() if flush is not None else ""
                 if tail:
                     yield ChatGenerationChunk(message=AIMessageChunk(content=tail))
 

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -590,21 +590,30 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         response = self._chat_with_param_retry(request)
         tool_call_ids: Dict[int, str] = {}
 
-        # Reset any per-stream provider state (currently the GenericProvider's
+        # Per-stream provider state (currently the GenericProvider's
         # incremental <tool_call> XML buffer used for Hermes/Llama-style DAC
-        # fine-tunes). Older providers don't define this hook.
-        reset = getattr(self._provider, "reset_stream_state", None)
-        if reset is not None:
-            reset()
+        # fine-tunes). Owned by this call and passed into the provider on
+        # every event, so concurrent streams sharing one chat-model instance
+        # can't corrupt each other's parsing state. Providers that predate
+        # the hook fall back to their legacy instance-level state.
+        new_state = getattr(self._provider, "new_stream_state", None)
+        stream_state = new_state() if new_state is not None else None
+        state_kwargs: Dict[str, Any] = (
+            {"stream_state": stream_state} if stream_state is not None else {}
+        )
+        if stream_state is None:
+            reset = getattr(self._provider, "reset_stream_state", None)
+            if reset is not None:
+                reset()
 
         for event in response.data.events():
             event_data = json.loads(event.data)
 
             if not self._provider.is_chat_stream_end(event_data):
                 # Process streaming content
-                delta = self._provider.chat_stream_to_text(event_data)
+                delta = self._provider.chat_stream_to_text(event_data, **state_kwargs)
                 tool_call_chunks = self._provider.process_stream_tool_calls(
-                    event_data, tool_call_ids
+                    event_data, tool_call_ids, **state_kwargs
                 )
 
                 # Surface incremental reasoning (e.g. xAI Grok, OpenAI o-series)
@@ -630,8 +639,11 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 # Flush any text the provider was holding back waiting on a
                 # potential <tool_call> opener; emit it as a final delta so
                 # callers don't lose trailing characters.
-                flush = getattr(self._provider, "flush_stream_state", None)
-                tail = flush() if flush is not None else ""
+                if stream_state is not None:
+                    tail = stream_state.flush()
+                else:
+                    flush = getattr(self._provider, "flush_stream_state", None)
+                    tail = flush() if flush is not None else ""
                 if tail:
                     yield ChatGenerationChunk(message=AIMessageChunk(content=tail))
 

--- a/libs/oci/langchain_oci/chat_models/providers/base.py
+++ b/libs/oci/langchain_oci/chat_models/providers/base.py
@@ -48,9 +48,31 @@ class Provider(ABC):
         """
         ...
 
+    def new_stream_state(self) -> Optional[Any]:
+        """Create per-stream parsing state for one ``_stream``/``_astream`` call.
+
+        Providers that need to accumulate state across streaming events (e.g.
+        GenericProvider's incremental ``<tool_call>`` XML buffer) return a
+        fresh state object here. The caller owns it for the lifetime of one
+        stream and passes it back via the ``stream_state`` keyword of
+        :meth:`chat_stream_to_text` and :meth:`process_stream_tool_calls` —
+        never store it on the provider, which is shared across concurrent
+        streams.
+
+        The default returns ``None`` (stateless provider); callers must not
+        pass ``stream_state`` to providers that returned ``None``.
+        """
+        return None
+
     @abstractmethod
-    def chat_stream_to_text(self, event_data: Dict) -> str:
-        """Extract chat text from a streaming event."""
+    def chat_stream_to_text(
+        self, event_data: Dict, stream_state: Optional[Any] = None
+    ) -> str:
+        """Extract chat text from a streaming event.
+
+        ``stream_state`` is the object returned by :meth:`new_stream_state`
+        for the current stream (``None`` for stateless providers).
+        """
         ...
 
     @abstractmethod
@@ -135,8 +157,13 @@ class Provider(ABC):
         self,
         event_data: Dict,
         tool_call_ids: Dict[int, str],
+        stream_state: Optional[Any] = None,
     ) -> List[ToolCallChunk]:
-        """Process streaming tool calls from event data into chunks."""
+        """Process streaming tool calls from event data into chunks.
+
+        ``stream_state`` is the object returned by :meth:`new_stream_state`
+        for the current stream (``None`` for stateless providers).
+        """
         ...
 
     @property

--- a/libs/oci/langchain_oci/chat_models/providers/cohere.py
+++ b/libs/oci/langchain_oci/chat_models/providers/cohere.py
@@ -209,8 +209,13 @@ class CohereProvider(Provider):
             )
         return text
 
-    def chat_stream_to_text(self, event_data: Dict) -> str:
-        """Extract text from a Cohere chat stream event (V1 or V2)."""
+    def chat_stream_to_text(
+        self, event_data: Dict, stream_state: Optional[Any] = None
+    ) -> str:
+        """Extract text from a Cohere chat stream event (V1 or V2).
+
+        ``stream_state`` is unused — Cohere parsing is stateless per event.
+        """
         # Return empty string if finish reason or tool calls are present
         if "finishReason" in event_data or "toolCalls" in event_data:
             return ""
@@ -730,7 +735,10 @@ class CohereProvider(Provider):
         return None
 
     def process_stream_tool_calls(
-        self, event_data: Dict, tool_call_ids: Dict[int, str]
+        self,
+        event_data: Dict,
+        tool_call_ids: Dict[int, str],
+        stream_state: Optional[Any] = None,
     ) -> List[ToolCallChunk]:
         """
         Process Cohere stream tool calls and return them as ToolCallChunk objects.
@@ -738,6 +746,7 @@ class CohereProvider(Provider):
         Args:
             event_data: The event data from the stream
             tool_call_ids: Dict mapping tool call IDs for aggregation
+            stream_state: Unused — Cohere parsing is stateless per event
 
         Returns:
             List of ToolCallChunk objects

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -134,9 +134,11 @@ class GenericProvider(Provider):
     def __init__(self) -> None:
         from oci.generative_ai_inference import models
 
-        # Per-stream incremental parser for inline <tool_call>...</tool_call>
-        # blocks emitted by Hermes/Llama/Qwen-style fine-tunes. Reset by
-        # `reset_stream_state()` at the start of each `_stream` call.
+        # Legacy fallback buffer for callers that don't pass per-stream state
+        # (see `new_stream_state`). Shared across every stream on this
+        # provider instance, so it is NOT safe under concurrent streaming —
+        # `_stream`/`_astream` create their own state via `new_stream_state`
+        # and never touch it.
         self._xml_buffer = XmlStreamBuffer()
 
         # Chat request and message models
@@ -242,13 +244,31 @@ class GenericProvider(Provider):
             )
         return cleaned
 
-    def chat_stream_to_text(self, event_data: Dict) -> str:
+    def new_stream_state(self) -> XmlStreamBuffer:
+        """Create a fresh per-stream ``<tool_call>`` parsing buffer.
+
+        ``ChatOCIGenAI._stream`` / ``_astream`` call this once per stream and
+        pass the buffer back via the ``stream_state`` keyword of
+        :meth:`chat_stream_to_text` and :meth:`process_stream_tool_calls`.
+        Because each stream owns its buffer, concurrent streams on a shared
+        chat-model instance can no longer wipe each other's partial blocks or
+        receive each other's tool calls.
+        """
+        return XmlStreamBuffer()
+
+    def chat_stream_to_text(
+        self, event_data: Dict, stream_state: Optional[XmlStreamBuffer] = None
+    ) -> str:
         """Extract text from Meta chat stream event.
 
         Routes the raw delta through :class:`XmlStreamBuffer` so inline
         ``<tool_call>``/``<tool_calling>`` blocks (Hermes/Llama/Qwen-style
         fine-tunes) are surfaced via :meth:`process_stream_tool_calls`
         instead of leaking into normal token-stream content.
+
+        ``stream_state`` must be the buffer from :meth:`new_stream_state` for
+        the current stream. When ``None``, the legacy instance-level buffer is
+        used, which is not safe under concurrent streaming.
         """
         content = event_data.get("message", {}).get("content", None)
         if not content:
@@ -257,23 +277,24 @@ class GenericProvider(Provider):
             raw_delta = "".join(
                 part.get("text", "") for part in content if part.get("text")
             )
-        return self._xml_buffer.feed(raw_delta)
+        buffer = stream_state if stream_state is not None else self._xml_buffer
+        return buffer.feed(raw_delta)
 
     def reset_stream_state(self) -> None:
-        """Clear per-stream ``<tool_call>`` parsing state.
+        """Clear the legacy instance-level ``<tool_call>`` parsing state.
 
-        Called by ``ChatOCIGenAI._stream`` / ``_astream`` at the start of each
-        new stream so a previous, possibly-aborted stream's leftover buffer
-        doesn't leak into the next one.
+        Only relevant for callers still using the shared instance buffer
+        (``stream_state=None``). ``_stream``/``_astream`` instead create
+        caller-owned state via :meth:`new_stream_state`, which needs no reset.
         """
         self._xml_buffer.reset()
 
     def flush_stream_state(self) -> str:
-        """Return any held-back text and reset the per-stream buffer.
+        """Return held-back text from the legacy instance-level buffer.
 
-        Called once at end-of-stream so trailing characters that were held
-        back as a possible ``<tool_call>`` prefix don't get dropped if the
-        opener never actually arrived.
+        Only relevant for callers still using the shared instance buffer
+        (``stream_state=None``); with caller-owned state, flush the
+        :class:`XmlStreamBuffer` returned by :meth:`new_stream_state` directly.
         """
         return self._xml_buffer.flush()
 
@@ -925,7 +946,10 @@ class GenericProvider(Provider):
         )
 
     def process_stream_tool_calls(
-        self, event_data: Dict, tool_call_ids: Dict[int, str]
+        self,
+        event_data: Dict,
+        tool_call_ids: Dict[int, str],
+        stream_state: Optional[XmlStreamBuffer] = None,
     ) -> List[ToolCallChunk]:
         """
         Process Meta stream tool calls and convert them to ToolCallChunks.
@@ -937,6 +961,9 @@ class GenericProvider(Provider):
         Args:
             event_data: The event data from the stream
             tool_call_ids: Dict mapping tool call index to ID for aggregation
+            stream_state: Per-stream buffer from :meth:`new_stream_state`;
+                when ``None``, falls back to the legacy instance-level buffer
+                (not safe under concurrent streaming)
 
         Returns:
             List of ToolCallChunk objects
@@ -944,7 +971,8 @@ class GenericProvider(Provider):
         tool_call_chunks: List[ToolCallChunk] = []
 
         # Drain XML tool calls that completed during this event.
-        for parsed in self._xml_buffer.drain_completed():
+        buffer = stream_state if stream_state is not None else self._xml_buffer
+        for parsed in buffer.drain_completed():
             index = len(tool_call_ids)
             tool_call_ids[index] = parsed["id"]
             tool_call_chunks.append(

--- a/libs/oci/tests/unit_tests/chat_models/test_concurrent_streaming.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_concurrent_streaming.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Regression tests for concurrent streaming on a shared chat-model instance.
+
+A single ``ChatOCIGenAI`` (and therefore a single agent built on it) is
+commonly shared across requests. The GenericProvider's incremental
+``<tool_call>`` XML parser used to live on the provider instance, which is
+cached per chat-model instance — so two concurrent streams fed one buffer:
+one stream's ``reset`` wiped the other's partial block, and one stream could
+drain (and execute) tool calls the model emitted in the *other* stream.
+
+The fix gives each ``_stream``/``_astream`` call its own parser state via
+``Provider.new_stream_state()``. These tests interleave two streams on one
+shared instance and assert full isolation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, Iterator, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from langchain_oci.chat_models import ChatOCIGenAI
+from langchain_oci.chat_models.providers.generic import GenericProvider
+
+# ---------------------------------------------------------------------------
+# Provider level: per-stream state isolates interleaved streams
+# ---------------------------------------------------------------------------
+
+
+def _event(text: str) -> Dict[str, Any]:
+    return {"message": {"content": [{"type": "TEXT", "text": text}]}}
+
+
+def test_new_stream_state_returns_fresh_buffer_each_call() -> None:
+    p = GenericProvider()
+    assert p.new_stream_state() is not p.new_stream_state()
+
+
+def test_interleaved_streams_do_not_wipe_each_others_partial_block() -> None:
+    """Stream B starting mid-way through stream A must not destroy A's
+    half-received <tool_call> block (previously reset_stream_state did)."""
+    p = GenericProvider()
+
+    state_a = p.new_stream_state()
+    p.chat_stream_to_text(
+        _event('<tool_call>{"name": "tool_a", "arguments": {"u": "A"'),
+        stream_state=state_a,
+    )
+    # Stream B starts concurrently on the same shared provider.
+    state_b = p.new_stream_state()
+    p.chat_stream_to_text(_event("hello from B"), stream_state=state_b)
+    # A's closing fragment arrives; A must recover its complete tool call.
+    tail = p.chat_stream_to_text(_event("}}</tool_call>"), stream_state=state_a)
+    a_calls = p.process_stream_tool_calls({}, {}, stream_state=state_a)
+
+    assert tail == ""  # no raw XML leaks into A's text
+    assert len(a_calls) == 1
+    assert a_calls[0]["name"] == "tool_a"
+    assert json.loads(a_calls[0]["args"] or "") == {"u": "A"}
+
+
+def test_interleaved_streams_do_not_receive_each_others_tool_calls() -> None:
+    """A tool call completed in stream A must never surface in stream B."""
+    p = GenericProvider()
+
+    state_a = p.new_stream_state()
+    state_b = p.new_stream_state()
+    p.chat_stream_to_text(
+        _event('<tool_call>{"name": "tool_a", "arguments": {}}</tool_call>'),
+        stream_state=state_a,
+    )
+    # B processes its next event before A drains.
+    p.chat_stream_to_text(_event("hello from B"), stream_state=state_b)
+    b_calls = p.process_stream_tool_calls({}, {}, stream_state=state_b)
+    a_calls = p.process_stream_tool_calls({}, {}, stream_state=state_a)
+
+    assert b_calls == []
+    assert len(a_calls) == 1
+    assert a_calls[0]["name"] == "tool_a"
+
+
+# ---------------------------------------------------------------------------
+# Model level (sync): two interleaved llm.stream() calls on one instance
+# ---------------------------------------------------------------------------
+
+
+def _stream_response(deltas: List[str]) -> MagicMock:
+    events = [
+        MagicMock(
+            data=json.dumps(
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "ASSISTANT",
+                        "content": [{"type": "TEXT", "text": d}],
+                    },
+                }
+            )
+        )
+        for d in deltas
+    ]
+    events.append(MagicMock(data=json.dumps({"finishReason": "stop"})))
+    response = MagicMock()
+    response.data.events.return_value = events
+    return response
+
+
+def _tool_call_deltas(user: str) -> List[str]:
+    """Text deltas where the tool call is split across events."""
+    return [
+        f"{user} says: ",
+        f'<tool_call>{{"name": "tool_{user}", ',
+        f'"arguments": {{"user": "{user}"}}}}',
+        "</tool_call>",
+        f" done {user}",
+    ]
+
+
+def _drain_interleaved(gen_a: Iterator, gen_b: Iterator) -> tuple:
+    """Alternate between two stream generators until both are exhausted."""
+    merged: List[Optional[Any]] = [None, None]
+    gens = [gen_a, gen_b]
+    live = [True, True]
+    while any(live):
+        for i, gen in enumerate(gens):
+            if not live[i]:
+                continue
+            try:
+                chunk = next(gen)
+            except StopIteration:
+                live[i] = False
+                continue
+            merged[i] = chunk if merged[i] is None else merged[i] + chunk
+    return merged[0], merged[1]
+
+
+@pytest.mark.requires("oci")
+def test_sync_interleaved_streams_on_shared_instance_are_isolated() -> None:
+    oci_client = MagicMock()
+    oci_client.chat.side_effect = [
+        _stream_response(_tool_call_deltas("A")),
+        _stream_response(_tool_call_deltas("B")),
+    ]
+    llm = ChatOCIGenAI(model_id="meta.llama-3.3-70b-instruct", client=oci_client)
+
+    gen_a = llm.stream([HumanMessage(content="query A")])
+    gen_b = llm.stream([HumanMessage(content="query B")])
+    merged_a, merged_b = _drain_interleaved(gen_a, gen_b)
+
+    for merged, user in ((merged_a, "A"), (merged_b, "B")):
+        assert "tool_call" not in merged.content, merged.content
+        assert merged.content == f"{user} says:  done {user}"
+        assert len(merged.tool_call_chunks) == 1
+        chunk = merged.tool_call_chunks[0]
+        assert chunk["name"] == f"tool_{user}"
+        assert json.loads(chunk["args"]) == {"user": user}
+
+
+# ---------------------------------------------------------------------------
+# Model level (async): concurrent astream() calls on one instance
+# ---------------------------------------------------------------------------
+
+
+def _fake_serialize(obj: Any) -> Any:
+    """Minimal stand-in for BaseClient.sanitize_for_serialization."""
+    if hasattr(obj, "attribute_map"):
+        return {
+            wire: _fake_serialize(getattr(obj, attr))
+            for attr, wire in obj.attribute_map.items()
+            if getattr(obj, attr) is not None
+        }
+    if isinstance(obj, list):
+        return [_fake_serialize(o) for o in obj]
+    if isinstance(obj, dict):
+        return {k: _fake_serialize(v) for k, v in obj.items()}
+    return obj
+
+
+def _make_async_llm() -> ChatOCIGenAI:
+    oci_client = MagicMock()
+    oci_client.base_client.signer = MagicMock()
+    oci_client.base_client.config = {}
+    oci_client.base_client.sanitize_for_serialization = _fake_serialize
+    return ChatOCIGenAI(
+        model_id="meta.llama-3.3-70b-instruct",
+        client=oci_client,
+        service_endpoint="https://example.invalid",
+    )
+
+
+@pytest.mark.requires("oci")
+async def test_async_concurrent_streams_on_shared_instance_are_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reported production scenario: one shared agent, two users calling
+    astream concurrently, both turns involving tool calls."""
+    from langchain_oci.common.async_support import OCIAsyncClient
+
+    def fake_chat_async(
+        self: Any,
+        compartment_id: str,
+        chat_request_dict: Dict[str, Any],
+        serving_mode_dict: Dict[str, Any],
+        stream: bool,
+    ) -> Any:
+        # Route each request to its own scripted stream by user message text.
+        text = chat_request_dict["messages"][-1]["content"][0]["text"]
+        user = "A" if "A" in text else "B"
+
+        async def gen() -> Any:
+            for delta in _tool_call_deltas(user):
+                # Force a real suspension so the two gathered streams
+                # interleave event-by-event, as they do over the network.
+                await asyncio.sleep(0)
+                yield {
+                    "message": {
+                        "role": "ASSISTANT",
+                        "content": [{"type": "TEXT", "text": delta}],
+                    }
+                }
+            await asyncio.sleep(0)
+            yield {"finishReason": "stop"}
+
+        return gen()
+
+    monkeypatch.setattr(OCIAsyncClient, "chat_async", fake_chat_async)
+    llm = _make_async_llm()
+
+    async def run(user: str) -> Any:
+        merged = None
+        async for chunk in llm.astream([HumanMessage(content=f"query {user}")]):
+            merged = chunk if merged is None else merged + chunk
+        return merged
+
+    merged_a, merged_b = await asyncio.gather(run("A"), run("B"))
+
+    for merged, user in ((merged_a, "A"), (merged_b, "B")):
+        assert "tool_call" not in merged.content, merged.content
+        assert merged.content == f"{user} says:  done {user}"
+        assert len(merged.tool_call_chunks) == 1
+        chunk = merged.tool_call_chunks[0]
+        assert chunk["name"] == f"tool_{user}"
+        assert json.loads(chunk["args"]) == {"user": user}


### PR DESCRIPTION
Fixes #255

## Problem

`GenericProvider` (Meta Llama, xAI Grok, OpenAI, Mistral, Gemini) kept the incremental `<tool_call>` XML stream parser (`XmlStreamBuffer`) as provider-instance state, and `ChatOCIGenAI` caches one provider instance per chat-model instance. Since one chat model (or an agent built on it) is commonly shared across requests, every concurrent `stream`/`astream` call fed the **same buffer**. Plain asyncio interleaving (no threads needed) then produces:

1. **Lost tool calls + raw XML leaking into text** — a stream starting mid-flight calls `reset_stream_state()`, wiping another stream's half-received `<tool_call>` block; the tail (`'}}</tool_call>'`) surfaces as visible text.
2. **Cross-request tool-call delivery** — a tool call completed in stream A is drained by stream B's `process_stream_tool_calls`, so B's agent executes a tool call requested in A's conversation.

A deterministic provider-level probe demonstrating both failure modes against `main` is in #255.

## Fix

Make the parser state **caller-owned per stream**, mirroring the existing `tool_call_ids` pattern:

- `Provider.new_stream_state()` (new hook, default `None` for stateless providers): `GenericProvider` returns a fresh `XmlStreamBuffer`.
- `_stream` / `_astream` call it once per stream and pass the state via the new optional `stream_state` keyword of `chat_stream_to_text` / `process_stream_tool_calls`; end-of-stream flush reads from the per-stream state.
- `CohereProvider` accepts and ignores the parameter (stateless per event).

**Backward compatibility:** the legacy instance-level buffer and `reset_stream_state`/`flush_stream_state` remain for direct callers and third-party providers predating the hook — the stream loops fall back to the old reset/flush behavior when `new_stream_state` is absent or returns `None`. No public API is removed; the new parameter is optional and keyword-only in practice.

## Testing

**New regression tests** (`tests/unit_tests/chat_models/test_concurrent_streaming.py`, 5 tests):
- Provider-level interleaving for both failure modes (partial-block wipe, cross-stream tool-call delivery).
- Model-level: two interleaved sync `stream()` generators on one shared `ChatOCIGenAI`.
- Model-level async (the reported production scenario): two concurrent `astream()` calls on one shared instance via `asyncio.gather`, both turns carrying tool calls split across events — each stream must receive exactly its own tool call and clean text.

Verified the tests **fail against `main`** (4/5 fail: lost tool calls, leaked XML, cross-delivered tool calls) and all pass with this change.

**Full suite / static checks:** 474 unit tests pass, 12 skipped; `ruff check`, `ruff format --check`, and `mypy` clean.

**Live verification against OCI GenAI (us-chicago-1):** with `meta.llama-3.3-70b-instruct` — non-streaming invoke, plain streaming, sync streaming with tools, and 3 rounds of two concurrent `astream` calls with different tools bound on a single shared instance: every round returned the correct tool call (`get_weather`/`get_stock_price`) with correct args in its own stream, no cross-contamination, no XML leakage. Cohere path (`cohere.command-a-03-2025`) sanity-checked for streaming text and streamed tool calls.
