### PR TITLE
feat(oci): native async for embeddings and the OCIGenAI completion LLM

### DIFF
--- a/libs/oci/langchain_oci/common/async_support.py
+++ b/libs/oci/langchain_oci/common/async_support.py
@@ -264,3 +264,70 @@ class OCIAsyncClient:
             else:
                 data = await response.json()
                 yield data
+
+    async def embed_text_async(
+        self,
+        embed_text_details_dict: Dict[str, Any],
+        timeout: int = 300,
+    ) -> Dict[str, Any]:
+        """Make async embed-text request to OCI GenAI.
+
+        Args:
+            embed_text_details_dict: Serialized EmbedTextDetails (includes
+                compartmentId, servingMode, inputs, ...), as produced by the
+                SDK's ``sanitize_for_serialization``.
+            timeout: Request timeout in seconds.
+
+        Returns:
+            The embed-text response dictionary (``embeddings`` key holds the
+            vectors).
+        """
+        url = f"{self.service_endpoint}/{OCI_GENAI_API_VERSION}/actions/embedText"
+        headers = self._sign_headers("POST", url, embed_text_details_dict)
+
+        async with self._arequest(
+            "POST", url, headers, embed_text_details_dict, timeout
+        ) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                raise OCIAsyncRequestError(response.status, error_text)
+            data: Dict[str, Any] = await response.json()
+            return data
+
+    async def generate_text_async(
+        self,
+        generate_text_details_dict: Dict[str, Any],
+        stream: bool = False,
+        timeout: int = 300,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Make async generate-text (completion) request to OCI GenAI.
+
+        Args:
+            generate_text_details_dict: Serialized GenerateTextDetails
+                (includes compartmentId, servingMode, inferenceRequest), as
+                produced by the SDK's ``sanitize_for_serialization``.
+            stream: Whether to stream the response.
+            timeout: Request timeout in seconds.
+
+        Yields:
+            For streaming: SSE event dictionaries.
+            For non-streaming: a single response dictionary.
+        """
+        url = f"{self.service_endpoint}/{OCI_GENAI_API_VERSION}/actions/generateText"
+        headers = self._sign_headers(
+            "POST", url, generate_text_details_dict, stream=stream
+        )
+
+        async with self._arequest(
+            "POST", url, headers, generate_text_details_dict, timeout
+        ) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                raise OCIAsyncRequestError(response.status, error_text)
+
+            if stream:
+                async for event in self._parse_sse_async(response.content):
+                    yield event
+            else:
+                data = await response.json()
+                yield data

--- a/libs/oci/langchain_oci/embeddings/image.py
+++ b/libs/oci/langchain_oci/embeddings/image.py
@@ -35,6 +35,14 @@ class ImageEmbeddingMixin:
         """Build an embed request (provided by host class)."""
         ...
 
+    async def _aembed_inputs(
+        self,
+        inputs: List[str],
+        input_type: Optional[str] = None,
+    ) -> List[List[float]]:
+        """Embed one batch of inputs asynchronously (provided by host class)."""
+        raise NotImplementedError
+
     def embed_image(
         self,
         image: Union[str, bytes, Path],
@@ -87,4 +95,30 @@ class ImageEmbeddingMixin:
             )
             response = self.client.embed_text(invocation_obj)
             embeddings.extend(response.data.embeddings)
+        return embeddings
+
+    async def aembed_image(
+        self,
+        image: Union[str, bytes, Path],
+        mime_type: str = "image/png",
+    ) -> List[float]:
+        """Embed a single image asynchronously (native async I/O).
+
+        See :meth:`embed_image` for argument semantics.
+        """
+        return (await self.aembed_image_batch([image], mime_type=mime_type))[0]
+
+    async def aembed_image_batch(
+        self,
+        images: Sequence[Union[str, bytes, Path]],
+        mime_type: str = "image/png",
+    ) -> List[List[float]]:
+        """Embed multiple images asynchronously (native async I/O).
+
+        See :meth:`embed_image_batch` for argument semantics.
+        """
+        embeddings: List[List[float]] = []
+        for image in images:
+            data_uri = to_data_uri(image, mime_type=mime_type)
+            embeddings.extend(await self._aembed_inputs([data_uri], input_type="IMAGE"))
         return embeddings

--- a/libs/oci/langchain_oci/embeddings/oci_data_science_model_deployment_endpoint.py
+++ b/libs/oci/langchain_oci/embeddings/oci_data_science_model_deployment_endpoint.py
@@ -190,6 +190,67 @@ class OCIModelDeploymentEndpointEmbeddings(BaseModel, Embeddings):
             results.extend(response)
         return results
 
+    async def _aembedding(self, texts: List[str]) -> List[List[float]]:
+        """Async call to the Model Deployment endpoint (native async I/O).
+
+        The request is signed with the same OCI signer as the sync path (a
+        requests.PreparedRequest is signed, then its headers and exact body
+        are replayed through aiohttp, keeping the body-hash signature valid).
+        """
+        import aiohttp
+
+        _model_kwargs = self.model_kwargs or {}
+        body = self._construct_request_body(texts, _model_kwargs)
+        _endpoint_kwargs = dict(self.endpoint_kwargs or {})
+        headers = _endpoint_kwargs.pop("headers", DEFAULT_HEADER)
+
+        req = requests.Request("POST", self.endpoint, json=body, headers=headers)
+        prepared = req.prepare()
+        signer = self.auth.get("signer")
+        if signer is not None:
+            prepared = signer(prepared)
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                self.endpoint,
+                data=prepared.body,
+                headers=dict(prepared.headers),
+                **_endpoint_kwargs,
+            ) as response:
+                if response.status != 200:
+                    text = await response.text()
+                    raise ValueError(
+                        f"Error raised by inference endpoint: "
+                        f"status {response.status}. Response: {text}"
+                    )
+                res_json = await response.json()
+
+        try:
+            embeddings: List[List[float]] = res_json["data"][0]["embedding"]
+            return embeddings
+        except Exception as e:
+            raise ValueError(
+                f"Error raised by inference API: {e}.\nResponse: {res_json}"
+            ) from e
+
+    async def aembed_documents(
+        self,
+        texts: List[str],
+        chunk_size: Optional[int] = None,
+    ) -> List[List[float]]:
+        """Async version of :meth:`embed_documents` (native async I/O)."""
+        results: List[List[float]] = []
+        _chunk_size = (
+            len(texts) if (not chunk_size or chunk_size > len(texts)) else chunk_size
+        )
+        for i in range(0, len(texts), _chunk_size):
+            results.extend(await self._aembedding(texts[i : i + _chunk_size]))
+        return results
+
+    async def aembed_query(self, text: str) -> List[float]:
+        """Async version of :meth:`embed_query` (native async I/O)."""
+        return (await self.aembed_documents([text]))[0]
+
     def embed_query(self, text: str) -> List[float]:
         """Compute query embeddings using OCI Data Science Model Deployment Endpoint.
 

--- a/libs/oci/langchain_oci/embeddings/oci_data_science_model_deployment_endpoint.py
+++ b/libs/oci/langchain_oci/embeddings/oci_data_science_model_deployment_endpoint.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-from typing import Any, Callable, Dict, List, Mapping, Optional
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional
 
 import requests
+
+if TYPE_CHECKING:
+    import aiohttp
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models.llms import create_base_retry_decorator
 from langchain_core.utils import get_from_dict_or_env
@@ -190,6 +194,24 @@ class OCIModelDeploymentEndpointEmbeddings(BaseModel, Embeddings):
             results.extend(response)
         return results
 
+    @cached_property
+    def _async_session(self) -> "aiohttp.ClientSession":
+        """Reusable aiohttp session for async calls, created on first use.
+
+        Mirrors the cached ``_async_client`` of the OCIGenAI classes: one
+        session per instance so connections are pooled across calls, and
+        :meth:`aclose` releases it.
+        """
+        import aiohttp
+
+        return aiohttp.ClientSession()
+
+    async def aclose(self) -> None:
+        """Close the async HTTP session and release resources."""
+        if "_async_session" in self.__dict__:
+            await self._async_session.close()
+            del self.__dict__["_async_session"]
+
     async def _aembedding(self, texts: List[str]) -> List[List[float]]:
         """Async call to the Model Deployment endpoint (native async I/O).
 
@@ -197,8 +219,6 @@ class OCIModelDeploymentEndpointEmbeddings(BaseModel, Embeddings):
         requests.PreparedRequest is signed, then its headers and exact body
         are replayed through aiohttp, keeping the body-hash signature valid).
         """
-        import aiohttp
-
         _model_kwargs = self.model_kwargs or {}
         body = self._construct_request_body(texts, _model_kwargs)
         _endpoint_kwargs = dict(self.endpoint_kwargs or {})
@@ -210,20 +230,19 @@ class OCIModelDeploymentEndpointEmbeddings(BaseModel, Embeddings):
         if signer is not None:
             prepared = signer(prepared)
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                self.endpoint,
-                data=prepared.body,
-                headers=dict(prepared.headers),
-                **_endpoint_kwargs,
-            ) as response:
-                if response.status != 200:
-                    text = await response.text()
-                    raise ValueError(
-                        f"Error raised by inference endpoint: "
-                        f"status {response.status}. Response: {text}"
-                    )
-                res_json = await response.json()
+        async with self._async_session.post(
+            self.endpoint,
+            data=prepared.body,
+            headers=dict(prepared.headers),
+            **_endpoint_kwargs,
+        ) as response:
+            if response.status != 200:
+                text = await response.text()
+                raise ValueError(
+                    f"Error raised by inference endpoint: "
+                    f"status {response.status}. Response: {text}"
+                )
+            res_json = await response.json()
 
         try:
             embeddings: List[List[float]] = res_json["data"][0]["embedding"]

