### PR TITLE
feat(oracledb): add exact-match OracleCache LLM cache

### DIFF
--- a/libs/oracledb/langchain_oracledb/__init__.py
+++ b/libs/oracledb/langchain_oracledb/__init__.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from langchain_oracledb.cache import OracleSemanticCache
+from langchain_oracledb.cache import OracleCache, OracleSemanticCache
 from langchain_oracledb.chat_message_histories import OracleChatMessageHistory
 from langchain_oracledb.document_loaders.oracleadb_loader import (
     OracleAutonomousDatabaseLoader,
@@ -26,6 +26,7 @@ from langchain_oracledb.vectorstores.oraclevs import OracleVS
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
+    "OracleCache",
     "OracleSemanticCache",
     "OracleChatMessageHistory",
     "OracleDocLoader",

--- a/libs/oracledb/langchain_oracledb/cache.py
+++ b/libs/oracledb/langchain_oracledb/cache.py
@@ -273,4 +273,159 @@ class OracleSemanticCache(BaseCache):
         return _quote_indentifier(self._table_name)
 
 
-__all__ = ["OracleSemanticCache"]
+DEFAULT_EXACT_TABLE_NAME = "langchain_exact_cache"
+
+
+class OracleCache(BaseCache):
+    """Exact-match LLM cache backed by a plain Oracle Database table.
+
+    Entries are keyed by ``sha256(prompt + llm_string)``, so lookups are a
+    single primary-key ``SELECT`` — no embedding call per lookup and no
+    false-positive risk. Use it as the cheap deterministic first tier in
+    front of (or instead of) :class:`OracleSemanticCache`.
+
+    Example:
+        .. code-block:: python
+
+            import oracledb
+            from langchain_core.globals import set_llm_cache
+            from langchain_oracledb import OracleCache
+
+            connection = oracledb.connect(user=..., password=..., dsn=...)
+            set_llm_cache(OracleCache(connection))
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        table_name: str = DEFAULT_EXACT_TABLE_NAME,
+    ) -> None:
+        """Initialize the Oracle exact-match cache.
+
+        Args:
+            client: ``oracledb.Connection`` or ``oracledb.ConnectionPool``.
+            table_name: Table used to store cache entries. Defaults to
+                ``langchain_exact_cache``. Created on init if missing.
+        """
+        if client is None:
+            raise ValueError("client must be provided")
+
+        _validate_indentifier(table_name)
+        self._client = client
+        self._table_name = table_name
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        ddl = f"""
+            CREATE TABLE IF NOT EXISTS {self._quoted_table_name} (
+                id VARCHAR2(64) PRIMARY KEY,
+                prompt_hash VARCHAR2(64) NOT NULL,
+                llm_string_hash VARCHAR2(64) NOT NULL,
+                generations CLOB NOT NULL,
+                created_at TIMESTAMP DEFAULT SYSTIMESTAMP
+            )
+        """
+        with _get_connection(self._client) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(ddl)
+            connection.commit()
+
+    def lookup(self, prompt: str, llm_string: str) -> Optional[RETURN_VAL_TYPE]:
+        """Look up the cached response for an exact prompt and llm string."""
+        query = f"SELECT generations FROM {self._quoted_table_name} WHERE id = :id"
+        with _get_connection(self._client) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query, {"id": _cache_entry_id(prompt, llm_string)})
+                row = cursor.fetchone()
+
+        if row is None:
+            return None
+
+        blob = row[0]
+        generations_str = blob.read() if hasattr(blob, "read") else blob
+        generations = _loads_generations(generations_str)
+        if generations is not None:
+            _reset_generation_ids(generations)
+        return generations
+
+    def update(self, prompt: str, llm_string: str, return_val: RETURN_VAL_TYPE) -> None:
+        """Insert or update a cache entry (idempotent MERGE on the hashed id).
+
+        Generations whose message carries ``tool_calls`` are intentionally
+        **not** cached, for the same reason as :class:`OracleSemanticCache`:
+        replaying procedural tool-call responses collapses agent state.
+        """
+        if _has_tool_calls(return_val):
+            return
+
+        merge = f"""
+            MERGE INTO {self._quoted_table_name} t
+            USING (SELECT :id AS id FROM dual) s
+            ON (t.id = s.id)
+            WHEN MATCHED THEN UPDATE SET
+                t.generations = :generations,
+                t.created_at = SYSTIMESTAMP
+            WHEN NOT MATCHED THEN INSERT
+                (id, prompt_hash, llm_string_hash, generations)
+                VALUES (:id, :prompt_hash, :llm_string_hash, :generations)
+        """
+        bind_vars = {
+            "id": _cache_entry_id(prompt, llm_string),
+            "prompt_hash": _hash_value(prompt),
+            "llm_string_hash": _hash_value(llm_string),
+            "generations": _dumps_generations(return_val),
+        }
+        with _get_connection(self._client) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(merge, bind_vars)
+            connection.commit()
+
+    def clear(self, **kwargs: Any) -> None:
+        """Clear cache entries.
+
+        Supported filters:
+            - ``prompt``: delete only entries written for the exact prompt
+            - ``llm_string``: delete only entries written for the exact llm string
+        """
+        prompt = kwargs.pop("prompt", None)
+        llm_string = kwargs.pop("llm_string", None)
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise ValueError(f"Unsupported clear filters: {unsupported}")
+
+        query = f"DELETE FROM {self._quoted_table_name}"
+        bind_vars: dict[str, Any] = {}
+        conditions = []
+
+        if prompt is not None:
+            conditions.append("prompt_hash = :prompt_hash")
+            bind_vars["prompt_hash"] = _hash_value(prompt)
+
+        if llm_string is not None:
+            conditions.append("llm_string_hash = :llm_hash")
+            bind_vars["llm_hash"] = _hash_value(llm_string)
+
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+
+        with _get_connection(self._client) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query, bind_vars)
+            connection.commit()
+
+    @staticmethod
+    def drop_table(client: Any, table_name: str = DEFAULT_EXACT_TABLE_NAME) -> None:
+        """Drop the exact cache table.
+
+        Args:
+            client: ``oracledb.Connection`` or ``oracledb.ConnectionPool``.
+            table_name: Table to drop. Defaults to ``langchain_exact_cache``.
+        """
+        drop_table_purge(client, table_name)
+
+    @property
+    def _quoted_table_name(self) -> str:
+        return _quote_indentifier(self._table_name)
+
+
+__all__ = ["OracleCache", "OracleSemanticCache"]

--- a/libs/oracledb/tests/integration_tests/test_exact_cache.py
+++ b/libs/oracledb/tests/integration_tests/test_exact_cache.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Integration tests for the exact-match OracleCache (issue #267)."""
+
+import os
+import uuid
+from collections.abc import Generator
+
+import oracledb
+import pytest
+from langchain_core.caches import BaseCache
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, Generation
+from langchain_tests.integration_tests import SyncCacheTestSuite
+
+from langchain_oracledb.cache import OracleCache
+
+username = os.environ.get("VECDB_USER")
+password = os.environ.get("VECDB_PASS")
+dsn = os.environ.get("VECDB_HOST")
+
+try:
+    oracledb.connect(user=username, password=password, dsn=dsn)
+except Exception as e:
+    pytest.skip(
+        allow_module_level=True,
+        reason=f"Database connection failed: {e}, skipping tests.",
+    )
+
+
+@pytest.fixture(scope="function")
+def connection() -> Generator[oracledb.Connection, None, None]:
+    conn = oracledb.connect(user=username, password=password, dsn=dsn)
+    try:
+        yield conn
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+@pytest.fixture(scope="function")
+def cache_table_name() -> Generator[str, None, None]:
+    yield f"EXACT_CACHE_{uuid.uuid4().hex[:8].upper()}"
+
+
+@pytest.fixture(scope="function")
+def exact_cache(
+    connection: oracledb.Connection, cache_table_name: str
+) -> Generator[OracleCache, None, None]:
+    cache = OracleCache(client=connection, table_name=cache_table_name)
+    try:
+        yield cache
+    finally:
+        OracleCache.drop_table(connection, cache_table_name)
+
+
+class TestOracleCacheStandard(SyncCacheTestSuite):
+    @pytest.fixture
+    def cache(
+        self,
+        connection: oracledb.Connection,
+        cache_table_name: str,
+    ) -> Generator[BaseCache, None, None]:
+        cache = OracleCache(client=connection, table_name=cache_table_name)
+        try:
+            yield cache
+        finally:
+            OracleCache.drop_table(connection, cache_table_name)
+
+
+def test_exact_cache_is_exact(exact_cache: OracleCache) -> None:
+    """Near-identical prompts must NOT hit (unlike the semantic cache)."""
+    exact_cache.update("what is 2+2?", "llm-a", [Generation(text="4")])
+
+    hit = exact_cache.lookup("what is 2+2?", "llm-a")
+    assert hit is not None and hit[0].text == "4"
+    assert exact_cache.lookup("what is 2 + 2?", "llm-a") is None
+    assert exact_cache.lookup("what is 2+2?", "llm-b") is None
+
+
+def test_exact_cache_update_is_idempotent(exact_cache: OracleCache) -> None:
+    exact_cache.update("p", "l", [Generation(text="v1")])
+    exact_cache.update("p", "l", [Generation(text="v2")])
+
+    hit = exact_cache.lookup("p", "l")
+    assert hit is not None and hit[0].text == "v2"
+
+
+def test_exact_cache_clear_filters(exact_cache: OracleCache) -> None:
+    exact_cache.update("p1", "l1", [Generation(text="a")])
+    exact_cache.update("p1", "l2", [Generation(text="b")])
+    exact_cache.update("p2", "l1", [Generation(text="c")])
+
+    exact_cache.clear(llm_string="l1")
+    assert exact_cache.lookup("p1", "l1") is None
+    assert exact_cache.lookup("p2", "l1") is None
+    assert exact_cache.lookup("p1", "l2") is not None
+
+    exact_cache.clear(prompt="p1")
+    assert exact_cache.lookup("p1", "l2") is None
+
+
+def test_exact_cache_clear_rejects_unsupported_filters(
+    exact_cache: OracleCache,
+) -> None:
+    with pytest.raises(ValueError, match="Unsupported clear filters"):
+        exact_cache.clear(bogus=True)
+
+
+def test_exact_cache_skips_tool_call_generations(exact_cache: OracleCache) -> None:
+    gen = ChatGeneration(
+        message=AIMessage(
+            content="",
+            tool_calls=[{"name": "t", "args": {}, "id": "x", "type": "tool_call"}],
+        )
+    )
+    exact_cache.update("p", "l", [gen])
+    assert exact_cache.lookup("p", "l") is None
+
+
+def test_exact_cache_resets_cached_message_ids(exact_cache: OracleCache) -> None:
+    gen = ChatGeneration(message=AIMessage(content="hi", id="lc_run--original"))
+    exact_cache.update("p", "l", [gen])
+
+    hit = exact_cache.lookup("p", "l")
+    assert hit is not None
+    assert hit[0].message.id is None  # type: ignore[union-attr]

--- a/libs/oracledb/tests/unit_tests/test_exact_cache.py
+++ b/libs/oracledb/tests/unit_tests/test_exact_cache.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for the exact-match OracleCache (mocked connection)."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import oracledb
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, Generation
+
+from langchain_oracledb.cache import (
+    OracleCache,
+    _cache_entry_id,
+    _dumps_generations,
+)
+
+
+def _mock_connection() -> MagicMock:
+    # spec makes isinstance(conn, oracledb.Connection) pass in _get_connection
+    conn = MagicMock(spec=oracledb.Connection)
+    cursor = MagicMock()
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__ = MagicMock(return_value=cursor)
+    cursor_cm.__exit__ = MagicMock(return_value=False)
+    conn.cursor = MagicMock(return_value=cursor_cm)
+    conn._mock_cursor = cursor
+    return conn
+
+
+@pytest.fixture
+def conn() -> MagicMock:
+    return _mock_connection()
+
+
+def test_init_creates_table(conn: MagicMock) -> None:
+    OracleCache(client=conn, table_name="MY_CACHE")
+
+    ddl = conn._mock_cursor.execute.call_args.args[0]
+    assert "CREATE TABLE IF NOT EXISTS" in ddl
+    assert '"MY_CACHE"' in ddl
+    conn.commit.assert_called()
+
+
+def test_init_rejects_missing_client() -> None:
+    with pytest.raises(ValueError, match="client must be provided"):
+        OracleCache(client=None)
+
+
+def test_lookup_miss_returns_none(conn: MagicMock) -> None:
+    cache = OracleCache(client=conn)
+    conn._mock_cursor.fetchone.return_value = None
+
+    assert cache.lookup("p", "l") is None
+    sql, binds = conn._mock_cursor.execute.call_args.args
+    assert "WHERE id = :id" in sql
+    assert binds == {"id": _cache_entry_id("p", "l")}
+
+
+def test_lookup_hit_deserializes_and_resets_ids(conn: MagicMock) -> None:
+    cache = OracleCache(client=conn)
+    gen = ChatGeneration(message=AIMessage(content="hi", id="lc_run--x"))
+    conn._mock_cursor.fetchone.return_value = (_dumps_generations([gen]),)
+
+    hit = cache.lookup("p", "l")
+    assert hit is not None
+    assert hit[0].message.id is None  # type: ignore[union-attr]
+    assert hit[0].message.content == "hi"  # type: ignore[union-attr]
+
+
+def test_lookup_reads_lob(conn: MagicMock) -> None:
+    cache = OracleCache(client=conn)
+    lob = MagicMock()
+    lob.read.return_value = _dumps_generations([Generation(text="v")])
+    conn._mock_cursor.fetchone.return_value = (lob,)
+
+    hit = cache.lookup("p", "l")
+    assert hit is not None and hit[0].text == "v"
+
+
+def test_update_merges_with_hashed_binds(conn: MagicMock) -> None:
+    cache = OracleCache(client=conn)
+    cache.update("p", "l", [Generation(text="v")])
+
+    sql, binds = conn._mock_cursor.execute.call_args.args
+    assert "MERGE INTO" in sql
+    assert binds["id"] == _cache_entry_id("p", "l")
+    assert "generations" in binds
+
+
+def test_update_skips_tool_calls(conn: MagicMock) -> None:
+    cache = OracleCache(client=conn)
+    calls_before = conn._mock_cursor.execute.call_count
+    gen = ChatGeneration(
+        message=AIMessage(
+            content="",
+            tool_calls=[{"name": "t", "args": {}, "id": "x", "type": "tool_call"}],
+        )
+    )
+    cache.update("p", "l", [gen])
+    assert conn._mock_cursor.execute.call_count == calls_before
+
+
+def test_clear_filters(conn: MagicMock) -> None:
+    cache = OracleCache(client=conn)
+    cache.clear(llm_string="l")
+
+    sql, binds = conn._mock_cursor.execute.call_args.args
+    assert "DELETE FROM" in sql and "llm_string_hash = :llm_hash" in sql
+
+    cache.clear()
+    sql2 = conn._mock_cursor.execute.call_args.args[0]
+    assert "WHERE" not in sql2
+
+
+def test_clear_rejects_unknown_filters(conn: MagicMock) -> None:
+    cache = OracleCache(client=conn)
+    with pytest.raises(ValueError, match="Unsupported clear filters"):
+        cache.clear(nope=1)
+
+
+def test_table_name_validated() -> None:
+    conn: Any = _mock_connection()
+    with pytest.raises(ValueError, match="not valid"):
+        OracleCache(client=conn, table_name='bad"name')


### PR DESCRIPTION
## Summary

Implements #267: an exact-match `BaseCache` complementing `OracleSemanticCache`, matching the two-tier pattern of peer packages (`MongoDBCache`+`MongoDBAtlasSemanticCache`, `RedisCache`+`RedisSemanticCache`).

```python
import oracledb
from langchain_core.globals import set_llm_cache
from langchain_oracledb import OracleCache

set_llm_cache(OracleCache(oracledb.connect(...)))
```

- Entries keyed by `sha256(prompt + llm_string)` → lookup is one primary-key `SELECT`; no embedding call, no false positives
- `MERGE` upserts (idempotent), `CREATE TABLE IF NOT EXISTS` on init, `clear(prompt=..., llm_string=...)` filters via dedicated hash columns
- Inherits the semantic cache's hard-won semantics: cached message ids reset on load (prevents LangGraph `add_messages` dedupe stalls) and tool-call generations excluded from caching
- Bind variables for all values; identifiers validated + quoted

## Files changed

- @libs/oracledb/langchain_oracledb/cache.py — new `OracleCache` class (shares module helpers with `OracleSemanticCache`)
- @libs/oracledb/langchain_oracledb/__init__.py — export
- @libs/oracledb/tests/unit_tests/test_exact_cache.py — new, 10 tests (mocked connection: DDL, binds, LOB reads, tool-call skip, clear filters, identifier validation)
- @libs/oracledb/tests/integration_tests/test_exact_cache.py — new, 14 tests including the official `langchain-tests` **SyncCacheTestSuite** plus exactness/idempotency/filter/id-reset checks

## Verification

- Unit: 10/10 passed; ruff clean.
- Live against **Oracle Database 23ai Free**: all 14 integration tests pass, including the conformance suite and a check that near-identical prompts do **not** hit (the defining difference from the semantic cache).