### PR TITLE
test(oci): adopt langchain-tests standard ChatModel conformance suite

### DIFF
--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -535,11 +535,14 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 else JsonOutputParser()
             )
         elif method == "json_schema":
-            json_schema_dict: Dict[str, Any] = (
-                schema.model_json_schema()  # type: ignore[union-attr]
-                if is_pydantic_schema
-                else schema  # type: ignore[assignment]
-            )
+            if is_pydantic_schema:
+                # model_json_schema is pydantic v2; v1 models expose schema()
+                schema_method = getattr(
+                    schema, "model_json_schema", None
+                ) or getattr(schema, "schema")
+                json_schema_dict: Dict[str, Any] = schema_method()
+            else:
+                json_schema_dict = schema  # type: ignore[assignment]
 
             # Resolve $ref references as OCI doesn't support $ref and $defs
             json_schema_dict = OCIUtils.resolve_schema_refs(json_schema_dict)

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -25,6 +25,7 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import (
     BaseChatModel,
+    LangSmithParams,
     generate_from_stream,
 )
 from langchain_core.messages import (
@@ -44,6 +45,7 @@ from langchain_core.output_parsers.openai_tools import (
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_json_schema
 from langchain_openai import ChatOpenAI
 from oci.exceptions import ServiceError
 from openai import DefaultAsyncHttpxClient, DefaultHttpxClient
@@ -183,13 +185,73 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         arbitrary_types_allowed=True,
     )
 
+    temperature: Optional[float] = None
+    """Sampling temperature. Takes precedence over model_kwargs["temperature"]."""
+
+    max_tokens: Optional[int] = None
+    """Maximum number of tokens to generate.
+    Takes precedence over model_kwargs["max_tokens"]."""
+
+    stop: Optional[List[str]] = None
+    """Default stop sequences, used when a call doesn't pass its own."""
+
     # Cached provider instance (not a Pydantic field to avoid serialization)
     _cached_provider_instance: Optional[Provider] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _map_streaming_alias(cls, values: Any) -> Any:
+        """Accept the standard ``streaming`` kwarg as an alias for ``is_stream``.
+
+        ``streaming`` is intentionally NOT a pydantic field: the ``@pre_init``
+        validator on OCIGenAIBase marks every field as explicitly set, and
+        langchain-core's ``_streaming_disabled`` hard-disables streaming when
+        a ``streaming`` field is "set" to False -- which would silently turn
+        every ``.stream()`` call into a non-streaming ``.invoke()``.
+        """
+        if isinstance(values, dict) and "streaming" in values:
+            values = dict(values)
+            values["is_stream"] = values.pop("streaming")
+        return values
+
+    @property
+    def streaming(self) -> bool:
+        """Standard-parameter alias for ``is_stream``."""
+        return self.is_stream
 
     @property
     def _llm_type(self) -> str:
         """Return the type of the language model."""
         return "oci_generative_ai_chat"
+
+    def _get_ls_params(
+        self, stop: Optional[List[str]] = None, **kwargs: Any
+    ) -> LangSmithParams:
+        """Get standard params for tracing."""
+        ls_params = super()._get_ls_params(stop=stop, **kwargs)
+        ls_params["ls_provider"] = "oci"
+        model_name = kwargs.get("model") or self.model_id
+        if model_name:
+            ls_params["ls_model_name"] = model_name
+        _model_kwargs = self.model_kwargs or {}
+        temperature = (
+            self.temperature
+            if self.temperature is not None
+            else _model_kwargs.get("temperature")
+        )
+        if temperature is not None:
+            ls_params["ls_temperature"] = temperature
+        max_tokens = (
+            self.max_tokens
+            if self.max_tokens is not None
+            else _model_kwargs.get("max_tokens")
+        )
+        if max_tokens is not None:
+            ls_params["ls_max_tokens"] = max_tokens
+        ls_stop = stop if stop is not None else self.stop
+        if ls_stop:
+            ls_params["ls_stop"] = ls_stop
+        return ls_params
 
     @property
     def _provider_map(self) -> Mapping[str, Provider]:
@@ -232,6 +294,13 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 "Please make sure you have the oci package installed."
             ) from ex
 
