### PR TITLE
[oracle/langchain-js]: Remove uuid dependency as it is unused

### DIFF
--- a/libs/js/langchain-oracledb/package.json
+++ b/libs/js/langchain-oracledb/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "htmlparser2": "^10.0.0",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.0"
   },
   "peerDependencies": {
     "@langchain/core": "^1.0.0",

--- a/libs/js/langchain-oracledb/package.json
+++ b/libs/js/langchain-oracledb/package.json
@@ -38,7 +38,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "htmlparser2": "^10.0.0"
+    "htmlparser2": "^10.0.0",
   },
   "peerDependencies": {
     "@langchain/core": "^1.0.0",

--- a/libs/js/langchain-oracledb/package.json
+++ b/libs/js/langchain-oracledb/package.json
@@ -38,8 +38,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "htmlparser2": "^10.0.0",
-    "uuid": "^11.0.0"
+    "htmlparser2": "^10.0.0"
   },
   "peerDependencies": {
     "@langchain/core": "^1.0.0",

--- a/libs/js/langchain-oracledb/package.json
+++ b/libs/js/langchain-oracledb/package.json
@@ -38,7 +38,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "htmlparser2": "^10.0.0",
+    "htmlparser2": "^10.0.0"
   },
   "peerDependencies": {
     "@langchain/core": "^1.0.0",


### PR DESCRIPTION
[oracle/langchain-js]: Update uuid dependency version to 11.0.0 the supported version 