### PR TITLE
chore(js): remove unused uuid dependency from langchain-oracledb

### DIFF
--- a/libs/js/langchain-oracledb/package.json
+++ b/libs/js/langchain-oracledb/package.json
@@ -38,8 +38,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "htmlparser2": "^10.0.0",
-    "uuid": "^10.0.0"
+    "htmlparser2": "^10.0.0"
   },
   "peerDependencies": {
     "@langchain/core": "^1.0.0",


### PR DESCRIPTION
`uuid` is declared as a runtime dependency of `@oracle/langchain-oracledb` but is never imported anywhere in the package source — `htmlparser2` is the only dependency actually used:

```
$ grep -rn uuid libs/js/langchain-oracledb/src/
(no results)
```

This removes the dependency instead of bumping it, as suggested in the #287 discussion. If #287's motivation was a security-scanner flag on uuid@10, removal resolves that too.

**Verification** (Node 18+, pnpm 9):
- `pnpm install` — lockfile resolves cleanly without uuid
- `pnpm build` — full ESM/CJS build + tree-shaking checks pass
- `pnpm test` — all unit tests pass; the 9 failing `*.int.test.ts` cases fail identically on `main` (NJS-125: no database configured) and are unrelated

Supersedes #287 if maintainers agree removal is preferable to the version bump.