+        if "tool_choice" in kwargs:
+            processed_tool_choice = self._provider.process_tool_choice(
+                kwargs.pop("tool_choice")
+            )
+            if processed_tool_choice is not None:
+                kwargs["tool_choice"] = processed_tool_choice
+
         oci_params = self._provider.messages_to_oci_params(
             messages,
             max_sequential_tool_calls=self.max_sequential_tool_calls,
@@ -241,8 +310,17 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         )
 
         oci_params["is_stream"] = stream
-        _model_kwargs = self.model_kwargs or {}
+        # Copy so per-request keys (e.g. stop sequences) never leak into the
+        # shared self.model_kwargs dict.
+        _model_kwargs = dict(self.model_kwargs or {})
 
+        if self.temperature is not None:
+            _model_kwargs["temperature"] = self.temperature
+        if self.max_tokens is not None:
+            _model_kwargs["max_tokens"] = self.max_tokens
+
+        if stop is None:
+            stop = self.stop
         if stop is not None:
             _model_kwargs[self._provider.stop_sequence_key] = stop
 
@@ -331,7 +409,11 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         formatted_tools = [self._provider.convert_to_oci_tool(tool) for tool in tools]
 
         if tool_choice is not None:
-            kwargs["tool_choice"] = self._provider.process_tool_choice(tool_choice)
+            # Stored raw and translated per-provider at request time
+            # (_prepare_request), so binding stays declarative: providers
+            # that reject tool_choice (e.g. Cohere) raise on invoke, not
+            # on bind.
+            kwargs["tool_choice"] = tool_choice
 
         # Add parallel tool calls support (only when explicitly enabled)
         if parallel_tool_calls:
@@ -352,6 +434,7 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
             "function_calling", "json_schema", "json_mode"
         ] = "function_calling",
         include_raw: bool = False,