--- a/libs/oci/langchain_oci/embeddings/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/embeddings/oci_generative_ai.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+from functools import cached_property
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import pre_init
 from pydantic import BaseModel, ConfigDict
 
+from langchain_oci.common.async_support import OCIAsyncClient
 from langchain_oci.common.auth import create_oci_client_kwargs
 from langchain_oci.common.utils import CUSTOM_ENDPOINT_PREFIX
 from langchain_oci.embeddings.image import ImageEmbeddingMixin
@@ -248,3 +250,58 @@ class OCIGenAIEmbeddings(BaseModel, Embeddings, ImageEmbeddingMixin):
             Embeddings for the text.
         """
         return self.embed_documents([text])[0]
+
+    @cached_property
+    def _async_client(self) -> OCIAsyncClient:
+        """Get the async client, creating it on first access.
+
+        Reuses the sync client's signer/config so sync and async requests
+        authenticate identically (same pattern as ChatOCIGenAI's async mixin).
+        """
+        base_client = self.client.base_client
+        return OCIAsyncClient(
+            service_endpoint=self.service_endpoint,  # type: ignore[arg-type]
+            signer=base_client.signer,
+            config=getattr(base_client, "config", {}),
+        )
+
+    async def aclose(self) -> None:
+        """Close the async HTTP client and release resources."""
+        if "_async_client" in self.__dict__:
+            await self._async_client.close()
+            del self.__dict__["_async_client"]
+
+    async def _aembed_inputs(
+        self, inputs: List[str], input_type: Optional[str] = None
+    ) -> List[List[float]]:
+        """Embed a single batch of inputs via the native async client."""
+        invocation_obj = self._build_embed_request(inputs, input_type=input_type)
+        body = self.client.base_client.sanitize_for_serialization(invocation_obj)
+        data = await self._async_client.embed_text_async(body)
+        vectors: List[List[float]] = data["embeddings"]
+        return vectors
+
+    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Async call to OCIGenAI's embedding endpoint (native async I/O).
+
+        Args:
+            texts: The list of texts to embed.
+
+        Returns:
+            List of embeddings, one for each text.
+        """
+        embeddings: List[List[float]] = []
+        for i in range(0, len(texts), self.batch_size):
+            embeddings.extend(await self._aembed_inputs(texts[i : i + self.batch_size]))
+        return embeddings
+
+    async def aembed_query(self, text: str) -> List[float]:
+        """Async call to OCIGenAI's embedding endpoint (native async I/O).
+
+        Args:
+            text: The text to embed.
+
+        Returns:
+            Embeddings for the text.
+        """
+        return (await self.aembed_documents([text]))[0]

--- a/libs/oci/langchain_oci/llms/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/llms/oci_generative_ai.py
@@ -6,14 +6,19 @@ from __future__ import annotations
 import json
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterator, List, Mapping, Optional
+from functools import cached_property
+from typing import Any, AsyncIterator, Dict, Iterator, List, Mapping, Optional
 
-from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
 from langchain_core.utils import pre_init
 from pydantic import BaseModel, ConfigDict, Field
 
+from langchain_oci.common.async_support import OCIAsyncClient
 from langchain_oci.common.auth import create_oci_client_kwargs
 from langchain_oci.common.utils import CUSTOM_ENDPOINT_PREFIX
 from langchain_oci.llms.utils import enforce_stop_tokens
@@ -360,4 +365,110 @@ class OCIGenAI(LLM, OCIGenAIBase):
             chunk = GenerationChunk(text=event_data_text)
             if run_manager:
                 run_manager.on_llm_new_token(chunk.text, chunk=chunk)
+            yield chunk
+
+    @cached_property
+    def _async_client(self) -> OCIAsyncClient:
+        """Get the async client, creating it on first access.
+
+        Reuses the sync client's signer/config so sync and async requests
+        authenticate identically (same pattern as ChatOCIGenAI's async mixin).
+        """
+        base_client = self.client.base_client
+        return OCIAsyncClient(
+            service_endpoint=self.service_endpoint,  # type: ignore[arg-type]
+            signer=base_client.signer,
+            config=getattr(base_client, "config", {}),
+        )
+
+    async def aclose(self) -> None:
+        """Close the async HTTP client and release resources."""
+        if "_async_client" in self.__dict__:
+            await self._async_client.close()
+            del self.__dict__["_async_client"]
+
+    def _prepare_async_invocation_body(
+        self, prompt: str, stop: Optional[List[str]], stream: bool, kwargs: Dict
+    ) -> Dict[str, Any]:
+        """Serialize a GenerateTextDetails for the async REST call.
+
+        Unlike the sync path, the stream flag is passed explicitly instead of
+        read from (or written to) the shared ``self.is_stream`` attribute, so
+        concurrent async calls can't interfere with each other.
+        """
+        # _prepare_invocation_object is annotated as Dict but actually returns
+        # the SDK's GenerateTextDetails object; treat it as Any here.
+        invocation_obj: Any = self._prepare_invocation_object(prompt, stop, kwargs)
+        invocation_obj.inference_request.is_stream = stream
+        body: Dict[str, Any] = self.client.base_client.sanitize_for_serialization(
+            invocation_obj
+        )
+        return body
+
+    @staticmethod
+    def _completion_text_from_dict(data: Dict[str, Any]) -> str:
+        """Extract generated text from a raw generate-text REST response.
+
+        Handles both response shapes: Cohere (``generatedTexts``) and
+        Meta/generic (``choices``).
+        """
+        inference = data.get("inferenceResponse") or {}
+        if inference.get("generatedTexts"):
+            return str(inference["generatedTexts"][0].get("text", ""))
+        if inference.get("choices"):
+            return str(inference["choices"][0].get("text", ""))
+        return ""
+
+    async def _acall(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Async call to the OCIGenAI generate endpoint (native async I/O).
+
+        Example:
+            .. code-block:: python
+
+               response = await llm.ainvoke("Tell me a joke.")
+        """
+        if self.is_stream:
+            text = ""
+            async for chunk in self._astream(prompt, stop, run_manager, **kwargs):
+                text += chunk.text
+            if stop is not None:
+                text = enforce_stop_tokens(text, stop)
+            return text
+
+        body = self._prepare_async_invocation_body(prompt, stop, False, kwargs)
+        response_data: Dict[str, Any] = {}
+        async for data in self._async_client.generate_text_async(body):
+            response_data = data
+
+        text = self._completion_text_from_dict(response_data)
+        if stop is not None:
+            text = enforce_stop_tokens(text, stop)
+        return text
+
+    async def _astream(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[GenerationChunk]:
+        """Stream OCIGenAI LLM asynchronously (native async I/O).
+
+        Example:
+            .. code-block:: python
+
+            async for chunk in llm.astream("Tell me a joke."):
+                print(chunk.text, end="", flush=True)
+        """
+        body = self._prepare_async_invocation_body(prompt, stop, True, kwargs)
+        async for event in self._async_client.generate_text_async(body, stream=True):
+            chunk = GenerationChunk(text=event.get("text", ""))
+            if run_manager:
+                await run_manager.on_llm_new_token(chunk.text, chunk=chunk)
             yield chunk

--- a/libs/oci/tests/unit_tests/embeddings/test_async_embeddings.py
+++ b/libs/oci/tests/unit_tests/embeddings/test_async_embeddings.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for native async support in OCI embeddings classes."""
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from langchain_oci.embeddings.oci_generative_ai import OCIGenAIEmbeddings
+
+
+@pytest.fixture
+def mock_oci_client() -> MagicMock:
+    client = MagicMock()
+    # Identity serializer: EmbedTextDetails objects pass through as-is in
+    # these tests; the mocked async client only records what it received.
+    client.base_client.sanitize_for_serialization = lambda obj: {
+        "inputs": obj.inputs,
+        "inputType": getattr(obj, "input_type", None),
+        "compartmentId": obj.compartment_id,
+    }
+    client.base_client.signer = MagicMock()
+    client.base_client.config = {}
+    return client
+
+
+@pytest.fixture
+def embeddings(mock_oci_client: MagicMock) -> OCIGenAIEmbeddings:
+    return OCIGenAIEmbeddings(
+        model_id="cohere.embed-v4.0",
+        compartment_id="test-compartment",
+        service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+        client=mock_oci_client,
+    )
+
+
+def _install_mock_async_client(
+    embeddings: OCIGenAIEmbeddings, vectors_by_call: List[List[List[float]]]
+) -> MagicMock:
+    """Install a mock OCIAsyncClient returning canned embed responses."""
+    async_client = MagicMock()
+    responses = [{"embeddings": v} for v in vectors_by_call]
+    async_client.embed_text_async = AsyncMock(side_effect=responses)
+    async_client.close = AsyncMock()
+    embeddings.__dict__["_async_client"] = async_client
+    return async_client
+
+
+@pytest.mark.requires("oci")
+async def test_aembed_documents(embeddings: OCIGenAIEmbeddings) -> None:
+    async_client = _install_mock_async_client(embeddings, [[[0.1, 0.2], [0.3, 0.4]]])
+
+    result = await embeddings.aembed_documents(["hello", "world"])
+
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+    async_client.embed_text_async.assert_awaited_once()
+    body = async_client.embed_text_async.await_args.args[0]
+    assert body["inputs"] == ["hello", "world"]
+    assert body["compartmentId"] == "test-compartment"
+
+
+@pytest.mark.requires("oci")
+async def test_aembed_documents_batches(embeddings: OCIGenAIEmbeddings) -> None:
+    """Inputs beyond batch_size are split across multiple async requests."""
+    embeddings.batch_size = 2
+    async_client = _install_mock_async_client(embeddings, [[[1.0], [2.0]], [[3.0]]])
+
+    result = await embeddings.aembed_documents(["a", "b", "c"])
+
+    assert result == [[1.0], [2.0], [3.0]]
+    assert async_client.embed_text_async.await_count == 2
+    first, second = async_client.embed_text_async.await_args_list
+    assert first.args[0]["inputs"] == ["a", "b"]
+    assert second.args[0]["inputs"] == ["c"]
+
+
+@pytest.mark.requires("oci")
+async def test_aembed_query(embeddings: OCIGenAIEmbeddings) -> None:
+    _install_mock_async_client(embeddings, [[[0.5, 0.6]]])
+
+    result = await embeddings.aembed_query("hello")
+
+    assert result == [0.5, 0.6]
+
+
+@pytest.mark.requires("oci")
+async def test_aembed_image_batch(embeddings: OCIGenAIEmbeddings) -> None:
+    """Async image embedding routes data URIs with input_type=IMAGE."""
+    async_client = _install_mock_async_client(embeddings, [[[0.7, 0.8]]])
+
+    data_uri = "data:image/png;base64,aGVsbG8="
+    result = await embeddings.aembed_image_batch([data_uri])
+
+    assert result == [[0.7, 0.8]]
+    body = async_client.embed_text_async.await_args.args[0]
+    assert body["inputs"] == [data_uri]
+    assert body["inputType"] == "IMAGE"
+
+
+@pytest.mark.requires("oci")
+async def test_aclose(embeddings: OCIGenAIEmbeddings) -> None:
+    async_client = _install_mock_async_client(embeddings, [])
+
+    await embeddings.aclose()
+
+    async_client.close.assert_awaited_once()
+    assert "_async_client" not in embeddings.__dict__
+
+
+@pytest.mark.requires("oci")
+async def test_async_uses_no_thread_pool(embeddings: OCIGenAIEmbeddings) -> None:
+    """aembed_documents must not fall back to the sync client."""
+    _install_mock_async_client(embeddings, [[[0.1]]])
+
+    await embeddings.aembed_documents(["x"])
+
+    embeddings.client.embed_text.assert_not_called()
+
+
+@pytest.mark.requires("oci")
+def test_sync_embed_documents_unchanged(embeddings: OCIGenAIEmbeddings) -> None:
+    """Sync path still uses the SDK client."""
+    response = MagicMock()
+    response.data.embeddings = [[0.9]]
+    embeddings.client.embed_text.return_value = response
+
+    assert embeddings.embed_documents(["x"]) == [[0.9]]
+    embeddings.client.embed_text.assert_called_once()
+
+
+class TestModelDeploymentAsync:
+    """Async tests for OCIModelDeploymentEndpointEmbeddings."""
+
+    def _make(self) -> Any:
+        pytest.importorskip("ads")
+        from langchain_oci.embeddings.oci_data_science_model_deployment_endpoint import (  # noqa: E501
+            OCIModelDeploymentEndpointEmbeddings,
+        )
+
+        return OCIModelDeploymentEndpointEmbeddings(
+            endpoint="https://modeldeployment.example.com/predict",
+            auth={"signer": None},
+        )
+
+    async def test_aembed_documents(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        embeddings = self._make()
+
+        captured: Dict[str, Any] = {}
+
+        async def fake_aembedding(texts: List[str]) -> List[List[float]]:
+            captured["texts"] = texts
+            return [[0.1] for _ in texts]
+
+        monkeypatch.setattr(embeddings, "_aembedding", fake_aembedding)
+
+        result = await embeddings.aembed_documents(["a", "b"])
+        assert result == [[0.1], [0.1]]
+        assert captured["texts"] == ["a", "b"]
+
+    async def test_aembed_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        embeddings = self._make()
+
+        async def fake_aembedding(texts: List[str]) -> List[List[float]]:
+            return [[0.2]]
+
+        monkeypatch.setattr(embeddings, "_aembedding", fake_aembedding)
+
+        assert await embeddings.aembed_query("q") == [0.2]

--- a/libs/oci/tests/unit_tests/embeddings/test_async_embeddings.py
+++ b/libs/oci/tests/unit_tests/embeddings/test_async_embeddings.py
@@ -168,3 +168,54 @@ class TestModelDeploymentAsync:
         monkeypatch.setattr(embeddings, "_aembedding", fake_aembedding)
 
         assert await embeddings.aembed_query("q") == [0.2]
+
+    async def test_async_session_cached_and_aclose(self) -> None:
+        """One session per instance, released by aclose (same pattern as
+        the OCIGenAI classes' cached _async_client)."""
+        pytest.importorskip("aiohttp")
+        embeddings = self._make()
+
+        session = embeddings._async_session
+        assert embeddings._async_session is session
+
+        await embeddings.aclose()
+        assert session.closed
+        assert "_async_session" not in embeddings.__dict__
+
+        reopened = embeddings._async_session
+        assert reopened is not session
+        await embeddings.aclose()
+
+    async def test_aembedding_reuses_cached_session(self) -> None:
+        """_aembedding posts through the shared session, not a new one."""
+        embeddings = self._make()
+
+        class FakeResponse:
+            status = 200
+
+            async def json(self) -> Dict[str, Any]:
+                return {"data": [{"embedding": [[0.3]]}]}
+
+            async def text(self) -> str:
+                return ""
+
+            async def __aenter__(self) -> "FakeResponse":
+                return self
+
+            async def __aexit__(self, *exc: Any) -> bool:
+                return False
+
+        class FakeSession:
+            def __init__(self) -> None:
+                self.posts = 0
+
+            def post(self, *args: Any, **kwargs: Any) -> FakeResponse:
+                self.posts += 1
+                return FakeResponse()
+
+        fake = FakeSession()
+        embeddings.__dict__["_async_session"] = fake
+
+        assert await embeddings._aembedding(["a"]) == [[0.3]]
+        assert await embeddings._aembedding(["b"]) == [[0.3]]
+        assert fake.posts == 2

--- a/libs/oci/tests/unit_tests/llms/test_async_llm.py
+++ b/libs/oci/tests/unit_tests/llms/test_async_llm.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for native async support in the OCIGenAI completion LLM."""
+
+from typing import Any, AsyncIterator, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from langchain_oci.llms.oci_generative_ai import OCIGenAI
+
+
+@pytest.fixture
+def mock_oci_client() -> MagicMock:
+    client = MagicMock()
+
+    def serialize(obj: Any) -> Dict[str, Any]:
+        return {
+            "compartmentId": obj.compartment_id,
+            "servingMode": {"modelId": obj.serving_mode.model_id},
+            "inferenceRequest": {
+                "prompt": obj.inference_request.prompt,
+                "isStream": obj.inference_request.is_stream,
+            },
+        }
+
+    client.base_client.sanitize_for_serialization = serialize
+    client.base_client.signer = MagicMock()
+    client.base_client.config = {}
+    return client
+
+
+def _make_llm(mock_oci_client: MagicMock, model_id: str) -> OCIGenAI:
+    return OCIGenAI(
+        model_id=model_id,
+        compartment_id="test-compartment",
+        service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+        client=mock_oci_client,
+    )
+
+
+def _install_async_gen(llm: OCIGenAI, payloads: List[Dict[str, Any]]) -> MagicMock:
+    """Install a mock async client whose generate_text_async yields payloads."""
+    async_client = MagicMock()
+    calls: List[Dict[str, Any]] = []
+
+    def generate_text_async(
+        body: Dict[str, Any], stream: bool = False, timeout: int = 300
+    ) -> AsyncIterator[Dict[str, Any]]:
+        calls.append({"body": body, "stream": stream})
+
+        async def gen() -> AsyncIterator[Dict[str, Any]]:
+            for p in payloads:
+                yield p
+
+        return gen()
+
+    async_client.generate_text_async = MagicMock(side_effect=generate_text_async)
+    async_client.close = AsyncMock()
+    async_client.calls = calls
+    llm.__dict__["_async_client"] = async_client
+    return async_client
+
+
+@pytest.mark.requires("oci")
+async def test_acall_cohere_response(mock_oci_client: MagicMock) -> None:
+    llm = _make_llm(mock_oci_client, "cohere.command")
+    async_client = _install_async_gen(
+        llm,
+        [{"inferenceResponse": {"generatedTexts": [{"text": "hello there"}]}}],
+    )
+
+    result = await llm.ainvoke("hi")
+
+    assert result == "hello there"
+    call = async_client.calls[0]
+    assert call["stream"] is False
+    assert call["body"]["inferenceRequest"]["prompt"] == "hi"
+    assert call["body"]["inferenceRequest"]["isStream"] is False
+
+
+@pytest.mark.requires("oci")
+async def test_acall_meta_response(mock_oci_client: MagicMock) -> None:
+    llm = _make_llm(mock_oci_client, "meta.llama-3.3-70b-instruct")
+    _install_async_gen(
+        llm,
+        [{"inferenceResponse": {"choices": [{"text": "meta says hi"}]}}],
+    )
+
+    assert await llm.ainvoke("hi") == "meta says hi"
+
+
+@pytest.mark.requires("oci")
+async def test_acall_enforces_stop(mock_oci_client: MagicMock) -> None:
+    llm = _make_llm(mock_oci_client, "cohere.command")
+    _install_async_gen(
+        llm,
+        [{"inferenceResponse": {"generatedTexts": [{"text": "one two STOP three"}]}}],
+    )
+
+    result = await llm.ainvoke("hi", stop=["STOP"])
+    assert result == "one two "
+
+
+@pytest.mark.requires("oci")
+async def test_astream(mock_oci_client: MagicMock) -> None:
+    llm = _make_llm(mock_oci_client, "cohere.command")
+    async_client = _install_async_gen(
+        llm, [{"text": "chunk1"}, {"text": "chunk2"}, {"finishReason": "stop"}]
+    )
+
+    chunks = [c async for c in llm.astream("hi")]
+
+    assert [c for c in chunks if c] and "".join(chunks) == "chunk1chunk2"
+    assert async_client.calls[0]["stream"] is True
+    assert async_client.calls[0]["body"]["inferenceRequest"]["isStream"] is True
+
+
+@pytest.mark.requires("oci")
+async def test_astream_does_not_mutate_is_stream(mock_oci_client: MagicMock) -> None:
+    """Unlike the sync path, _astream must not flip shared instance state."""
+    llm = _make_llm(mock_oci_client, "cohere.command")
+    _install_async_gen(llm, [{"text": "x"}])
+
+    assert llm.is_stream is False
+    async for _ in llm.astream("hi"):
+        pass
+    assert llm.is_stream is False
+
+
+@pytest.mark.requires("oci")
+async def test_async_uses_no_sync_client(mock_oci_client: MagicMock) -> None:
+    llm = _make_llm(mock_oci_client, "cohere.command")
+    _install_async_gen(
+        llm, [{"inferenceResponse": {"generatedTexts": [{"text": "y"}]}}]
+    )
+
+    await llm.ainvoke("hi")
+
+    mock_oci_client.generate_text.assert_not_called()
+
+
+@pytest.mark.requires("oci")
+async def test_aclose(mock_oci_client: MagicMock) -> None:
+    llm = _make_llm(mock_oci_client, "cohere.command")
+    async_client = _install_async_gen(llm, [])
+
+    await llm.aclose()
+
+    async_client.close.assert_awaited_once()
+    assert "_async_client" not in llm.__dict__


### PR DESCRIPTION
## Summary

Implements #263: true async I/O (no thread-pool fallbacks) for the remaining sync-only classes in `langchain-oci`, reusing the signed-aiohttp infrastructure the chat async mixin already uses.

**New async surface**
- `OCIGenAIEmbeddings.aembed_documents` / `aembed_query` — native async, batching semantics preserved (`batch_size=96`)
- `OCIGenAIEmbeddings.aembed_image` / `aembed_image_batch` — async image embeddings for multimodal models (e.g. `cohere.embed-v4.0`)
- `OCIModelDeploymentEndpointEmbeddings.aembed_documents` / `aembed_query` — signs a `requests.PreparedRequest` with the OCI signer, then replays exact body + headers through aiohttp so the body-hash signature stays valid
- `OCIGenAI` (completion LLM) `_acall` / `_astream` — so `ainvoke`/`astream` no longer run in executor threads
- `aclose()` on each class for explicit session cleanup

**Design notes**
- `OCIAsyncClient` gains `embed_text_async` and `generate_text_async`; requests serialize through the SDK's own `sanitize_for_serialization`, so sync and async produce identical JSON.
- The async LLM path passes the stream flag explicitly instead of mutating the shared `self.is_stream` (the sync `_stream` sets `self.is_stream = True` on the instance — the async path doesn't replicate that shared-state mutation, and a unit test pins this).

## Files changed

- @libs/oci/langchain_oci/common/async_support.py — `embed_text_async`, `generate_text_async`
- @libs/oci/langchain_oci/embeddings/oci_generative_ai.py — async client wiring + `aembed_*`
- @libs/oci/langchain_oci/embeddings/image.py — `aembed_image` / `aembed_image_batch`
- @libs/oci/langchain_oci/embeddings/oci_data_science_model_deployment_endpoint.py — async MD embeddings
- @libs/oci/langchain_oci/llms/oci_generative_ai.py — `_acall` / `_astream` on `OCIGenAI`
- @libs/oci/tests/unit_tests/embeddings/test_async_embeddings.py — new
- @libs/oci/tests/unit_tests/llms/test_async_llm.py — new

## Verification

- Unit: 500 passed (16 new async tests, including "sync client never called from async path" and "astream does not mutate is_stream"); ruff + mypy clean.
- Live against OCI GenAI: `aembed_documents` output matches sync (cosine 0.99996 — the service itself is nondeterministic across identical sync calls at ~0.9999), `aembed_query`, `aembed_image` (dim 1536 via embed-v4.0), and 4 concurrent `aembed_query` calls on one instance in 0.24s wall time (true concurrency).
- The legacy `generateText` completion API rejects current models identically on sync and async paths (parity verified); async LLM logic is pinned by unit tests with mocked transport.

Closes #263
