### PR TITLE
feat(oracledb): support nested metadata filters in OracleVS

### DIFF
--- a/libs/oracledb/langchain_oracledb/vectorstores/oraclevs.py
+++ b/libs/oracledb/langchain_oracledb/vectorstores/oraclevs.py
@@ -349,8 +349,30 @@ def _generate_condition(
 
             return res
 
+        elif any(value_key.startswith("$") for value_key in value.keys()):
+            raise ValueError(
+                "Invalid filter: operator keys ($...) cannot be mixed with "
+                f"nested metadata keys in {value!r}."
+            )
+
         else:
-            raise ValueError("Nested filters are not supported.")
+            # Nested metadata path: {"address": {"city": "NYC"}} is
+            # equivalent to {"address.city": "NYC"}. Recurse with the
+            # dotted path; operator dicts and scalars terminate the
+            # recursion, so arbitrary nesting depth is supported.
+            nested_conditions = [
+                _generate_condition(
+                    f"{metadata_key}.{sub_key}", sub_value, bind_variables
+                )
+                for sub_key, sub_value in value.items()
+            ]
+
+            res = " AND ".join(nested_conditions)
+
+            if len(nested_conditions) > 1:
+                return "(" + res + ")"
+
+            return res
 
     else:
         raise ValueError("Filter format is invalid.")

--- a/libs/oracledb/tests/integration_tests/vectorstores/test_nested_filters.py
+++ b/libs/oracledb/tests/integration_tests/vectorstores/test_nested_filters.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Integration tests for nested metadata filters in OracleVS (issue #272).
+
+Requires a reachable Oracle Database 23ai+ via the usual env vars:
+VECDB_USER, VECDB_PASS, VECDB_HOST (dsn).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, List
+
+import oracledb
+import pytest
+from langchain_core.documents import Document
+from langchain_core.embeddings import DeterministicFakeEmbedding
+
+from langchain_oracledb.vectorstores import DistanceStrategy, OracleVS
+from langchain_oracledb.vectorstores.oraclevs import drop_table_purge
+
+username = os.environ.get("VECDB_USER")
+password = os.environ.get("VECDB_PASS")
+dsn = os.environ.get("VECDB_HOST")
+
+try:
+    oracledb.connect(user=username, password=password, dsn=dsn)
+except Exception as e:
+    pytest.skip(
+        allow_module_level=True,
+        reason=f"Database connection failed: {e}, skipping tests.",
+    )
+
+TABLE = "ORAVS_NESTED_FILTER_IT"
+
+DOCS = [
+    Document(
+        page_content="alpha",
+        metadata={"address": {"city": "NYC", "zip": "10001"}, "level": 1},
+    ),
+    Document(
+        page_content="beta",
+        metadata={"address": {"city": "LA", "zip": "90001"}, "level": 2},
+    ),
+    Document(
+        page_content="gamma",
+        metadata={"address": {"city": "NYC", "zip": "11201"}, "level": 3},
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def vectorstore() -> Any:
+    conn = oracledb.connect(user=username, password=password, dsn=dsn)
+    drop_table_purge(conn, TABLE)
+    vs = OracleVS.from_documents(
+        DOCS,
+        DeterministicFakeEmbedding(size=64),
+        client=conn,
+        table_name=TABLE,
+        distance_strategy=DistanceStrategy.COSINE,
+    )
+    yield vs
+    drop_table_purge(conn, TABLE)
+
+
+def _contents(results: List[Document]) -> List[str]:
+    return sorted(d.page_content for d in results)
+
+
+def test_nested_path_scalar(vectorstore: OracleVS) -> None:
+    r = vectorstore.similarity_search("x", k=5, filter={"address": {"city": "NYC"}})
+    assert _contents(r) == ["alpha", "gamma"]
+
+
+def test_nested_siblings_with_operator(vectorstore: OracleVS) -> None:
+    r = vectorstore.similarity_search(
+        "x", k=5, filter={"address": {"city": "NYC", "zip": {"$ne": "10001"}}}
+    )
+    assert _contents(r) == ["gamma"]
+
+
+def test_or_with_nested_branch(vectorstore: OracleVS) -> None:
+    r = vectorstore.similarity_search(
+        "x",
+        k=5,
+        filter={"$or": [{"address": {"city": "LA"}}, {"level": {"$gte": 3}}]},
+    )
+    assert _contents(r) == ["beta", "gamma"]
+
+
+def test_logical_nesting_with_nested_path(vectorstore: OracleVS) -> None:
+    r = vectorstore.similarity_search(
+        "x",
+        k=5,
+        filter={
+            "$and": [
+                {"$or": [{"level": 1}, {"level": 2}]},
+                {"address": {"zip": "90001"}},
+            ]
+        },
+    )
+    assert _contents(r) == ["beta"]
+
+
+def test_nested_equals_dotted_spelling(vectorstore: OracleVS) -> None:
+    nested = vectorstore.similarity_search(
+        "x", k=5, filter={"address": {"city": "NYC"}}
+    )
+    dotted = vectorstore.similarity_search("x", k=5, filter={"address.city": "NYC"})
+    assert _contents(nested) == _contents(dotted)

--- a/libs/oracledb/tests/unit_tests/vectorstores/test_nested_filters.py
+++ b/libs/oracledb/tests/unit_tests/vectorstores/test_nested_filters.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for nested metadata filters in OracleVS (issue #272).
+
+Nested dict filters like ``{"address": {"city": "NYC"}}`` are translated
+into dotted JSON paths (``$.address.city``), equivalent to the already
+supported ``{"address.city": "NYC"}`` spelling. Operator dicts and scalars
+terminate the recursion, so nesting depth is arbitrary.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from langchain_oracledb.vectorstores.oraclevs import _generate_where_clause
+
+
+def _clause(filter: Dict[str, Any]) -> tuple[str, List[Any]]:
+    binds: List[Any] = []
+    return _generate_where_clause(filter, binds), binds
+
+
+def test_nested_path_scalar() -> None:
+    sql, binds = _clause({"address": {"city": "NYC"}})
+
+    assert "'$.address.city?(@ == $val)'" in sql
+    assert binds == ["NYC"]
+
+
+def test_nested_path_equivalent_to_dotted_key() -> None:
+    nested_sql, nested_binds = _clause({"address": {"city": "NYC"}})
+    dotted_sql, dotted_binds = _clause({"address.city": "NYC"})
+
+    assert nested_sql == dotted_sql
+    assert nested_binds == dotted_binds
+
+
+def test_nested_path_with_operator_leaf() -> None:
+    sql, binds = _clause({"address": {"zip": {"$gte": 10000}}})
+
+    assert "'$.address.zip?(@ >= $val0)'" in sql
+    assert binds == [10000]
+
+
+def test_deeply_nested_path() -> None:
+    sql, binds = _clause({"a": {"b": {"c": {"d": "deep"}}}})
+
+    assert "'$.a.b.c.d?(@ == $val)'" in sql
+    assert binds == ["deep"]
+
+
+def test_nested_siblings_combine_with_and() -> None:
+    sql, binds = _clause({"address": {"city": {"$ne": "LA"}, "zip": "10001"}})
+
+    assert sql.startswith("(") and sql.endswith(")")
+    assert " AND " in sql
+    assert "'$.address.city?(@ != $val0)'" in sql
+    assert "'$.address.zip?(@ == $val)'" in sql
+    assert binds == ["LA", "10001"]
+
+
+def test_nested_inside_logical_operators() -> None:
+    sql, binds = _clause(
+        {"$or": [{"address": {"city": "NYC"}}, {"profile": {"level": 3}}]}
+    )
+
+    assert " OR " in sql
+    assert "'$.address.city?(@ == $val)'" in sql
+    assert "'$.profile.level?(@ == $val)'" in sql
+    assert binds == ["NYC", 3]
+
+
+def test_logical_nesting_still_supported() -> None:
+    """Pre-existing behavior pinned: $and/$or compose recursively."""
+    sql, binds = _clause(
+        {"$and": [{"$or": [{"a": 1}, {"b": 2}]}, {"$nor": [{"c": 3}]}]}
+    )
+
+    assert " OR " in sql and " AND " in sql and "NOT" in sql
+    assert binds == [1, 2, 3]
+
+
+def test_mixed_operator_and_nested_keys_raise() -> None:
+    with pytest.raises(ValueError, match="cannot be mixed"):
+        _clause({"a": {"$eq": 1, "b": 2}})
+
+
+def test_bind_variables_stay_positional() -> None:
+    """Bind names must track the shared bind list across nested branches."""
+    sql, binds = _clause({"$and": [{"x": {"y": "1"}}, {"z": {"$in": ["a", "b"]}}]})
+
+    assert ":value0" in sql
+    assert binds[0] == "1"
+    assert len(binds) == 3  # "1" + two $in values


### PR DESCRIPTION
## Summary

Implements #272. One scoping correction discovered during implementation: nested **logical** composition (`{"$and": [{"$or": [...]}, ...]}`) already worked — `_generate_where_clause` recurses over `$and`/`$or`/`$nor`. The actual limitation was nested **metadata paths**: `{"address": {"city": "NYC"}}` raised `ValueError("Nested filters are not supported.")`.

Nested dicts are now translated recursively into dotted JSON paths (`$.address.city`), exactly equivalent to the already-supported `{"address.city": "NYC"}` spelling:

```python
vs.similarity_search(q, filter={"address": {"city": "NYC", "zip": {"$ne": "10001"}}})
vs.similarity_search(q, filter={"$or": [{"address": {"city": "LA"}}, {"level": {"$gte": 3}}]})
```

- Operator dicts and scalars terminate the recursion → arbitrary nesting depth
- Sibling keys at the same nesting level combine with `AND`
- Values still flow through positional bind variables (no SQL injection surface)
- Mixing operator keys with nested keys in one dict (`{"a": {"$eq": 1, "b": 2}}`) is ambiguous and now fails with a specific message instead of the generic error

## Files changed

- @libs/oracledb/langchain_oracledb/vectorstores/oraclevs.py — recursive nested-path branch in `_generate_condition`
- @libs/oracledb/tests/unit_tests/vectorstores/test_nested_filters.py — new: 9 tests pinning the emitted `JSON_EXISTS` SQL and bind lists, including nested/dotted equivalence and the pre-existing logical recursion
- @libs/oracledb/tests/integration_tests/vectorstores/test_nested_filters.py — new: 5 env-gated tests (`VECDB_*` convention)

## Verification

- Unit: 385 passed (9 new); ruff + mypy clean.
- Live against Oracle Database 23ai Free: all 5 integration tests pass — nested scalar path, nested siblings + `$ne`, `$or` over a nested branch, `$and`+`$or` logical nesting combined with a nested path, and nested-vs-dotted result equivalence.

Closes #272