+        strict: Optional[bool] = None,
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, Union[Dict, BaseModel]]:
         """Model wrapper that returns outputs formatted to match the given schema.
@@ -379,6 +462,11 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 response will be returned. If an error occurs during output parsing it
                 will be caught and returned as well. The final output is always a dict
                 with keys "raw", "parsed", and "parsing_error".
+            strict:
+                Whether to enforce strict schema adherence. Only honored by the
+                "json_schema" method (mapped to the OCI response-format
+                ``is_strict`` flag, default True); accepted and ignored by the
+                other methods for cross-provider compatibility.
 
         Returns:
             A Runnable that takes any ChatModel input and returns as output:
@@ -400,6 +488,20 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         if kwargs:
             raise ValueError(f"Unsupported arguments: {kwargs}")
         is_pydantic_schema = OCIUtils.is_pydantic_class(schema)
+
+        # Structured-output metadata surfaced to tracing/callbacks
+        # (consumed and popped by BaseChatModel before the request is built).
+        try:
+            ls_format_schema = (
+                convert_to_json_schema(schema) if schema is not None else None
+            )
+        except ValueError:
+            ls_format_schema = None
+        ls_structured_output_format = {
+            "kwargs": {"method": method, "strict": strict},
+            "schema": ls_format_schema,
+        }
+
         if method == "function_calling":
             if schema is None:
                 raise ValueError("Schema must be provided for function_calling method.")
@@ -410,6 +512,7 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
             bind_kwargs: Dict[str, Any] = {**kwargs}
             if self._provider.supports_tool_choice and "tool_choice" not in bind_kwargs:
                 bind_kwargs["tool_choice"] = "required"
+            bind_kwargs["ls_structured_output_format"] = ls_structured_output_format
             llm = self.bind_tools([schema], **bind_kwargs)
             tool_name = getattr(self._provider.convert_to_oci_tool(schema), "name")
             if is_pydantic_schema:
@@ -422,7 +525,10 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                     key_name=tool_name, first_tool_only=True
                 )
         elif method == "json_mode":
-            llm = self.bind(response_format={"type": "JSON_OBJECT"})  # type: ignore[assignment, unused-ignore]
+            llm = self.bind(  # type: ignore[assignment, unused-ignore]
+                response_format={"type": "JSON_OBJECT"},
+                ls_structured_output_format=ls_structured_output_format,
+            )
             output_parser = (
                 PydanticOutputParser(pydantic_object=schema)
                 if is_pydantic_schema
@@ -442,14 +548,17 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 name=json_schema_dict.get("title", "response"),
                 description=json_schema_dict.get("description", ""),
                 schema=json_schema_dict,
-                is_strict=True,
+                is_strict=strict if strict is not None else True,
             )
 
             response_format_obj = self._provider.oci_json_schema_response_format(
                 json_schema=response_json_schema
             )
 
-            llm = self.bind(response_format=response_format_obj)  # type: ignore[assignment, unused-ignore]
+            llm = self.bind(  # type: ignore[assignment, unused-ignore]
+                response_format=response_format_obj,
+                ls_structured_output_format=ls_structured_output_format,
+            )
             if is_pydantic_schema:
                 output_parser = PydanticOutputParser(pydantic_object=schema)
             else:
@@ -515,6 +624,9 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         raw_tool_calls = self._provider.chat_tool_calls(response)
 
         generation_info = self._provider.chat_generation_info(response)
+        # Standard response_metadata key expected by LangChain tooling
+        # (traces, callbacks); model_id is kept for backwards compatibility.
+        generation_info.setdefault("model_name", response.data.model_id)
 
         if raw_tool_calls:
             generation_info["tool_calls"] = self._provider.format_response_tool_calls(
@@ -655,6 +767,8 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                     yield ChatGenerationChunk(message=AIMessageChunk(content=tail))
 
                 generation_info = self._provider.chat_stream_generation_info(event_data)
+                if self.model_id:
+                    generation_info.setdefault("model_name", self.model_id)
                 yield ChatGenerationChunk(
                     message=AIMessageChunk(
                         content="",

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -537,9 +537,9 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         elif method == "json_schema":
             if is_pydantic_schema:
                 # model_json_schema is pydantic v2; v1 models expose schema()
-                schema_method = getattr(
-                    schema, "model_json_schema", None
-                ) or getattr(schema, "schema")
+                schema_method = getattr(schema, "model_json_schema", None) or getattr(
+                    schema, "schema"
+                )
                 json_schema_dict: Dict[str, Any] = schema_method()
             else:
                 json_schema_dict = schema  # type: ignore[assignment]

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -25,6 +25,7 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import (
     BaseChatModel,
+    LangSmithParams,
     generate_from_stream,
 )
 from langchain_core.messages import (
@@ -44,6 +45,7 @@ from langchain_core.output_parsers.openai_tools import (
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_json_schema
 from langchain_openai import ChatOpenAI
 from oci.exceptions import ServiceError
 from openai import DefaultAsyncHttpxClient, DefaultHttpxClient
@@ -186,13 +188,73 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
     use_responses_api: bool = False
     """Whether to use the Responses API instead of the Chat API."""
 
+    temperature: Optional[float] = None
+    """Sampling temperature. Takes precedence over model_kwargs["temperature"]."""
+
+    max_tokens: Optional[int] = None
+    """Maximum number of tokens to generate.
+    Takes precedence over model_kwargs["max_tokens"]."""
+
+    stop: Optional[List[str]] = None
+    """Default stop sequences, used when a call doesn't pass its own."""
+
     # Cached provider instance (not a Pydantic field to avoid serialization)
     _cached_provider_instance: Optional[Provider] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _map_streaming_alias(cls, values: Any) -> Any:
+        """Accept the standard ``streaming`` kwarg as an alias for ``is_stream``.
+
+        ``streaming`` is intentionally NOT a pydantic field: the ``@pre_init``
+        validator on OCIGenAIBase marks every field as explicitly set, and
+        langchain-core's ``_streaming_disabled`` hard-disables streaming when
+        a ``streaming`` field is "set" to False -- which would silently turn
+        every ``.stream()`` call into a non-streaming ``.invoke()``.
+        """
+        if isinstance(values, dict) and "streaming" in values:
+            values = dict(values)
+            values["is_stream"] = values.pop("streaming")
+        return values
+
+    @property
+    def streaming(self) -> bool:
+        """Standard-parameter alias for ``is_stream``."""
+        return self.is_stream
 
     @property
     def _llm_type(self) -> str:
         """Return the type of the language model."""
         return "oci_generative_ai_chat"
