### PR TITLE
feat(oracledb): OracleByteStore and OracleDocStore (langchain-core BaseStore)

### DIFF
--- a/libs/oracledb/langchain_oracledb/__init__.py
+++ b/libs/oracledb/langchain_oracledb/__init__.py
@@ -20,13 +20,16 @@ from langchain_oracledb.retrievers.hybrid_search import (
 from langchain_oracledb.retrievers.text_search import (
     OracleTextSearchRetriever,
 )
+from langchain_oracledb.storage import OracleByteStore, OracleDocStore
 from langchain_oracledb.utilities.oracleai import OracleSummary
 from langchain_oracledb.vectorstores.oraclevs import OracleVS
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
+    "OracleByteStore",
     "OracleCache",
+    "OracleDocStore",
     "OracleSemanticCache",
     "OracleChatMessageHistory",
     "OracleDocLoader",

--- a/libs/oracledb/langchain_oracledb/storage.py
+++ b/libs/oracledb/langchain_oracledb/storage.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Key-value stores backed by Oracle Database.
+
+Implements ``langchain_core.stores.BaseStore`` so Oracle can back the
+patterns built on top of it:
+
+- :class:`OracleByteStore` (``BaseStore[str, bytes]``) — e.g. for
+  ``CacheBackedEmbeddings`` so re-ingestion doesn't re-embed unchanged text.
+- :class:`OracleDocStore` (``BaseStore[str, Document]``) — e.g. as the
+  parent-document store for ``ParentDocumentRetriever`` next to
+  :class:`~langchain_oracledb.vectorstores.OracleVS`.
+
+Note: this is the *langchain-core* key-value store abstraction. The
+LangGraph long-term-memory ``BaseStore`` is a different interface, provided
+by the ``langgraph-oracledb`` package.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import (
+    Any,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+)
+
+from langchain_core.documents import Document
+from langchain_core.stores import BaseStore
+
+from langchain_oracledb.vectorstores.utils import (
+    _get_connection,
+    _quote_indentifier,
+    _validate_indentifier,
+    drop_table_purge,
+)
+
+V = TypeVar("V")
+
+DEFAULT_BYTE_STORE_TABLE_NAME = "langchain_byte_store"
+DEFAULT_DOC_STORE_TABLE_NAME = "langchain_doc_store"
+
+# Oracle limits IN-list literals to 1000 elements; stay under it.
+_BATCH_SIZE = 500
+
+
+class _OracleKVStore(BaseStore[str, V], Generic[V]):
+    """Shared Oracle-table implementation behind the typed store classes.
+
+    Subclasses define the value column type and the value (de)serialization.
+    """
+
+    _VALUE_COLUMN_TYPE = "BLOB"
+
+    def __init__(self, client: Any, table_name: str) -> None:
+        if client is None:
+            raise ValueError("client must be provided")
+        _validate_indentifier(table_name)
+        self._client = client
+        self._table_name = table_name
+        self._ensure_table()
+
+    @property
+    def _quoted_table_name(self) -> str:
+        return _quote_indentifier(self._table_name)
+
+    def _ensure_table(self) -> None:
+        ddl = f"""
+            CREATE TABLE IF NOT EXISTS {self._quoted_table_name} (
+                k VARCHAR2(1000) PRIMARY KEY,
+                v {self._VALUE_COLUMN_TYPE} NOT NULL,
+                updated_at TIMESTAMP DEFAULT SYSTIMESTAMP
+            )
+        """
+        with _get_connection(self._client) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(ddl)
+            connection.commit()
+
+    # -- serialization hooks -------------------------------------------------
+
+    def _serialize(self, value: V) -> Any:
+        raise NotImplementedError
+
+    def _deserialize(self, raw: Any) -> V:
+        raise NotImplementedError
+
+    @staticmethod
+    def _read_raw(raw: Any) -> Any:
+        return raw.read() if hasattr(raw, "read") else raw
+
+    # -- BaseStore interface -------------------------------------------------
+
+    def mget(self, keys: Sequence[str]) -> List[Optional[V]]:
+        """Get the values associated with the given keys (order-preserving)."""
+        if not keys:
+            return []
+
+        found: dict[str, V] = {}
+        with _get_connection(self._client) as connection:
+            with connection.cursor() as cursor:
+                for start in range(0, len(keys), _BATCH_SIZE):
+                    batch = list(keys[start : start + _BATCH_SIZE])
+                    placeholders = ", ".join(f":k{i}" for i in range(len(batch)))
+                    cursor.execute(
+                        f"SELECT k, v FROM {self._quoted_table_name} "
+                        f"WHERE k IN ({placeholders})",
+                        {f"k{i}": key for i, key in enumerate(batch)},
+                    )
+                    for row_key, row_value in cursor.fetchall():
+                        found[row_key] = self._deserialize(self._read_raw(row_value))
+
+        return [found.get(key) for key in keys]
+
+    def mset(self, key_value_pairs: Sequence[Tuple[str, V]]) -> None:
+        """Set the values for the given keys (idempotent MERGE upsert)."""
+        if not key_value_pairs:
+            return
+
+        merge = f"""
+            MERGE INTO {self._quoted_table_name} t
+            USING (SELECT :k AS k FROM dual) s
+            ON (t.k = s.k)
+            WHEN MATCHED THEN UPDATE SET
+                t.v = :v,
+                t.updated_at = SYSTIMESTAMP
+            WHEN NOT MATCHED THEN INSERT (k, v) VALUES (:k, :v)
+        """
+        rows = [
+            {"k": key, "v": self._serialize(value)} for key, value in key_value_pairs
+        ]
+        with _get_connection(self._client) as connection:
+            with connection.cursor() as cursor:
+                cursor.executemany(merge, rows)
+            connection.commit()
+
+    def mdelete(self, keys: Sequence[str]) -> None:
+        """Delete the given keys (missing keys are ignored)."""
+        if not keys:
+            return
+
+        with _get_connection(self._client) as connection:
+            with connection.cursor() as cursor:
+                cursor.executemany(
+                    f"DELETE FROM {self._quoted_table_name} WHERE k = :k",
+                    [{"k": key} for key in keys],
+                )
+            connection.commit()
+
+    def yield_keys(self, *, prefix: Optional[str] = None) -> Iterator[str]:
+        """Yield keys in the store, optionally filtered by prefix."""
+        query = f"SELECT k FROM {self._quoted_table_name}"
+        bind_vars: dict[str, Any] = {}
+        if prefix is not None:
+            # ESCAPE so % and _ in the caller's prefix match literally
+            escaped = (
+                prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            )
+            query += " WHERE k LIKE :prefix ESCAPE '\\'"
+            bind_vars["prefix"] = f"{escaped}%"
+
+        with _get_connection(self._client) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query, bind_vars)
+                for (key,) in cursor:
+                    yield key
+
+    @staticmethod
+    def drop_table(client: Any, table_name: str) -> None:
+        """Drop the store table."""
+        drop_table_purge(client, table_name)
+
+
+class OracleByteStore(_OracleKVStore[bytes]):
+    """``BaseStore[str, bytes]`` backed by an Oracle table with a BLOB column.
+
+    Use with ``CacheBackedEmbeddings`` to persist embedding vectors:
+
+    .. code-block:: python
+
+        import oracledb
+        from langchain.embeddings import CacheBackedEmbeddings
+        from langchain_oracledb import OracleByteStore
+
+        connection = oracledb.connect(user=..., password=..., dsn=...)
+        store = OracleByteStore(connection)
+        cached_embedder = CacheBackedEmbeddings.from_bytes_store(
+            underlying_embeddings, store, namespace=underlying_embeddings.model
+        )
+    """
+
+    _VALUE_COLUMN_TYPE = "BLOB"
+
+    def __init__(
+        self,
+        client: Any,
+        table_name: str = DEFAULT_BYTE_STORE_TABLE_NAME,
+    ) -> None:
+        """Initialize the byte store.
+
+        Args:
+            client: ``oracledb.Connection`` or ``oracledb.ConnectionPool``.
+            table_name: Table used to store entries. Defaults to
+                ``langchain_byte_store``. Created on init if missing.
+        """
+        super().__init__(client, table_name)
+
+    def _serialize(self, value: bytes) -> bytes:
+        if not isinstance(value, bytes):
+            raise TypeError(f"OracleByteStore values must be bytes, got {type(value)}")
+        return value
+
+    def _deserialize(self, raw: Any) -> bytes:
+        return bytes(raw)
+
+
+class OracleDocStore(_OracleKVStore[Document]):
+    """``BaseStore[str, Document]`` backed by an Oracle table.
+
+    Use as the parent-document store for ``ParentDocumentRetriever``:
+
+    .. code-block:: python
+
+        import oracledb
+        from langchain.retrievers import ParentDocumentRetriever
+        from langchain_oracledb import OracleDocStore, OracleVS
+
+        connection = oracledb.connect(user=..., password=..., dsn=...)
+        retriever = ParentDocumentRetriever(
+            vectorstore=OracleVS(...),
+            docstore=OracleDocStore(connection),
+            child_splitter=child_splitter,
+        )
+    """
+
+    _VALUE_COLUMN_TYPE = "CLOB"
+
+    def __init__(
+        self,
+        client: Any,
+        table_name: str = DEFAULT_DOC_STORE_TABLE_NAME,
+    ) -> None:
+        """Initialize the document store.
+
+        Args:
+            client: ``oracledb.Connection`` or ``oracledb.ConnectionPool``.
+            table_name: Table used to store entries. Defaults to
+                ``langchain_doc_store``. Created on init if missing.
+        """
+        super().__init__(client, table_name)
+
+    def _serialize(self, value: Document) -> str:
+        if not isinstance(value, Document):
+            raise TypeError(
+                f"OracleDocStore values must be Documents, got {type(value)}"
+            )
+        payload = {"page_content": value.page_content, "metadata": value.metadata}
+        if value.id is not None:
+            payload["id"] = value.id
+        return json.dumps(payload)
+
+    def _deserialize(self, raw: Any) -> Document:
+        payload = json.loads(raw)
+        return Document(
+            page_content=payload["page_content"],
+            metadata=payload.get("metadata") or {},
+            id=payload.get("id"),
+        )
+
+
+__all__ = ["OracleByteStore", "OracleDocStore"]

