### PR TITLE
feat(oci): standard content blocks and output_version="v1" support in ChatOCIGenAI

### DIFF
--- a/libs/oci/langchain_oci/chat_models/providers/cohere.py
+++ b/libs/oci/langchain_oci/chat_models/providers/cohere.py
@@ -496,7 +496,9 @@ class CohereProvider(Provider):
             role = self.get_role(msg)
             if role in ("USER", "SYSTEM"):
                 oci_chat_history.append(
-                    self.oci_chat_message[role](message=msg.content)
+                    self.oci_chat_message[role](
+                        message=OCIUtils.content_to_text(msg.content)
+                    )
                 )
             elif isinstance(msg, AIMessage):
                 # Skip tool calls if forcing single step
@@ -510,7 +512,7 @@ class CohereProvider(Provider):
                     if msg.tool_calls
                     else None
                 )
-                msg_content = msg.content if msg.content else " "
+                msg_content = OCIUtils.content_to_text(msg.content) or " "
                 oci_chat_history.append(
                     self.oci_chat_message[role](
                         message=msg_content, tool_calls=tool_calls
@@ -541,7 +543,9 @@ class CohereProvider(Provider):
                     # by an AI message
                     oci_chat_history.append(
                         self.oci_chat_message["CHATBOT"](
-                            message=messages[len(messages) - i - 2].content
+                            message=OCIUtils.content_to_text(
+                                messages[len(messages) - i - 2].content
+                            )
                         )
                     )
                 break
@@ -570,7 +574,9 @@ class CohereProvider(Provider):
             oci_tool_results = None
 
         # Use last message's content if no tool results are present
-        message_str = "" if oci_tool_results else messages[-1].content
+        message_str = (
+            "" if oci_tool_results else OCIUtils.content_to_text(messages[-1].content)
+        )
 
         oci_params = {
             "message": message_str,

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -770,6 +770,13 @@ class GenericProvider(Provider):
                             f"application/pdf"
                         )
 
+                # Standard v1 content blocks that are transmitted through
+                # dedicated request fields rather than message content:
+                # tool calls come from AIMessage.tool_calls, and reasoning
+                # is model output that the API doesn't accept back as input.
+                elif content_type in ("tool_use", "tool_call", "reasoning"):
+                    continue
+
                 else:
                     raise ValueError(
                         f"Unsupported content type: {content_type}. "

--- a/libs/oci/langchain_oci/common/utils.py
+++ b/libs/oci/langchain_oci/common/utils.py
@@ -26,6 +26,26 @@ class OCIUtils:
         return isinstance(obj, type) and issubclass(obj, BaseModel)
 
     @staticmethod
+    def content_to_text(content: Any) -> str:
+        """Coerce message content (str or v1 list-of-blocks) to plain text.
+
+        Joins ``text`` blocks in order. Non-text blocks (``reasoning``,
+        ``tool_call``, ``tool_use``, ...) are transmitted through dedicated
+        message/request fields, so they are skipped here rather than fatal.
+        """
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, str):
+                    parts.append(block)
+                elif isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+            return "".join(parts)
+        return str(content)
+
+    @staticmethod
     def remove_signature_from_tool_description(name: str, description: str) -> str:
         """
         Remove the tool signature and Args section from a tool description.

--- a/libs/oci/tests/unit_tests/chat_models/test_content_blocks_v1.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_content_blocks_v1.py
@@ -14,10 +14,16 @@ from typing import Any, List
 from unittest.mock import MagicMock
 
 import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
 from langchain_oci.common.utils import OCIUtils
+
+# output_version / content_blocks only exist on langchain-core >= 1.0
+# (absent on the Python 3.9 / langchain-core 0.3.x matrix). The v1 *input*
+# tolerance tests below run on both matrices.
+_CORE_SUPPORTS_V1 = "output_version" in BaseChatModel.model_fields
 
 V1_AI_MESSAGE = AIMessage(
     content=[
@@ -98,6 +104,9 @@ def test_cohere_provider_accepts_v1_history() -> None:
 
 
 @pytest.mark.requires("oci")
+@pytest.mark.skipif(
+    not _CORE_SUPPORTS_V1, reason="output_version requires langchain-core>=1.0"
+)
 def test_output_version_v1_rewrites_content(monkeypatch: pytest.MonkeyPatch) -> None:
     """End to end with a mocked client: invoke returns list-of-blocks content."""
 
@@ -106,7 +115,7 @@ def test_output_version_v1_rewrites_content(monkeypatch: pytest.MonkeyPatch) -> 
             return self.get(val)
 
     client = MagicMock()
-    llm = ChatOCIGenAI(
+    llm = ChatOCIGenAI(  # type: ignore[call-arg]  # kwarg absent on core 0.3.x
         model_id="meta.llama-3.3-70b-instruct",
         client=client,
         compartment_id="c",
@@ -155,4 +164,5 @@ def test_output_version_v1_rewrites_content(monkeypatch: pytest.MonkeyPatch) -> 
     result = llm.invoke("hi")
     assert isinstance(result.content, list)
     assert result.content == [{"type": "text", "text": "Hello world"}]
-    assert result.content_blocks == [{"type": "text", "text": "Hello world"}]
+    blocks = result.content_blocks  # type: ignore[attr-defined]  # core 0.3.x
+    assert blocks == [{"type": "text", "text": "Hello world"}]

--- a/libs/oci/tests/unit_tests/chat_models/test_content_blocks_v1.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_content_blocks_v1.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for standard content blocks / output_version="v1" (issue #260).
+
+langchain-core >= 1.0 rewrites ``AIMessage.content`` into the standardized
+list-of-blocks form when ``output_version="v1"`` is set. The provider request
+builders must therefore accept v1-format message *input*: text blocks render,
+while ``reasoning``/``tool_call``/``tool_use`` blocks are carried by
+dedicated fields and are skipped, not fatal.
+"""
+
+from typing import Any, List
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
+from langchain_oci.common.utils import OCIUtils
+
+V1_AI_MESSAGE = AIMessage(
+    content=[
+        {"type": "reasoning", "reasoning": "User wants weather; call the tool."},
+        {"type": "text", "text": "Checking."},
+        {
+            "type": "tool_call",
+            "id": "c1",
+            "name": "get_weather",
+            "args": {"city": "Rome"},
+        },
+    ],
+    tool_calls=[
+        {
+            "name": "get_weather",
+            "args": {"city": "Rome"},
+            "id": "c1",
+            "type": "tool_call",
+        }
+    ],
+)
+
+HISTORY: List[Any] = [
+    HumanMessage("Weather in Rome?"),
+    V1_AI_MESSAGE,
+    ToolMessage("Sunny, 28C", tool_call_id="c1"),
+]
+
+
+def test_content_to_text_str() -> None:
+    assert OCIUtils.content_to_text("plain") == "plain"
+
+
+def test_content_to_text_v1_blocks() -> None:
+    assert (
+        OCIUtils.content_to_text(V1_AI_MESSAGE.content) == "Checking."
+    )  # reasoning/tool_call skipped
+
+
+def test_content_to_text_mixed_str_items() -> None:
+    assert OCIUtils.content_to_text(["a", {"type": "text", "text": "b"}]) == "ab"
+
+
+@pytest.mark.requires("oci")
+def test_generic_provider_accepts_v1_history() -> None:
+    """Meta/Generic path: v1 blocks in history must build a valid request."""
+    llm = ChatOCIGenAI(
+        model_id="meta.llama-3.3-70b-instruct",
+        client=MagicMock(),
+        compartment_id="c",
+    )
+    request = llm._prepare_request(HISTORY, stop=None, stream=False)
+    # The reasoning/tool_call blocks are skipped; the text block survives.
+    rendered = str(request.chat_request.messages)
+    assert "Checking." in rendered
+    assert "User wants weather; call the tool." not in rendered
+
+
+@pytest.mark.requires("oci")
+def test_cohere_provider_accepts_v1_history() -> None:
+    """Cohere V1 path coerces list content to text for its string fields."""
+    llm = ChatOCIGenAI(
+        model_id="cohere.command-r-plus-08-2024",
+        client=MagicMock(),
+        compartment_id="c",
+    )
+    request = llm._prepare_request(
+        [
+            HumanMessage("hi"),
+            AIMessage(content=[{"type": "text", "text": "hello"}]),
+            HumanMessage("bye"),
+        ],
+        stop=None,
+        stream=False,
+    )
+    history = request.chat_request.chat_history
+    assert any(getattr(m, "message", None) == "hello" for m in history)
+
+
+@pytest.mark.requires("oci")
+def test_output_version_v1_rewrites_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End to end with a mocked client: invoke returns list-of-blocks content."""
+
+    class MockResponseDict(dict):
+        def __getattr__(self, val: str) -> Any:
+            return self.get(val)
+
+    client = MagicMock()
+    llm = ChatOCIGenAI(
+        model_id="meta.llama-3.3-70b-instruct",
+        client=client,
+        compartment_id="c",
+        output_version="v1",
+    )
+
+    def mocked_chat(*args: Any, **kwargs: Any) -> Any:
+        return MockResponseDict(
+            {
+                "status": 200,
+                "data": MockResponseDict(
+                    {
+                        "chat_response": MockResponseDict(
+                            {
+                                "choices": [
+                                    MockResponseDict(
+                                        {
+                                            "message": MockResponseDict(
+                                                {
+                                                    "content": [
+                                                        MockResponseDict(
+                                                            {"text": "Hello world"}
+                                                        )
+                                                    ],
+                                                    "tool_calls": None,
+                                                }
+                                            ),
+                                            "finish_reason": "stop",
+                                        }
+                                    )
+                                ],
+                                "time_created": "2026-01-01T00:00:00Z",
+                            }
+                        ),
+                        "model_id": "meta.llama-3.3-70b-instruct",
+                        "model_version": "1.0",
+                    }
+                ),
+                "request_id": "r",
+                "headers": MockResponseDict({"content-length": "1"}),
+            }
+        )
+
+    monkeypatch.setattr(llm.client, "chat", mocked_chat)
+
+    result = llm.invoke("hi")
+    assert isinstance(result.content, list)
+    assert result.content == [{"type": "text", "text": "Hello world"}]
+    assert result.content_blocks == [{"type": "text", "text": "Hello world"}]


### PR DESCRIPTION
## Summary

Implements #260 — LangChain 1.0 standard content blocks for `ChatOCIGenAI`.

Key finding that shaped the implementation: **langchain-core ≥ 1.0 already handles the output side.** With `output_version="v1"` the base model rewrites `AIMessage.content` into the standardized list-of-blocks form, and core's parser maps our message shape (text, `additional_kwargs["reasoning_content"]`, `tool_calls`) to `text`/`reasoning`/`tool_call` blocks. What was broken was the **input side**: feeding a v1-format message back into the model raised `ValueError: Unsupported content type: reasoning` on the Generic/Meta path, and the Cohere V1 path would push list content into string-typed request fields — which made any multi-turn v1 conversation or agent loop impossible.

**Changes**
- `GenericProvider._process_message_content` skips `reasoning`/`tool_call`/`tool_use` blocks — tool calls travel via `AIMessage.tool_calls`, and reasoning is model output the API doesn't accept back as input
- New `OCIUtils.content_to_text` (joins text blocks in order, skips dedicated-field block types); the Cohere V1 path uses it at every string-content site (history, AIMessage content, dummy repeat message, final message). The Cohere V2 vision path already tolerated unknown blocks
- 6 new unit tests covering the coercion helper, both provider request builders with v1 histories, and a mocked end-to-end v1 invoke

```python
llm = ChatOCIGenAI(model_id=..., output_version="v1")
llm.invoke("hi").content
# [{'type': 'text', 'text': 'Hello!'}]
```

## Files changed

- @libs/oci/langchain_oci/chat_models/providers/generic.py — skip v1 dedicated-field blocks in content parsing
- @libs/oci/langchain_oci/chat_models/providers/cohere.py — coerce content via `content_to_text` at V1 string sites
- @libs/oci/langchain_oci/common/utils.py — `OCIUtils.content_to_text`
- @libs/oci/tests/unit_tests/chat_models/test_content_blocks_v1.py — new

## Verification

- Unit: 492 passed (6 new); ruff + mypy clean.
- Live against OCI GenAI, **7/7**: v1 invoke returns block lists; v1 streaming chunks aggregate correctly; v1 histories containing `reasoning`+`tool_call` blocks round-trip; a complete tool-calling round-trip runs entirely under v1 on both Meta and Cohere paths; **`xai.grok-3-mini` emits a standard `reasoning` block alongside `text` under v1**; Cohere accepts v1 histories.

Note: the Generic-provider hunk touches the same region as #277's `tool_use`/`tool_call` skip (this one supersedes it by adding `reasoning`); whichever merges second is a one-hunk rebase.