+
+    def _get_ls_params(
+        self, stop: Optional[List[str]] = None, **kwargs: Any
+    ) -> LangSmithParams:
+        """Get standard params for tracing."""
+        ls_params = super()._get_ls_params(stop=stop, **kwargs)
+        ls_params["ls_provider"] = "oci"
+        model_name = kwargs.get("model") or self.model_id
+        if model_name:
+            ls_params["ls_model_name"] = model_name
+        _model_kwargs = self.model_kwargs or {}
+        temperature = (
+            self.temperature
+            if self.temperature is not None
+            else _model_kwargs.get("temperature")
+        )
+        if temperature is not None:
+            ls_params["ls_temperature"] = temperature
+        max_tokens = (
+            self.max_tokens
+            if self.max_tokens is not None
+            else _model_kwargs.get("max_tokens")
+        )
+        if max_tokens is not None:
+            ls_params["ls_max_tokens"] = max_tokens
+        ls_stop = stop if stop is not None else self.stop
+        if ls_stop:
+            ls_params["ls_stop"] = ls_stop
+        return ls_params
 
     @property
     def _provider_map(self) -> Mapping[str, Provider]:
@@ -238,6 +300,13 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 "Please make sure you have the oci package installed."
             ) from ex
 
+        if "tool_choice" in kwargs:
+            processed_tool_choice = self._provider.process_tool_choice(
+                kwargs.pop("tool_choice")
+            )
+            if processed_tool_choice is not None:
+                kwargs["tool_choice"] = processed_tool_choice
+
         oci_params = self._provider.messages_to_oci_params(
             messages,
             max_sequential_tool_calls=self.max_sequential_tool_calls,
@@ -247,8 +316,17 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         )
 
         oci_params["is_stream"] = stream
-        _model_kwargs = self.model_kwargs or {}
+        # Copy so per-request keys (e.g. stop sequences) never leak into the
+        # shared self.model_kwargs dict.
+        _model_kwargs = dict(self.model_kwargs or {})
 
+        if self.temperature is not None:
+            _model_kwargs["temperature"] = self.temperature
+        if self.max_tokens is not None:
+            _model_kwargs["max_tokens"] = self.max_tokens
+
+        if stop is None:
+            stop = self.stop
         if stop is not None:
             _model_kwargs[self._provider.stop_sequence_key] = stop
 
@@ -337,7 +415,11 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         formatted_tools = [self._provider.convert_to_oci_tool(tool) for tool in tools]
 
         if tool_choice is not None:
-            kwargs["tool_choice"] = self._provider.process_tool_choice(tool_choice)
+            # Stored raw and translated per-provider at request time
+            # (_prepare_request), so binding stays declarative: providers
+            # that reject tool_choice (e.g. Cohere) raise on invoke, not
+            # on bind.
+            kwargs["tool_choice"] = tool_choice
 
         # Add parallel tool calls support (only when explicitly enabled)
         if parallel_tool_calls:
@@ -358,6 +440,7 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
             "function_calling", "json_schema", "json_mode"
         ] = "function_calling",
         include_raw: bool = False,