--- a/libs/oracledb/tests/integration_tests/test_storage.py
+++ b/libs/oracledb/tests/integration_tests/test_storage.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Integration tests for OracleByteStore / OracleDocStore (issue #269)."""
+
+import os
+import uuid
+from collections.abc import Generator
+from typing import Tuple
+
+import oracledb
+import pytest
+from langchain_core.documents import Document
+from langchain_core.embeddings import DeterministicFakeEmbedding
+from langchain_core.stores import BaseStore
+from langchain_tests.integration_tests import BaseStoreSyncTests
+
+from langchain_oracledb.storage import OracleByteStore, OracleDocStore
+
+username = os.environ.get("VECDB_USER")
+password = os.environ.get("VECDB_PASS")
+dsn = os.environ.get("VECDB_HOST")
+
+try:
+    oracledb.connect(user=username, password=password, dsn=dsn)
+except Exception as e:
+    pytest.skip(
+        allow_module_level=True,
+        reason=f"Database connection failed: {e}, skipping tests.",
+    )
+
+
+@pytest.fixture(scope="function")
+def connection() -> Generator[oracledb.Connection, None, None]:
+    conn = oracledb.connect(user=username, password=password, dsn=dsn)
+    try:
+        yield conn
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+class TestOracleByteStoreStandard(BaseStoreSyncTests[bytes]):
+    @pytest.fixture
+    def kv_store(
+        self, connection: oracledb.Connection
+    ) -> Generator[BaseStore[str, bytes], None, None]:
+        table = f"BYTE_STORE_{uuid.uuid4().hex[:8].upper()}"
+        store = OracleByteStore(connection, table_name=table)
+        try:
+            yield store
+        finally:
+            OracleByteStore.drop_table(connection, table)
+
+    @pytest.fixture
+    def three_values(self) -> Tuple[bytes, bytes, bytes]:
+        return b"alpha", b"beta", b"\x00\x01\xff binary"
+
+
+class TestOracleDocStoreStandard(BaseStoreSyncTests[Document]):
+    @pytest.fixture
+    def kv_store(
+        self, connection: oracledb.Connection
+    ) -> Generator[BaseStore[str, Document], None, None]:
+        table = f"DOC_STORE_{uuid.uuid4().hex[:8].upper()}"
+        store = OracleDocStore(connection, table_name=table)
+        try:
+            yield store
+        finally:
+            OracleDocStore.drop_table(connection, table)
+
+    @pytest.fixture
+    def three_values(self) -> Tuple[Document, Document, Document]:
+        return (
+            Document(page_content="alpha", metadata={"n": 1}),
+            Document(page_content="beta", metadata={"nested": {"a": [1, 2]}}),
+            Document(page_content="gamma", id="doc-3"),
+        )
+
+
+def test_yield_keys_prefix_escapes_wildcards(
+    connection: oracledb.Connection,
+) -> None:
+    table = f"BYTE_STORE_{uuid.uuid4().hex[:8].upper()}"
+    store = OracleByteStore(connection, table_name=table)
+    try:
+        store.mset([("a%b/1", b"x"), ("axb/2", b"y"), ("a_b/3", b"z")])
+        # % and _ in the prefix must match literally, not as LIKE wildcards
+        assert list(store.yield_keys(prefix="a%b")) == ["a%b/1"]
+        assert list(store.yield_keys(prefix="a_b")) == ["a_b/3"]
+    finally:
+        OracleByteStore.drop_table(connection, table)
+
+
+def test_cache_backed_embeddings_end_to_end(
+    connection: oracledb.Connection,
+) -> None:
+    """OracleByteStore powers CacheBackedEmbeddings: second run hits the store."""
+    try:
+        # langchain 1.x moved it to langchain-classic
+        from langchain_classic.embeddings import CacheBackedEmbeddings
+    except ImportError:
+        try:
+            from langchain.embeddings import (  # type: ignore[attr-defined,no-redef]
+                CacheBackedEmbeddings,
+            )
+        except ImportError:
+            pytest.skip("CacheBackedEmbeddings not available")
+    table = f"EMB_CACHE_{uuid.uuid4().hex[:8].upper()}"
+    store = OracleByteStore(connection, table_name=table)
+    underlying = DeterministicFakeEmbedding(size=8)
+    try:
+        cached = CacheBackedEmbeddings.from_bytes_store(
+            underlying, store, namespace="fake-model"
+        )
+        first = cached.embed_documents(["hello", "world"])
+        assert len(list(store.yield_keys())) == 2
+
+        second = cached.embed_documents(["hello", "world"])
+        assert first == second
+    finally:
+        OracleByteStore.drop_table(connection, table)
+
+
+def test_parent_document_retriever_end_to_end(
+    connection: oracledb.Connection,
+) -> None:
+    """OracleDocStore + OracleVS power ParentDocumentRetriever."""
+    try:
+        # langchain 1.x moved it to langchain-classic
+        from langchain_classic.retrievers import ParentDocumentRetriever
+    except ImportError:
+        try:
+            from langchain.retrievers import (  # type: ignore[attr-defined,no-redef]
+                ParentDocumentRetriever,
+            )
+        except ImportError:
+            pytest.skip("ParentDocumentRetriever not available")
+    splitters = pytest.importorskip("langchain_text_splitters")
+
+    from langchain_oracledb.vectorstores import OracleVS
+    from langchain_oracledb.vectorstores.oraclevs import drop_table_purge
+    from langchain_oracledb.vectorstores.utils import DistanceStrategy
+
+    vs_table = f"PDR_VS_{uuid.uuid4().hex[:8].upper()}"
+    doc_table = f"PDR_DOCS_{uuid.uuid4().hex[:8].upper()}"
+    vectorstore = OracleVS(
+        client=connection,
+        embedding_function=DeterministicFakeEmbedding(size=16),
+        table_name=vs_table,
+        distance_strategy=DistanceStrategy.COSINE,
+    )
+    docstore = OracleDocStore(connection, table_name=doc_table)
+    try:
+        retriever = ParentDocumentRetriever(
+            vectorstore=vectorstore,
+            docstore=docstore,
+            child_splitter=splitters.RecursiveCharacterTextSplitter(
+                chunk_size=64, chunk_overlap=0
+            ),
+        )
+        parent = Document(
+            page_content=(
+                "Oracle Database 23ai introduces AI Vector Search. "
+                "It supports HNSW and IVF vector indexes. "
+                "Bananas are rich in potassium and unrelated to databases."
+            ),
+            metadata={"source": "doc-1"},
+        )
+        retriever.add_documents([parent])
+
+        results = retriever.invoke("vector indexes in Oracle")
+        assert len(results) == 1
+        # The retriever returns the FULL parent, not the matched child chunk.
+        assert results[0].page_content == parent.page_content
+    finally:
+        drop_table_purge(connection, vs_table)
+        OracleDocStore.drop_table(connection, doc_table)

--- a/libs/oracledb/tests/unit_tests/test_storage.py
+++ b/libs/oracledb/tests/unit_tests/test_storage.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+"""Unit tests for OracleByteStore / OracleDocStore (mocked connection)."""
+
+import json
+from unittest.mock import MagicMock
+
+import oracledb
+import pytest
+from langchain_core.documents import Document
+
+from langchain_oracledb.storage import OracleByteStore, OracleDocStore
+
+
+def _mock_connection() -> MagicMock:
+    # spec makes isinstance(conn, oracledb.Connection) pass in _get_connection
+    conn = MagicMock(spec=oracledb.Connection)
+    cursor = MagicMock()
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__ = MagicMock(return_value=cursor)
+    cursor_cm.__exit__ = MagicMock(return_value=False)
+    conn.cursor = MagicMock(return_value=cursor_cm)
+    conn._mock_cursor = cursor
+    return conn
+
+
+@pytest.fixture
+def conn() -> MagicMock:
+    return _mock_connection()
+
+
+def test_init_creates_table_blob(conn: MagicMock) -> None:
+    OracleByteStore(conn, table_name="BYTES")
+
+    ddl = conn._mock_cursor.execute.call_args.args[0]
+    assert "CREATE TABLE IF NOT EXISTS" in ddl and '"BYTES"' in ddl
+    assert "BLOB" in ddl
+
+
+def test_init_creates_table_clob(conn: MagicMock) -> None:
+    OracleDocStore(conn, table_name="DOCS")
+
+    ddl = conn._mock_cursor.execute.call_args.args[0]
+    assert "CLOB" in ddl
+
+
+def test_init_rejects_missing_client() -> None:
+    with pytest.raises(ValueError, match="client must be provided"):
+        OracleByteStore(None)
+
+
+def test_mget_preserves_order_and_missing(conn: MagicMock) -> None:
+    store = OracleByteStore(conn)
+    conn._mock_cursor.fetchall.return_value = [("b", b"2"), ("a", b"1")]
+
+    assert store.mget(["a", "missing", "b"]) == [b"1", None, b"2"]
+    sql, binds = conn._mock_cursor.execute.call_args.args
+    assert "WHERE k IN (:k0, :k1, :k2)" in sql
+    assert binds == {"k0": "a", "k1": "missing", "k2": "b"}
+
+
+def test_mget_empty(conn: MagicMock) -> None:
+    store = OracleByteStore(conn)
+    calls_before = conn._mock_cursor.execute.call_count
+    assert store.mget([]) == []
+    assert conn._mock_cursor.execute.call_count == calls_before
+
+
+def test_mset_merges(conn: MagicMock) -> None:
+    store = OracleByteStore(conn)
+    store.mset([("a", b"1"), ("b", b"2")])
+
+    sql, rows = conn._mock_cursor.executemany.call_args.args
+    assert "MERGE INTO" in sql
+    assert rows == [{"k": "a", "v": b"1"}, {"k": "b", "v": b"2"}]
+    conn.commit.assert_called()
+
+
+def test_bytestore_rejects_non_bytes(conn: MagicMock) -> None:
+    store = OracleByteStore(conn)
+    with pytest.raises(TypeError, match="must be bytes"):
+        store.mset([("a", "not-bytes")])  # type: ignore[list-item]
+
+
+def test_docstore_round_trips_document(conn: MagicMock) -> None:
+    store = OracleDocStore(conn)
+    doc = Document(page_content="hello", metadata={"n": {"a": 1}}, id="d1")
+
+    serialized = store._serialize(doc)
+    restored = store._deserialize(serialized)
+    assert restored == doc
+    assert json.loads(serialized)["id"] == "d1"
+
+
+def test_docstore_rejects_non_document(conn: MagicMock) -> None:
+    store = OracleDocStore(conn)
+    with pytest.raises(TypeError, match="must be Documents"):
+        store.mset([("a", "text")])  # type: ignore[list-item]
+
+
+def test_mdelete(conn: MagicMock) -> None:
+    store = OracleByteStore(conn)
+    store.mdelete(["a", "b"])
+
+    sql, rows = conn._mock_cursor.executemany.call_args.args
+    assert "DELETE FROM" in sql
+    assert rows == [{"k": "a"}, {"k": "b"}]
+
+
+def test_yield_keys_prefix_uses_escaped_like(conn: MagicMock) -> None:
+    store = OracleByteStore(conn)
+    conn._mock_cursor.__iter__ = MagicMock(return_value=iter([("a%b/1",)]))
+
+    keys = list(store.yield_keys(prefix="a%b"))
+    assert keys == ["a%b/1"]
+    sql, binds = conn._mock_cursor.execute.call_args.args
+    assert "LIKE :prefix ESCAPE" in sql
+    assert binds == {"prefix": "a\\%b%"}
+
+
+def test_yield_keys_without_prefix(conn: MagicMock) -> None:
+    store = OracleByteStore(conn)
+    conn._mock_cursor.__iter__ = MagicMock(return_value=iter([("k1",), ("k2",)]))
+
+    assert list(store.yield_keys()) == ["k1", "k2"]
+    sql = conn._mock_cursor.execute.call_args.args[0]
+    assert "WHERE" not in sql
+
+
+def test_table_name_validated() -> None:
+    with pytest.raises(ValueError, match="not valid"):
+        OracleByteStore(_mock_connection(), table_name='bad"name')


### PR DESCRIPTION
## Summary

Implements #269 — the enabler gap from the parity review: without a `langchain_core.stores.BaseStore` backend, Oracle users had to pair `OracleVS` with in-memory or third-party stores for two standard patterns. Peer precedent: `MongoDBDocStore` in langchain-mongodb.

- **`OracleByteStore`** (`BaseStore[str, bytes]`, BLOB) → powers `CacheBackedEmbeddings`
- **`OracleDocStore`** (`BaseStore[str, Document]`, CLOB) → powers `ParentDocumentRetriever` next to `OracleVS`

```python
store = OracleByteStore(connection)
cached_embedder = CacheBackedEmbeddings.from_bytes_store(embeddings, store, namespace=...)

retriever = ParentDocumentRetriever(
    vectorstore=OracleVS(...), docstore=OracleDocStore(connection), child_splitter=...
)
```

**Implementation notes**
- `MERGE` upserts via `executemany`; order-preserving `mget` batched under Oracle's 1000-element IN-list limit; `yield_keys(prefix=...)` uses `LIKE ... ESCAPE` so `%`/`_` in prefixes match literally
- Bind variables for all values; identifiers validated + quoted; `CREATE TABLE IF NOT EXISTS` on init (23ai)
- Deliberately named to avoid confusion with `langgraph-oracledb`'s `OracleStore`, which implements LangGraph's distinct memory-store interface (module docstring spells out the difference)

## Files changed

- @libs/oracledb/langchain_oracledb/storage.py — new
- @libs/oracledb/langchain_oracledb/__init__.py — exports
- @libs/oracledb/tests/unit_tests/test_storage.py — new, 13 tests (DDL, order-preserving mget, MERGE rows, type guards, LIKE-escape, identifier validation)
- @libs/oracledb/tests/integration_tests/test_storage.py — new, 27 tests

## Verification

- Unit: 13/13; full package suite 389 passed; ruff clean.
- Live against **Oracle Database 23ai Free** — 27/27 integration tests:
  - the official `langchain-tests` **BaseStoreSyncTests** conformance suite for **both** classes,
  - wildcard-escape behavior with keys containing `%` and `_`,
  - **`CacheBackedEmbeddings` end to end** (two documents embedded once; second run served entirely from the Oracle store),
  - **`ParentDocumentRetriever` end to end** (child-chunk vector search via `OracleVS` returns the full parent document).

Closes #269