+        strict: Optional[bool] = None,
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, Union[Dict, BaseModel]]:
         """Model wrapper that returns outputs formatted to match the given schema.
@@ -385,6 +468,11 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 response will be returned. If an error occurs during output parsing it
                 will be caught and returned as well. The final output is always a dict
                 with keys "raw", "parsed", and "parsing_error".
+            strict:
+                Whether to enforce strict schema adherence. Only honored by the
+                "json_schema" method (mapped to the OCI response-format
+                ``is_strict`` flag, default True); accepted and ignored by the
+                other methods for cross-provider compatibility.
 
         Returns:
             A Runnable that takes any ChatModel input and returns as output:
@@ -406,6 +494,20 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         if kwargs:
             raise ValueError(f"Unsupported arguments: {kwargs}")
         is_pydantic_schema = OCIUtils.is_pydantic_class(schema)
+
+        # Structured-output metadata surfaced to tracing/callbacks
+        # (consumed and popped by BaseChatModel before the request is built).
+        try:
+            ls_format_schema = (
+                convert_to_json_schema(schema) if schema is not None else None
+            )
+        except ValueError:
+            ls_format_schema = None
+        ls_structured_output_format = {
+            "kwargs": {"method": method, "strict": strict},
+            "schema": ls_format_schema,
+        }
+
         if method == "function_calling":
             if schema is None:
                 raise ValueError("Schema must be provided for function_calling method.")
@@ -416,6 +518,7 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
             bind_kwargs: Dict[str, Any] = {**kwargs}
             if self._provider.supports_tool_choice and "tool_choice" not in bind_kwargs:
                 bind_kwargs["tool_choice"] = "required"
+            bind_kwargs["ls_structured_output_format"] = ls_structured_output_format
             llm = self.bind_tools([schema], **bind_kwargs)
             tool_name = getattr(self._provider.convert_to_oci_tool(schema), "name")
             if is_pydantic_schema:
@@ -428,7 +531,10 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                     key_name=tool_name, first_tool_only=True
                 )
         elif method == "json_mode":
-            llm = self.bind(response_format={"type": "JSON_OBJECT"})  # type: ignore[assignment, unused-ignore]
+            llm = self.bind(  # type: ignore[assignment, unused-ignore]
+                response_format={"type": "JSON_OBJECT"},
+                ls_structured_output_format=ls_structured_output_format,
+            )
             output_parser = (
                 PydanticOutputParser(pydantic_object=schema)
                 if is_pydantic_schema
@@ -448,14 +554,17 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 name=json_schema_dict.get("title", "response"),
                 description=json_schema_dict.get("description", ""),
                 schema=json_schema_dict,
-                is_strict=True,
+                is_strict=strict if strict is not None else True,
             )
 
             response_format_obj = self._provider.oci_json_schema_response_format(
                 json_schema=response_json_schema
             )
 
-            llm = self.bind(response_format=response_format_obj)  # type: ignore[assignment, unused-ignore]
+            llm = self.bind(  # type: ignore[assignment, unused-ignore]
+                response_format=response_format_obj,
+                ls_structured_output_format=ls_structured_output_format,
+            )
             if is_pydantic_schema:
                 output_parser = PydanticOutputParser(pydantic_object=schema)
             else:
@@ -524,6 +633,9 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         raw_tool_calls = self._provider.chat_tool_calls(response)
 
         generation_info = self._provider.chat_generation_info(response)
+        # Standard response_metadata key expected by LangChain tooling
+        # (traces, callbacks); model_id is kept for backwards compatibility.
+        generation_info.setdefault("model_name", response.data.model_id)
 
         if raw_tool_calls:
             generation_info["tool_calls"] = self._provider.format_response_tool_calls(
@@ -934,6 +1046,8 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                     yield ChatGenerationChunk(message=AIMessageChunk(content=tail))
 
                 generation_info = self._provider.chat_stream_generation_info(event_data)
+                if self.model_id:
+                    generation_info.setdefault("model_name", self.model_id)
                 yield ChatGenerationChunk(
                     message=AIMessageChunk(
                         content="",

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -541,11 +541,14 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 else JsonOutputParser()
             )
         elif method == "json_schema":
-            json_schema_dict: Dict[str, Any] = (
-                schema.model_json_schema()  # type: ignore[union-attr]
-                if is_pydantic_schema
-                else schema  # type: ignore[assignment]
-            )
+            if is_pydantic_schema:
+                # model_json_schema is pydantic v2; v1 models expose schema()
+                schema_method = getattr(
+                    schema, "model_json_schema", None
+                ) or getattr(schema, "schema")
+                json_schema_dict: Dict[str, Any] = schema_method()
+            else:
+                json_schema_dict = schema  # type: ignore[assignment]
 
             # Resolve $ref references as OCI doesn't support $ref and $defs
             json_schema_dict = OCIUtils.resolve_schema_refs(json_schema_dict)

--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -543,9 +543,9 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
         elif method == "json_schema":
             if is_pydantic_schema:
                 # model_json_schema is pydantic v2; v1 models expose schema()
-                schema_method = getattr(
-                    schema, "model_json_schema", None
-                ) or getattr(schema, "schema")
+                schema_method = getattr(schema, "model_json_schema", None) or getattr(
+                    schema, "schema"
+                )
                 json_schema_dict: Dict[str, Any] = schema_method()
             else:
                 json_schema_dict = schema  # type: ignore[assignment]

--- a/libs/oci/langchain_oci/common/utils.py
+++ b/libs/oci/langchain_oci/common/utils.py
@@ -9,7 +9,7 @@ import uuid
 from typing import Any, Dict, List, Optional, Union
 
 from langchain_core.messages import AIMessage, BaseMessage, ToolCall, ToolMessage
-from pydantic import BaseModel
+from langchain_core.utils.pydantic import is_basemodel_subclass
 
 try:
     from langchain_core.messages import UsageMetadata
@@ -22,8 +22,8 @@ class OCIUtils:
 
     @staticmethod
     def is_pydantic_class(obj: Any) -> bool:
-        """Check if an object is a Pydantic BaseModel subclass."""
-        return isinstance(obj, type) and issubclass(obj, BaseModel)
+        """Check if an object is a Pydantic BaseModel subclass (v2 or v1)."""
+        return isinstance(obj, type) and is_basemodel_subclass(obj)
 
     @staticmethod
     def content_to_text(content: Any) -> str:

--- a/libs/oci/tests/integration_tests/chat_models/test_standard.py
+++ b/libs/oci/tests/integration_tests/chat_models/test_standard.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Standard LangChain conformance integration tests (langchain-tests).
+
+Makes real OCI Generative AI calls. Follows the same env-var conventions as
+the other chat-model integration tests:
+
+Required:
+    OCI_COMPARTMENT_ID  -- compartment OCID to bill the calls against.
+
+Optional:
+    OCI_REGION          -- GenAI region (default: us-chicago-1)
+    OCI_AUTH_TYPE       -- auth type (default: API_KEY)
+    OCI_CONFIG_PROFILE  -- ~/.oci/config profile (default: DEFAULT)
+    OCI_STANDARD_TEST_MODEL_ID -- model to run the suite against
+                                  (default: meta.llama-3.3-70b-instruct)
+
+Capability flags are set for the default Meta model; some flags differ per
+provider (e.g. Cohere has no tool_choice, Gemini adds pdf/video/audio), so
+runs against another OCI_STANDARD_TEST_MODEL_ID may need adjusted flags.
+"""
+
+import os
+from typing import Any, Dict, Type
+
+import pytest
+from langchain_tests.integration_tests import ChatModelIntegrationTests
+
+from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OCI_COMPARTMENT_ID"),
+    reason="OCI_COMPARTMENT_ID environment variable not set",
+)
+
+
+class TestChatOCIGenAIStandardIntegration(ChatModelIntegrationTests):
+    """Standard integration tests for ChatOCIGenAI."""
+
+    @property
+    def chat_model_class(self) -> Type[ChatOCIGenAI]:
+        return ChatOCIGenAI
+
+    @property
+    def chat_model_params(self) -> Dict[str, Any]:
+        region = os.environ.get("OCI_REGION", "us-chicago-1")
+        return {
+            "model_id": os.environ.get(
+                "OCI_STANDARD_TEST_MODEL_ID", "meta.llama-3.3-70b-instruct"
+            ),
+            "compartment_id": os.environ["OCI_COMPARTMENT_ID"],
+            "service_endpoint": (
+                f"https://inference.generativeai.{region}.oci.oraclecloud.com"
+            ),
+            "auth_type": os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
+            "auth_profile": os.environ.get("OCI_CONFIG_PROFILE", "DEFAULT"),
+        }
+
+    @property
+    def standard_chat_model_params(self) -> Dict[str, Any]:
+        # timeout/max_retries/api_key are not top-level kwargs yet; see
+        # https://github.com/oracle/langchain-oracle/issues/261.
+        return {
+            "temperature": 0,
+            "max_tokens": 512,
+        }
+
+    @property
+    def supports_model_override(self) -> bool:
+        # The serving mode is always built from model_id; there is no
+        # per-call model override.
+        return False
+
+    @property
+    def has_tool_choice(self) -> bool:
+        # Supported on the Generic/Meta provider path used by the default
+        # test model. Set to False when running against Cohere models.
+        return True
+
+    @property
+    def supports_json_mode(self) -> bool:
+        return True
+
+    @property
+    def supports_image_inputs(self) -> bool:
+        # Default Meta test model is text-only; vision-capable model ids
+        # (Llama vision, Gemini, GPT-5.x) accept image blocks.
+        return False
+
+    @property
+    def returns_usage_metadata(self) -> bool:
+        return True
+
+    @pytest.mark.xfail(
+        reason=(
+            "OCI GenAI streaming responses carry no usage payload: the final "
+            "SSE event contains only message/finishReason (verified against "
+            "meta.llama-3.3-70b-instruct, 2026-07-22). Tracked in "
+            "https://github.com/oracle/langchain-oracle/issues/261."
+        )
+    )
+    def test_usage_metadata_streaming(self, model: Any) -> None:
+        super().test_usage_metadata_streaming(model)
+
+    @pytest.mark.xfail(
+        reason=(
+            "OCI GenAI service bug: streaming with response_format "
+            "JSON_OBJECT returns empty content and finishReason=tool_calls "
+            "on the Generic/Meta path; json_mode works on invoke but not "
+            "stream. Tracked in "
+            "https://github.com/oracle/langchain-oracle/issues/261."
+        )
+    )
+    def test_json_mode(self, model: Any) -> None:
+        super().test_json_mode(model)

--- a/libs/oci/tests/unit_tests/chat_models/test_standard.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_standard.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Standard LangChain conformance tests (langchain-tests) for chat models.
+
+Unit tests run fully offline: the OCI client / signer is injected as a mock,
+which skips the auth-time client construction in ``validate_environment``.
+"""
+
+from typing import Any, Dict, Type
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_tests.unit_tests import ChatModelUnitTests
+
+from langchain_oci.chat_models.oci_data_science import ChatOCIModelDeployment
+from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
+
+
+class ChatOCIGenAIStandardBase(ChatModelUnitTests):
+    """Shared configuration for ChatOCIGenAI standard tests."""
+
+    @property
+    def chat_model_class(self) -> Type[ChatOCIGenAI]:
+        return ChatOCIGenAI
+
+    @property
+    def standard_chat_model_params(self) -> Dict[str, Any]:
+        # timeout, max_retries and api_key are excluded from the defaults:
+        # they are not accepted as top-level constructor kwargs yet (auth is
+        # configured via auth_type/auth_profile, and the retry strategy lives
+        # on the injected OCI client).
+        # See https://github.com/oracle/langchain-oracle/issues/261.
+        return {
+            "temperature": 0,
+            "max_tokens": 100,
+            "stop": [],
+        }
+
+
+@pytest.mark.requires("oci")
+class TestChatOCIGenAIMetaStandard(ChatOCIGenAIStandardBase):
+    """Standard unit tests for ChatOCIGenAI on the Meta/Llama provider path."""
+
+    @property
+    def chat_model_params(self) -> Dict[str, Any]:
+        return {
+            "model_id": "meta.llama-3.3-70b-instruct",
+            "client": MagicMock(),
+            "compartment_id": "test-compartment-ocid",
+        }
+
+
+@pytest.mark.requires("oci")
+class TestChatOCIGenAICohereStandard(ChatOCIGenAIStandardBase):
+    """Standard unit tests for ChatOCIGenAI on the Cohere provider path."""
+
+    @property
+    def chat_model_params(self) -> Dict[str, Any]:
+        return {
+            "model_id": "cohere.command-r-plus-08-2024",
+            "client": MagicMock(),
+            "compartment_id": "test-compartment-ocid",
+        }
+
+    @property
+    def has_tool_choice(self) -> bool:
+        # tool_choice is rejected on the Cohere provider path.
+        # See https://github.com/oracle/langchain-oracle/issues/266.
+        return False
+
+
+@pytest.mark.requires("oci", "ads")
+class TestChatOCIModelDeploymentStandard(ChatModelUnitTests):
+    """Standard unit tests for ChatOCIModelDeployment (Data Science endpoints)."""
+
+    @property
+    def chat_model_class(self) -> Type[ChatOCIModelDeployment]:
+        return ChatOCIModelDeployment
+
+    @property
+    def chat_model_params(self) -> Dict[str, Any]:
+        return {
+            "endpoint": "https://modeldeployment.example.oci.customer-oci.com/ocid/predict",
+            "model": "odsc-llm",
+            "auth": {"signer": MagicMock()},
+        }


### PR DESCRIPTION
## Summary

Implements #261: adds the official `langchain-tests` conformance suite for the chat models in `libs/oci`, plus the library fixes for every gap the suite surfaced.

**New tests**
- `tests/unit_tests/chat_models/test_standard.py` — `ChatModelUnitTests` for `ChatOCIGenAI` on the Meta and Cohere provider paths (capability flags set honestly, e.g. `has_tool_choice=False` for Cohere per #266) and for `ChatOCIModelDeployment` (gated on `ads`).
- `tests/integration_tests/chat_models/test_standard.py` — `ChatModelIntegrationTests` for `ChatOCIGenAI`, gated on `OCI_COMPARTMENT_ID` following the existing integration-test conventions.

**Conformance fixes surfaced by the suite**
- `ChatOCIGenAI` now accepts standard top-level params: `temperature`, `max_tokens`, `stop`, and `streaming`. `streaming` is a constructor alias for `is_stream` implemented as a before-validator rather than a pydantic field — the `@pre_init` validator marks every field as explicitly set, and langchain-core's `_streaming_disabled` would then treat a defaulted `streaming=False` as an explicit opt-out and silently reroute every `.stream()` call to `.invoke()`.
- `_get_ls_params` now emits `ls_model_name` / `ls_temperature` / `ls_max_tokens` / `ls_stop`, so LangSmith traces attribute calls to the correct model.
- `response_metadata` now includes the standard `model_name` key (invoke and final stream chunk); `model_id` is kept for backwards compatibility.
- `with_structured_output` accepts the standard `strict` kwarg (mapped to the `json_schema` `is_strict` flag) and binds `ls_structured_output_format` metadata for tracing callbacks.
- `tool_choice` validation is deferred from bind time to request time, so binding stays declarative; providers that reject `tool_choice` (Cohere) now raise on invoke, not on bind.
- Pydantic **v1** model classes are now recognized by `with_structured_output` (`is_pydantic_class` uses `is_basemodel_subclass`), so results parse to the model instance instead of a dict.
- The Generic provider path now skips `tool_use`/`tool_call` content blocks in list-form `AIMessage` histories instead of raising — the calls are transmitted through the request's dedicated `tool_calls` field. This fixes both `test_tool_message_histories_list_content` and the `create_agent` agent-loop test.
- `model_kwargs` is copied before adding per-request stop sequences, fixing a latent shared-dict mutation.

## Test results

- Unit: 502 passed, 26 skipped (includes 30 new standard-test cases).
- Integration (real OCI GenAI, `meta.llama-3.3-70b-instruct`): **37 passed, 11 skipped, 2 xfailed, 0 failed.**

The two xfails document service-side limitations, tracked in #261:
1. Streaming responses carry no usage payload (final SSE event contains only `message`/`finishReason`).
2. Streaming with `response_format` `JSON_OBJECT` returns empty content with `finishReason=tool_calls` on the Generic/Meta path (json_mode works on invoke, not stream).

Remaining #261 follow-ups (not in this PR): top-level `timeout`/`max_retries` kwargs (they belong in the shared client-construction module), per-provider capability matrix in the README.

## Files changed

- @libs/oci/langchain_oci/chat_models/oci_generative_ai.py — standard params (`temperature`/`max_tokens`/`stop`), `streaming` alias via before-validator, `_get_ls_params`, `model_name` in response metadata (invoke + stream), `strict` kwarg + `ls_structured_output_format` in `with_structured_output`, pydantic v1 `json_schema` support, deferred `tool_choice` processing, `model_kwargs` copy fix
- @libs/oci/langchain_oci/chat_models/async_mixin.py — streaming decision kept in sync with the sync path
- @libs/oci/langchain_oci/chat_models/providers/generic.py — skip `tool_use`/`tool_call` content blocks in list-form AIMessage histories instead of raising
- @libs/oci/langchain_oci/common/utils.py — `is_pydantic_class` recognizes pydantic v1 and v2 (`is_basemodel_subclass`)
- @libs/oci/tests/unit_tests/chat_models/test_standard.py — new: `ChatModelUnitTests` for ChatOCIGenAI (Meta + Cohere paths) and ChatOCIModelDeployment
- @libs/oci/tests/integration_tests/chat_models/test_standard.py — new: `ChatModelIntegrationTests` for ChatOCIGenAI, env-gated, with documented xfails

Closes #261
