### PR TITLE
docs(oci): exhaustive deepagents documentation set

### DIFF
--- a/libs/oci/docs/deepagents/capabilities.md
+++ b/libs/oci/docs/deepagents/capabilities.md
@@ -69,12 +69,16 @@ agent = create_deepagents_agent(
 result = agent.invoke(inputs, cfg)           # pauses before write_file
 # inspect result["__interrupt__"], then approve:
 from langgraph.types import Command
-result = agent.invoke(Command(resume=[{"type": "accept"}]), cfg)
+result = agent.invoke(
+    Command(resume={"decisions": [{"type": "approve"}]}), cfg
+)
 ```
 
 Values can be `True` or an `InterruptOnConfig` (allowed decision types,
-description). Applies to the main agent; declarative subagents inherit unless
-they override.
+description). The resume payload is a dict with one decision per pending
+interrupt; decision types are `"approve"`, `"edit"`, and `"reject"`
+(shape verified live against langchain 1.3 / deepagents 0.7.5). Applies to
+the main agent; declarative subagents inherit unless they override.
 
 ## Filesystem permissions
 

--- a/libs/oci/docs/deepagents/capabilities.md
+++ b/libs/oci/docs/deepagents/capabilities.md
@@ -1,0 +1,116 @@
+# Deep Agents on OCI — Capabilities
+
+Part of the [Deep Agents documentation](../../langchain_oci/agents/deepagents/README.md).
+See also: [Core guide](guide.md) · [Datastores & retrieval](datastores.md) · [Persistence](persistence.md) · [Operations](operations.md)
+
+Everything here is forwarded verbatim to `deepagents.create_deep_agent`;
+semantics below were verified against `deepagents` 0.7.5 (installed range:
+`>=0.6.1`). Setting any of these forces the deep path (see
+[Core guide](guide.md#the-two-build-paths)).
+
+## Built-in tools
+
+On the deep path the agent always gets: `ls`, `read_file`, `write_file`,
+`edit_file`, `glob`, `grep` (virtual filesystem, storage per `backend`),
+`task` (subagent delegation, present when any sync subagent — including the
+auto-added general-purpose one — exists), and `execute` (returns an error
+unless the backend implements the sandbox protocol; no shell execution happens
+with the default backend). Your `tools=` and the datastore tools are additive
+— built-ins are never removed by adding tools.
+
+## Subagents
+
+```python
+research_subagent = {
+    "name": "literature-scanner",
+    "description": "Scans the research datastore and produces raw findings",
+    "system_prompt": "You are a focused literature scanner. Only search and list findings.",
+    "tools": [...],          # optional; may also override model, middleware, skills…
+}
+agent = create_deepagents_agent(..., subagents=[research_subagent])
+```
+
+Three spec forms: declarative `SubAgent` dicts (compiled for you, invoked via
+`task`), `CompiledSubAgent` (pre-built runnable), and `AsyncSubAgent`
+(remote/background, identified by `graph_id`). A default `general-purpose`
+subagent is added automatically when you don't provide one. Declarative
+subagents inherit the parent's `interrupt_on` and `permissions` unless they
+define their own.
+
+## Skills
+
+```python
+agent = create_deepagents_agent(..., skills=["/skills/project/"])
+```
+
+Skill paths are POSIX-style relative to the backend root. With the default
+state backend, supply skill files via `invoke(files={...})`; with a
+filesystem/store backend they load from that backend. Same-name skills: last
+source wins.
+
+## Memory
+
+```python
+agent = create_deepagents_agent(..., memory=["/memory/AGENTS.md"])
+```
+
+`AGENTS.md`-style files loaded at startup and injected into the system prompt
+— persistent instructions, not conversation history (that's the checkpointer's
+job — see [Persistence](persistence.md)).
+
+## Human-in-the-loop (`interrupt_on`)
+
+```python
+agent = create_deepagents_agent(
+    ...,
+    checkpointer=checkpointer,   # required to pause/resume
+    interrupt_on={"write_file": True, "edit_file": True},
+)
+result = agent.invoke(inputs, cfg)           # pauses before write_file
+# inspect result["__interrupt__"], then approve:
+from langgraph.types import Command
+result = agent.invoke(Command(resume=[{"type": "accept"}]), cfg)
+```
+
+Values can be `True` or an `InterruptOnConfig` (allowed decision types,
+description). Applies to the main agent; declarative subagents inherit unless
+they override.
+
+## Filesystem permissions
+
+```python
+agent = create_deepagents_agent(
+    ...,
+    permissions=[
+        {"path": "/reports/**", "mode": "allow"},
+        {"path": "/**", "mode": "deny"},
+    ],
+)
+```
+
+Rules are evaluated in order, **first match wins**, unmatched calls are
+allowed. `mode="interrupt"` pauses for approval (auto-installs the HITL
+middleware and merges with `interrupt_on`; user-supplied entries win per tool
+name). Enforced at the filesystem-tool level, inherited by subagents unless
+they define their own. See the upstream `deepagents` docs for the
+`FilesystemPermission` type in your installed version.
+
+## Structured output, context, middleware
+
+- `response_format=` — a Pydantic model / TypedDict / schema dict; the final
+  state carries the structured response alongside messages.
+- `context_schema=` — typed, immutable run-scoped context (passed at
+  `invoke(..., context=...)`).
+- `middleware=` — your `AgentMiddleware` instances are inserted **after** the
+  deepagents base stack (skills → filesystem → subagents → summarization →
+  tool-call patching) and **before** the tail stack (prompt caching, memory,
+  HITL). Note the base stack includes `SummarizationMiddleware` — long
+  conversations are auto-summarized on the deep path.
+
+## Not exposed (documented limitation)
+
+Upstream `create_deep_agent` also accepts `state_schema` (custom
+`DeepAgentState` subclass). The `langchain-oci` factory does **not** expose it
+today — if you need custom state channels, prefer middleware-scoped state, or
+call `deepagents.create_deep_agent` directly with a `ChatOCIGenAI` you build
+yourself.

--- a/libs/oci/docs/deepagents/datastores.md
+++ b/libs/oci/docs/deepagents/datastores.md
@@ -182,9 +182,11 @@ Details that matter in practice:
 - **Tool descriptions are composed at build time**: static description + usage
   hint + `"Available stores: name (description), …"` — so the LLM knows what
   stores exist without a tool call, but `stats` gives it live counts.
-- **All tool errors return formatted strings**
+- **Search and retrieval failures return formatted strings**
   (`Error during hybrid search: …`) instead of raising — the agent loop keeps
-  going and can self-correct.
+  going and can self-correct. (One exception: a failure while *routing* the
+  query — e.g. the embedding call itself failing — happens before the guarded
+  section and propagates.)
 - Two more tool classes are exported for manual composition but *not* included
   by the factory: `SearchTool` (semantic-only) and `KeywordSearchTool` (exact
   terms). Swap or add them if you build the tool list yourself:

--- a/libs/oci/docs/deepagents/datastores.md
+++ b/libs/oci/docs/deepagents/datastores.md
@@ -1,0 +1,268 @@
+# Deep Agents on OCI — Datastores & Retrieval
+
+Part of the [Deep Agents documentation](../../langchain_oci/agents/deepagents/README.md).
+See also: [Core guide](guide.md) · [Persistence](persistence.md) · [Capabilities](capabilities.md) · [Operations](operations.md)
+
+## The `VectorDataStore` contract
+
+```mermaid
+classDiagram
+    class VectorDataStore {
+        <<abstract>>
+        +name: str*
+        +datastore_description: str
+        +connect(embedding_model)*
+        +vectorstore: VectorStore*
+        +keyword_retriever: BaseRetriever?
+        +search_documents(query, top_k)
+        +search_documents_with_scores(query, top_k)
+        +keyword_search_documents(query, top_k)
+        +hybrid_search_documents(query, top_k)
+        +get(document_id)*
+        +insert(title, content, source, embedding)*
+        +bulk_insert(documents, embeddings)*
+        +update(document_id, ...)*
+        +delete(document_id)*
+        +stats()*
+    }
+    class ADB {
+        dsn, user, password
+        wallet_location, wallet_password
+        table_name = VECTOR_DOCUMENTS
+        chunk_on_write = true
+        +close()
+    }
+    class OpenSearch {
+        endpoint, index_name
+        username, password
+        vector_field = embedding
+        search_fields = [title, content]
+    }
+    VectorDataStore <|-- ADB : OracleVS + Oracle Text
+    VectorDataStore <|-- OpenSearch : knn + multi_match
+```
+
+The ABC is built on standard LangChain contracts: implementations expose a
+`VectorStore` for semantic search and optionally a `BaseRetriever` for keyword
+search; all higher-level tooling works against those, never against
+backend-specific APIs. Base-class provided behavior:
+
+- `search_documents_with_scores` uses `similarity_search_with_score` when the
+  vector store has it, else scores everything `0.0`.
+- `keyword_search_documents` temporarily overrides the retriever's `k` to
+  `top_k` and restores it after.
+- `hybrid_search_documents` implements RRF (below) and **falls back to
+  semantic-only** when the store has no keyword retriever.
+
+## The ADB adapter (Oracle Autonomous Database / 26ai)
+
+Built on `langchain_oracledb`: `OracleVS` (cosine distance,
+`mutate_on_duplicate=True`), `OracleTextSearchRetriever` for keyword search,
+and optionally `OracleTextSplitter` for server-side chunking.
+
+**Constructor:**
+
+| Field | Default | Notes |
+|---|---|---|
+| `dsn`, `user`, `password` | required | TNS alias or full descriptor |
+| `wallet_location` | `None` | Expanded (`~` ok); used as both `config_dir` and `wallet_location` |
+| `wallet_password` | `None` | **Defaults to `password`** when unset |
+| `table_name` | `"VECTOR_DOCUMENTS"` | Must follow the OracleVS schema (`id`, `embedding`, `text`, `metadata`) |
+| `datastore_description` | `""` | Routing text (see below) |
+| `chunk_on_write` | `True` | Server-side chunking via `OracleTextSplitter` on ingest |
+| `chunking_params` | `None` | Defaults to `{"split": "sentence", "max": 20, "normalize": "all"}` |
+
+**Behavior contracts:**
+
+- **Chunked documents round-trip.** With `chunk_on_write`, rows carry chunk IDs
+  as primary keys; the *logical* document id lives in `metadata.id`.
+  `get(document_id)` collects all rows where `JSON_VALUE(metadata,'$.id')`
+  matches, sorts by `metadata.chunk_index`, and joins chunk texts with newlines
+  — you get the whole document back.
+- **A function-based index is auto-created** on `JSON_VALUE(metadata, '$.id')`
+  at connect time (name `IDX_{table}_MID`, truncated to Oracle's 30-char cap).
+  `ORA-00955` (already exists) is silently accepted; any other DDL failure logs
+  a warning and lookups fall back to full scans — the store still works.
+- **`update()` is delete-then-reinsert with snapshot recovery.** It snapshots
+  the current document, deletes (which commits), re-ingests; if re-ingestion
+  raises, it restores the snapshot and re-raises. There is a small window where
+  a crash between delete and re-insert loses the row — treat updates as
+  non-transactional.
+- **`search()` scores are similarity** (`1 − cosine_distance`), content
+  previews capped at 1,000 chars per hit.
+- **`stats()`** returns row count plus top-10 sources grouped from
+  `metadata.$.source` (falls back to a `SOURCE` column, then `{}`).
+- **`close()` is idempotent** and the store is a context manager
+  (`with ADB(...) as store:`). After `close()`, reconnect via `connect()`
+  before reuse.
+- Requires `oracledb` and `langchain-oracledb` — clear `ImportError`s name the
+  missing package.
+
+## The OpenSearch adapter
+
+A minimal, self-contained adapter (no `langchain-community` dependency): an
+internal `VectorStore` doing `knn` queries and an internal `BaseRetriever`
+doing `multi_match` keyword queries.
+
+**Constructor:**
+
+| Field | Default | Notes |
+|---|---|---|
+| `endpoint`, `index_name` | required | |
+| `username`, `password` | `None` | Basic auth when both set |
+| `use_ssl` / `verify_certs` | `True` / `True` | |
+| `vector_field` | `"embedding"` | knn field; always excluded from returned `_source` |
+| `search_fields` | `["title", "content"]` | `multi_match` targets (`best_fields`, `fuzziness=AUTO`) |
+| `datastore_description` | `""` | Routing text (see below) |
+
+**Behavior contracts:**
+
+- `connect()` pings the cluster (`client.info()`) — bad endpoints fail at build
+  time. Timeout 30s, `RequestsHttpConnection`.
+- **Document normalization** tolerates heterogeneous indices: content is taken
+  from `content`, then `text`, then `metadata.content` (skipping values that
+  look like JSON blobs); `title` falls back through `metadata.title` to
+  `"Untitled"`; `source` falls back through `source_path` and metadata
+  equivalents. You can point the adapter at an existing index that wasn't
+  written by this SDK.
+- **Writes are bulk with `refresh=true`** (immediately searchable). Per-item
+  bulk failures are logged and **only the IDs that actually indexed are
+  returned** — check the return length on `bulk_insert`.
+- `add_texts` computes embeddings via the connected embedding model when not
+  supplied, and validates ids/texts/metadatas/embeddings lengths match.
+- `update()` is a partial-document update of only the provided fields;
+  `delete()`/`get()` map OpenSearch 404s to `False`/`None`.
+- `stats()` reads `indices.stats`: primary doc count + `size_bytes`.
+
+## Writing a custom datastore
+
+Subclass `VectorDataStore` and implement the abstract members (`name`,
+`connect`, `vectorstore`, `get`, `insert`, `bulk_insert`, `update`, `delete`,
+`stats`). Optionally expose `keyword_retriever` to unlock true hybrid search —
+without it, `search` silently degrades to semantic-only. Set
+`datastore_description` for routing. Your store then works everywhere
+`ADB`/`OpenSearch` do, including `create_datastore_tools` and the agent
+factory.
+
+```python
+from langchain_oci.datastores import VectorDataStore
+
+class MyStore(VectorDataStore):
+    @property
+    def name(self) -> str:
+        return "my_store"
+
+    @property
+    def datastore_description(self) -> str:
+        return "product manuals, spec sheets"
+
+    def connect(self, embedding_model):
+        self._vs = ...  # any LangChain VectorStore
+
+    @property
+    def vectorstore(self):
+        return self._vs
+
+    # get / insert / bulk_insert / update / delete / stats ...
+```
+
+## The generated tools
+
+`create_datastore_tools(...)` (also called internally by the agent factory)
+returns exactly three tools:
+
+| Tool | Name the LLM sees | What it does |
+|---|---|---|
+| `StatsTool` | `stats` | "START HERE" — document counts, descriptions, and backend extras per store (or one store via `store=`). Errors per store are embedded in the output rather than raised. |
+| `HybridSearchTool` | `search` | Routes the query to one store, runs hybrid semantic+keyword search with RRF, formats results with Doc IDs, relevance scores, and 500-char content previews, plus an explicit *"ALWAYS cite Doc IDs"* instruction. |
+| `GetDocumentTool` | `get_document` | Fetches the **full** document by ID. Takes an optional `store` argument; **does not route** — uses `default_store` unless told otherwise. Unknown stores/IDs return instructive error strings, not exceptions. |
+
+Details that matter in practice:
+
+- **Tool descriptions are composed at build time**: static description + usage
+  hint + `"Available stores: name (description), …"` — so the LLM knows what
+  stores exist without a tool call, but `stats` gives it live counts.
+- **All tool errors return formatted strings**
+  (`Error during hybrid search: …`) instead of raising — the agent loop keeps
+  going and can self-correct.
+- Two more tool classes are exported for manual composition but *not* included
+  by the factory: `SearchTool` (semantic-only) and `KeywordSearchTool` (exact
+  terms). Swap or add them if you build the tool list yourself:
+
+```python
+from langchain_oci.datastores import (
+    KeywordSearchTool, SearchTool, StoreSelector, ResultFormatter,
+)
+```
+
+- The tools are plain LangChain `BaseTool`s — they work with **any** agent
+  (`create_oci_agent`, LangGraph, plain `bind_tools`), not just deepagents.
+
+## Query routing (`StoreSelector`)
+
+```mermaid
+sequenceDiagram
+    participant LLM as Agent LLM
+    participant T as search tool
+    participant SEL as StoreSelector
+    participant E as Embedding model
+    participant S as Selected store
+
+    Note over SEL: at build time: embed each store's<br/>datastore_description once
+    LLM->>T: search(query="incident retries spiking")
+    T->>SEL: route(query)
+    alt single store
+        SEL-->>T: that store (no embedding call)
+    else multiple stores
+        SEL->>E: embed_query(query)
+        SEL->>SEL: cosine(query, each description)
+        alt best score > 0
+            SEL-->>T: best-matching store
+        else all scores ≤ 0
+            SEL-->>T: default_store
+        end
+    end
+    T->>S: hybrid_search_documents(query, top_k)
+    S-->>T: (doc, score) pairs
+    T-->>LLM: formatted results + Doc IDs + citation reminder
+```
+
+- Score threshold is `0.0`: any positive cosine similarity wins;
+  ties/non-positive fall through to `default_store` (first dict key unless you
+  set it).
+- Descriptions are embedded **once** at build time; each routed query costs one
+  query embedding.
+- A store with an empty description is embedded under its **name** — always set
+  `datastore_description`, and make descriptions distinct across stores
+  (domain, document types, topics), e.g.
+  `"incident reports, runbooks, error logs"` vs
+  `"legal contracts, compliance policies"`.
+- Routing picks exactly **one** store per query. The agent naturally covers
+  multiple stores across research steps because each search call routes
+  independently.
+
+## Hybrid search (RRF)
+
+For each `search` call against the routed store:
+
+1. Fetch `2 × top_k` semantic hits (with scores) and `2 × top_k` keyword hits.
+2. Fuse with Reciprocal Rank Fusion: `score(d) = Σ 1/(60 + rank + 1)` across
+   both lists, deduplicating by document id (`doc.id`, else `metadata.id`,
+   else a synthetic per-list key).
+3. Return the top `top_k` by fused score.
+
+No keyword retriever (custom stores) → semantic results returned directly. On
+ADB the keyword leg is Oracle Text; on OpenSearch it's `multi_match` with
+fuzziness.
+
+## Embeddings
+
+- **Default:** `OCIGenAIEmbeddings` with `cohere.embed-v4.0`, overridable via
+  `$OCI_EMBEDDING_MODEL_ID` / `$OCI_EMBEDDING_MODEL`, built with the same
+  compartment/endpoint/auth as the agent.
+- **One model, three jobs:** routing, query-time search, and (for stores that
+  embed on write) ingestion. **Index-time and query-time models must match** —
+  and the embedding dimension must match your vector column.
+- Pass any LangChain `Embeddings` implementation via `embedding_model=` to opt
+  out of OCI entirely (relevant with BYO models — see
+  [Operations](operations.md#bring-your-own-model)).

--- a/libs/oci/docs/deepagents/guide.md
+++ b/libs/oci/docs/deepagents/guide.md
@@ -1,0 +1,211 @@
+# Deep Agents on OCI — Core Guide
+
+Part of the [Deep Agents documentation](../../langchain_oci/agents/deepagents/README.md).
+See also: [Datastores & retrieval](datastores.md) · [Persistence](persistence.md) · [Capabilities](capabilities.md) · [Operations](operations.md)
+
+`create_deepagents_agent(...)` builds a LangGraph agent for multi-step research
+workflows on OCI: it wires an OCI GenAI chat model (or any LangChain chat model
+you bring) to auto-generated retrieval tools over Oracle Autonomous Database and
+OpenSearch vector stores, and — on the full path — to the `deepagents` harness:
+planning, a virtual filesystem, subagents, skills, memory, and human-in-the-loop
+controls.
+
+## Architecture at a glance
+
+```mermaid
+flowchart LR
+    APP["Your app<br/>agent.invoke(messages, config)"] --> AGENT
+
+    subgraph AGENT["Compiled LangGraph agent"]
+        LLM["ChatOCIGenAI<br/>(or BYO chat model)"]
+        DT["Datastore tools<br/>stats · search · get_document"]
+        BT["Deep-path built-ins<br/>ls · read_file · write_file · edit_file<br/>glob · grep · task (subagents)"]
+        LLM -- "tool calls" --> DT
+        LLM -- "tool calls" --> BT
+    end
+
+    DT --> SEL["StoreSelector<br/>cosine routing over<br/>datastore descriptions"]
+    SEL -- "routes to one store" --> ADB["ADB adapter<br/>OracleVS + Oracle Text"]
+    SEL -- "routes to one store" --> OS["OpenSearch adapter<br/>knn + multi_match"]
+
+    ADB --> ORA[("Oracle ADB / 26ai<br/>VECTOR_DOCUMENTS")]
+    OS --> OSI[("OpenSearch index")]
+
+    AGENT -. "checkpointer=" .-> CKPT["OracleSaver /<br/>AsyncOracleSaver"]
+    AGENT -. "store= / backend=" .-> ST["OracleStore /<br/>StoreBackend"]
+    CKPT --> ORA2[("Oracle DB<br/>checkpoint tables")]
+    ST --> ORA2
+
+    LLM -- "chat + embeddings" --> GENAI["OCI Generative AI<br/>inference endpoint"]
+```
+
+Three layers, each usable on its own:
+
+| Layer | Entry point | Use it alone when… |
+|---|---|---|
+| Agent factory | `create_deepagents_agent(...)` | you want the whole thing assembled |
+| Datastore tools | `create_datastore_tools(...)` | you have your own agent (e.g. `create_oci_agent`) and just want the tools |
+| Datastore adapters | `ADB(...)`, `OpenSearch(...)`, `VectorDataStore` | you want vector search primitives with no agent at all |
+
+## The two build paths
+
+`create_deepagents_agent` compiles one of two very different graphs. Which one
+you get is decided by the config — and it changes which parameters take effect
+and which packages must be installed.
+
+```mermaid
+flowchart TD
+    START["create_deepagents_agent(...)"] --> NEED{"Any deep-only option set?<br/>subagents · skills · memory ·<br/>backend · cache · interrupt_on ·<br/>response_format · context_schema ·<br/>permissions"}
+    NEED -- yes --> DEEP
+    NEED -- no --> MW{"middleware == [ ]<br/>(explicit empty list)"}
+    MW -- yes --> LIGHT["Lightweight path<br/>langchain create_agent<br/>(or legacy create_react_agent)"]
+    MW -- "no (None or non-empty)" --> DEEP["Deep path<br/>deepagents.create_deep_agent"]
+
+    DEEP --> DREQ["Requires: Python ≥ 3.11<br/>+ deepagents installed"]
+    LIGHT --> LREQ["No deepagents needed.<br/>Plain ReAct loop over your tools."]
+```
+
+**Rules, exactly as implemented:**
+
+1. Any of `subagents`, `skills`, `memory`, `backend`, `cache`, `interrupt_on`,
+   `response_format`, `context_schema`, `permissions` → **deep path**, always.
+2. Otherwise, `middleware=[]` (an explicit empty list) → **lightweight path**.
+   This is the only opt-out.
+3. Everything else — including the default `middleware=None` and including
+   datastore-only configs — → **deep path**. Datastores *compose with* the deep
+   harness; they do not downgrade it.
+
+**What differs per path:**
+
+| | Lightweight | Deep |
+|---|---|---|
+| Underlying factory | `langchain.agents.create_agent` (falls back to `langgraph.prebuilt.create_react_agent` on old installs) | `deepagents.create_deep_agent` |
+| Built-in tools | none — only your tools + datastore tools | filesystem (`ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`), `task` (subagents), `execute` (errors unless a sandbox backend is configured) |
+| Honors `interrupt_before` / `interrupt_after` | ✅ | ❌ silently unused |
+| Honors `interrupt_on` | ❌ (forces deep path if set) | ✅ |
+| Honors `middleware` | ✅ on the new `create_agent` API only | ✅ (inserted mid-stack, see [Capabilities](capabilities.md#structured-output-context-middleware)) |
+| Requires `deepagents` package | no | yes (`ImportError` with install hint if missing; `RuntimeError` on Python < 3.11) |
+| Conversation summarization | no | yes (built-in `SummarizationMiddleware`) |
+
+> **Rule of thumb:** deploying on Python 3.9/3.10, or want a minimal ReAct
+> tool-loop with no planning/filesystem overhead? Pass `middleware=[]`.
+> Otherwise take the default.
+
+## Construction lifecycle
+
+Everything below happens **inside the factory call** — including network I/O.
+Budget for it at startup, not per-request.
+
+```mermaid
+sequenceDiagram
+    participant U as Caller
+    participant F as create_deepagents_agent
+    participant C as DeepagentsConfig
+    participant T as create_datastore_tools
+    participant S as Each datastore
+    participant R as StoreSelector
+    participant B as Agent builder
+
+    U->>F: kwargs
+    F->>C: validate (pydantic)
+    C->>C: compartment_id ← arg or $OCI_COMPARTMENT_ID<br/>(ValueError if missing and no model=)
+    C->>C: service_endpoint ← arg or $OCI_SERVICE_ENDPOINT<br/>or built from $OCI_REGION (default us-chicago-1)
+    F->>T: stores, embedding_model, top_k, auth
+    T->>T: resolve default embedding model if none given
+    T->>S: connect(embedding_model)  — DB/HTTP connections open here
+    T->>R: build selector
+    R->>R: embed every datastore_description once (network call)
+    T-->>F: [stats, search, get_document]
+    F->>F: append caller tools
+    F->>B: lightweight or deep build
+    B-->>F: CompiledStateGraph
+    F->>F: attach ._oci_llm (for cleanup)
+    F-->>U: agent
+```
+
+Consequences worth knowing:
+
+- **Credentials are exercised at build time.** A bad wallet, DSN, or OpenSearch
+  endpoint fails the factory call, not the first `invoke`.
+- **Description embeddings are computed once** per store at build time and
+  reused for every routed query.
+- **`ADB.connect` opens a real `oracledb` connection** and keeps it; call
+  `store.close()` (or use the store as a context manager) when tearing down.
+
+## Complete parameter reference
+
+### Datastores
+
+| Parameter | Type / default | Behavior |
+|---|---|---|
+| `datastores` | `dict[str, VectorDataStore]` = `None` | Named stores. Presence generates the three datastore tools. Names are what the router and `get_document(store=...)` use. |
+| `default_datastore` | `str` = `None` | Fallback store when routing is inconclusive. Defaults to the **first key** of `datastores`. |
+| `default_store` | alias | Exact alias of `default_datastore` (both accepted; `default_store` wins if both are passed). |
+| `embedding_model` | LangChain embeddings = `None` | Used for routing *and* store search. Default: `OCIGenAIEmbeddings` (see [Embeddings](datastores.md#embeddings)). |
+| `top_k` | `int` = `5` | Results per `search` call. |
+
+### Model
+
+| Parameter | Type / default | Behavior |
+|---|---|---|
+| `model` | `BaseChatModel` = `None` | **Bring-your-own model.** Used as-is; `model_id` + all OCI inference auth options are ignored (see [Operations](operations.md#bring-your-own-model)). |
+| `model_id` | `str` = `"google.gemini-2.5-pro"` | OCI GenAI model used to build a `ChatOCIGenAI` when `model` is not given. |
+| `temperature` | `float` = `None` | Merged into the model kwargs. |
+| `max_tokens` | `int` = `None` | Max output tokens. The provider layer remaps to `max_completion_tokens` for OpenAI-family models automatically. |
+| `max_input_tokens` | `int` = `None` | **Accepted but ignored** — input limits are model-determined. Kept for signature compatibility. |
+| `**model_kwargs` | any | Passed through to `ChatOCIGenAI(model_kwargs=...)`. |
+
+### OCI auth (used for the built model and/or default embeddings)
+
+| Parameter | Type / default | Behavior |
+|---|---|---|
+| `compartment_id` | `str` = `None` | Falls back to `$OCI_COMPARTMENT_ID`. **Required** unless `model=` is supplied (then only resolved opportunistically for datastore embeddings). `ValueError` otherwise. |
+| `service_endpoint` | `str` = `None` | Falls back to `$OCI_SERVICE_ENDPOINT`, then `https://inference.generativeai.{$OCI_REGION or us-chicago-1}.oci.oraclecloud.com`. |
+| `auth_type` | `str \| OCIAuthType` = `API_KEY` | One of `API_KEY`, `SECURITY_TOKEN`, `INSTANCE_PRINCIPAL`, `RESOURCE_PRINCIPAL` — enum or string. |
+| `auth_profile` | `str` = `"DEFAULT"` | Profile in the OCI config file. |
+| `auth_file_location` | `str` = `"~/.oci/config"` | OCI config file path. |
+
+### Deep-agent options (all force the deep path except `system_prompt`/`middleware`)
+
+| Parameter | Type / default | Behavior (details in [Capabilities](capabilities.md)) |
+|---|---|---|
+| `system_prompt` | `str` = `None` | Your instructions, placed first in the assembled system prompt (both paths). |
+| `subagents` | `list` = `None` | `SubAgent` / `CompiledSubAgent` / `AsyncSubAgent` specs, invoked via the `task` tool. |
+| `skills` | `list[str]` = `None` | Skill source paths (POSIX, relative to the backend root; last-wins on name clash). |
+| `memory` | `list[str]` = `None` | `AGENTS.md`-style memory file paths, loaded at startup into the system prompt. |
+| `middleware` | `Sequence` = `None` | `[]` → lightweight path. Non-empty → inserted between the deepagents base stack and tail stack. |
+| `response_format` | schema = `None` | Structured output for the final answer. |
+| `context_schema` | `type` = `None` | Immutable run-scoped context schema. |
+| `permissions` | `list[FilesystemPermission]` = `None` | Path-level allow/deny/interrupt rules for the filesystem tools; first match wins. |
+
+### LangGraph options
+
+| Parameter | Path | Behavior |
+|---|---|---|
+| `checkpointer` | both | Thread-level state persistence — e.g. `OracleSaver` (see [Persistence](persistence.md)). |
+| `store` | both | Cross-thread key/value + vector store — e.g. `OracleStore`. Required if `backend` uses `StoreBackend`. |
+| `backend` | deep only | Storage backend for the deep agent's virtual filesystem — e.g. `StoreBackend`. |
+| `cache` | deep only | LangGraph `BaseCache` for caching node results. |
+| `interrupt_before` / `interrupt_after` | **lightweight only** | Node-name interrupt lists. |
+| `interrupt_on` | **deep only** | `{tool_name: bool \| InterruptOnConfig}` human-in-the-loop gates. |
+| `debug` | both | LangGraph debug mode (deep path: only forwarded when `True`). |
+| `name` | both | Graph name. |
+
+## Configuration & environment variables
+
+Read by the **SDK** itself:
+
+| Variable | Read when | Effect |
+|---|---|---|
+| `OCI_COMPARTMENT_ID` | `compartment_id` not passed | Compartment for inference + default embeddings |
+| `OCI_SERVICE_ENDPOINT` | `service_endpoint` not passed | Full inference endpoint URL |
+| `OCI_REGION` | neither endpoint given | Builds `https://inference.generativeai.{region}.oci.oraclecloud.com`; default `us-chicago-1` |
+| `OCI_EMBEDDING_MODEL_ID` | default embedding model is built | Embedding model id (takes precedence) |
+| `OCI_EMBEDDING_MODEL` | ″ | Same, lower precedence; final fallback `cohere.embed-v4.0` |
+
+Used by the **samples and integration tests** only (conventions, not SDK
+behavior): `OCI_AUTH_TYPE`, `OCI_AUTH_PROFILE`, `OCI_DEEPAGENTS_MODEL`,
+`OCI_DEEPAGENTS_MAX_TOKENS`, `ADB_DSN`, `ADB_USER`, `ADB_PASSWORD`,
+`ADB_WALLET_LOCATION`, `ADB_WALLET_PASSWORD`, `OPENSEARCH_ENDPOINT`,
+`OPENSEARCH_USERNAME`, `OPENSEARCH_PASSWORD`, `OPENSEARCH_VECTOR_FIELD`,
+`OPENSEARCH_SEARCH_FIELDS`, `OPENSEARCH_USE_SSL`, `OPENSEARCH_VERIFY_CERTS`.

--- a/libs/oci/docs/deepagents/guide.md
+++ b/libs/oci/docs/deepagents/guide.md
@@ -91,6 +91,15 @@ flowchart TD
 > tool-loop with no planning/filesystem overhead? Pass `middleware=[]`.
 > Otherwise take the default.
 
+> **Known issue (deepagents ≥ 0.7 + Gemini):** the 0.7.x built-in `grep`
+> tool's schema contains `exclusiveMinimum` (from a `max_count` `gt=0`
+> constraint), which Gemini's function-calling API rejects with a 400 —
+> so the deep path currently fails on `google.gemini-*` models with
+> `deepagents>=0.7` installed. Workarounds: use a non-Gemini model on the
+> deep path (verified with `meta.llama-3.3-70b-instruct`), pin
+> `deepagents<0.7`, or use the lightweight path with Gemini. See the
+> [troubleshooting table](operations.md#troubleshooting).
+
 ## Construction lifecycle
 
 Everything below happens **inside the factory call** — including network I/O.

--- a/libs/oci/docs/deepagents/guide.md
+++ b/libs/oci/docs/deepagents/guide.md
@@ -97,7 +97,10 @@ flowchart TD
 > so the deep path currently fails on `google.gemini-*` models with
 > `deepagents>=0.7` installed. Workarounds: use a non-Gemini model on the
 > deep path (verified with `meta.llama-3.3-70b-instruct`), pin
-> `deepagents<0.7`, or use the lightweight path with Gemini. See the
+> `deepagents<0.7`, or use the lightweight path with Gemini. A provider-level
+> fix (rewriting the bounds to `minimum`/`maximum` for Gemini) is proposed in
+> [#291](https://github.com/oracle/langchain-oracle/pull/291); this note
+> applies to releases without it. See the
 > [troubleshooting table](operations.md#troubleshooting).
 
 ## Construction lifecycle

--- a/libs/oci/docs/deepagents/operations.md
+++ b/libs/oci/docs/deepagents/operations.md
@@ -110,7 +110,7 @@ debug output.
 | `Unclosed client session` warnings | Async model client never closed | `await agent._oci_llm.aclose()` |
 | Slow `get`/`delete` on ADB at scale | `metadata.id` index couldn't be created (check warning log) | Create the function-based index manually |
 | `ORA-00955` in logs | Index already exists | Benign — silently handled |
-| Deep path + Gemini model 400s: `Unknown name "exclusiveMinimum" at 'tools[0]...'` | `deepagents>=0.7` ships a built-in `grep` tool whose `max_count` field (`gt=0`) emits `exclusiveMinimum`, which Gemini's function-declaration API rejects (verified live 2026-08) | Use a non-Gemini model on the deep path (e.g. `meta.llama-3.3-70b-instruct` — verified working), pin `deepagents<0.7` (0.6.x has no such constraint), or use the lightweight path (`middleware=[]`) with Gemini |
+| Deep path + Gemini model 400s: `Unknown name "exclusiveMinimum" at 'tools[0]...'` | `deepagents>=0.7` ships a built-in `grep` tool whose `max_count` field (`gt=0`) emits `exclusiveMinimum`, which Gemini's function-declaration API rejects (verified live 2026-08) | Fixed by [#291](https://github.com/oracle/langchain-oracle/pull/291) (Gemini provider rewrites the bounds). On releases without it: use a non-Gemini model on the deep path (e.g. `meta.llama-3.3-70b-instruct` — verified working), pin `deepagents<0.7`, or use the lightweight path (`middleware=[]`) with Gemini |
 
 ## Testing
 

--- a/libs/oci/docs/deepagents/operations.md
+++ b/libs/oci/docs/deepagents/operations.md
@@ -1,0 +1,129 @@
+# Deep Agents on OCI — Operations
+
+Part of the [Deep Agents documentation](../../langchain_oci/agents/deepagents/README.md).
+See also: [Core guide](guide.md) · [Datastores & retrieval](datastores.md) · [Persistence](persistence.md) · [Capabilities](capabilities.md)
+
+## Bring your own model
+
+```python
+from langchain_anthropic import ChatAnthropic
+from langchain_oci import create_deepagents_agent
+
+agent = create_deepagents_agent(
+    datastores={"research": store},
+    model=ChatAnthropic(model="claude-opus-4-8"),
+    embedding_model=my_embeddings,   # otherwise OCI auth is still needed for embeddings
+)
+```
+
+- `model=` is used **as-is**; `model_id`, `temperature`, `max_tokens`,
+  `**model_kwargs`, and the OCI inference auth options are all ignored —
+  configure them on the model you pass.
+- `compartment_id` stops being required — but is still resolved
+  opportunistically because **default datastore embeddings are OCI-backed**.
+  Pass `embedding_model=` to sever the last OCI dependency.
+- Works with any tool-calling LangChain chat model: Anthropic, OpenAI, a
+  self-hosted vLLM endpoint via `ChatOpenAI(base_url=...)`, or a
+  custom-configured `ChatOCIGenAI` (e.g. kwargs the factory doesn't expose).
+  The model must support tool calling; for the deep path, models with strong
+  multi-step tool use work markedly better.
+- Same `model=` parameter exists on `create_oci_agent`.
+
+## Async usage & resource cleanup
+
+- The compiled graph supports `await agent.ainvoke(...)` / `astream(...)`.
+  With `ChatOCIGenAI`, native async is used where available.
+- The factory attaches the built model as **`agent._oci_llm`** so long-lived
+  processes can release the async HTTP session:
+
+```python
+llm = getattr(agent, "_oci_llm", None)
+if llm is not None and hasattr(llm, "aclose"):
+    await llm.aclose()
+```
+
+  Skipping this in long-lived async apps produces "unclosed client session"
+  warnings at shutdown. With BYO models, `_oci_llm` is your model — close it
+  per its own API.
+- `ADB` stores hold a real DB connection: `store.close()` (idempotent) or use
+  the store as a context manager.
+
+## Sharp edges & built-in workarounds
+
+- **`middleware=None` ≠ `middleware=[]`.** Default `None` takes the deep path;
+  only the explicit empty list is the lightweight opt-out.
+- **`interrupt_before/after` vs `interrupt_on`** are path-specific and
+  silently unused on the other path (see the
+  [parameter reference](guide.md#langgraph-options)).
+- **`max_input_tokens` is accepted and ignored.**
+- **Factory-time network I/O:** datastore connections and description
+  embeddings happen inside `create_deepagents_agent`.
+- **The pydantic/langgraph schema fallback.** Deepagents middleware annotates
+  runtime-injected fields with `OmitFromSchema + NotRequired`, which pydantic
+  rejects (`PydanticForbiddenQualifier`), which would crash langgraph's graph
+  compilation. The factory wraps compilation in a scoped patch of
+  `langgraph._internal._pydantic.create_model` that falls back to a permissive
+  `Any` schema for exactly the failing model, restoring the original
+  afterwards. It no-ops on langgraph versions with a different internal
+  layout. If you see `langgraph schema fallback for <model>` at DEBUG level,
+  this is that mechanism working as intended.
+- **ADB `update()` is not transactional** (delete commits before re-insert;
+  snapshot-restore on failure).
+- **OpenSearch `bulk_insert` may partially succeed** — compare the returned
+  count.
+- **Routing selects one store per query** — multi-store coverage emerges
+  across agent steps, not within one `search` call.
+
+## Logging & observability
+
+Component-scoped loggers, all under standard `logging`:
+
+| Logger | Emits |
+|---|---|
+| `langchain_oci.datastores.vectorstores.adb.ADB` | connect/close, backend init, search requests (DEBUG), index-creation warnings |
+| `langchain_oci.datastores.tools.*.HybridSearchTool` (etc.) | per-call start/success at INFO (`store=… top_k=… query=…`), failures with stack traces |
+| `langchain_oci.agents.common` | schema-fallback events at DEBUG |
+
+```python
+import logging
+logging.getLogger("langchain_oci.datastores").setLevel(logging.INFO)
+```
+
+For step-level agent tracing use LangSmith or
+`agent.stream(..., stream_mode="updates")`; `debug=True` enables LangGraph's
+debug output.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ValueError: compartment_id must be provided…` | No `compartment_id` arg, no `$OCI_COMPARTMENT_ID`, no `model=` | Pass one of the three |
+| `RuntimeError: Deepagents requires Python 3.11+` | Deep path on old Python | Upgrade, or opt into `middleware=[]` |
+| `ImportError: …'deepagents' package` | Deep path without the extra | `pip install 'langchain-oci[deepagents]'` |
+| `ImportError: oracledb required` / `langchain-oracledb required` / `opensearch-py required` | ADB / OpenSearch store without its driver | Install the named package |
+| Factory call hangs or fails before any invoke | Store connectivity (wallet path, DSN, endpoint) — connections open at build time | Test `oracledb.connect(...)` / `curl` the OpenSearch endpoint directly |
+| `RuntimeError: ADB datastore is not connected` | Adapter used before `connect()` / after `close()` | Let the factory connect it, or call `connect(embedding_model)` |
+| Search returns nothing relevant | Index/query embedding model mismatch, or empty table | Same model both sides; `stats` tool to check counts |
+| Every query routes to the same store | Missing/similar `datastore_description`s | Distinct, content-focused descriptions |
+| `get_document` "not found" for an ID seen in results | Doc lives in a non-default store | Pass `store=` — `get_document` does not route |
+| Truncated final reports | Output-token ceiling | Raise `max_tokens` (e.g. 65536 on Gemini 2.5 Pro) |
+| `Unclosed client session` warnings | Async model client never closed | `await agent._oci_llm.aclose()` |
+| Slow `get`/`delete` on ADB at scale | `metadata.id` index couldn't be created (check warning log) | Create the function-based index manually |
+| `ORA-00955` in logs | Index already exists | Benign — silently handled |
+
+## Testing
+
+```bash
+cd libs/oci
+# Unit (no credentials; deepagents/langgraph mocked where needed)
+poetry run pytest tests/unit_tests/agents/test_deepagents.py tests/unit_tests/agents/test_datastores.py -q
+
+# Integration (real OCI GenAI + optional ADB/OpenSearch)
+export OCI_COMPARTMENT_ID=... OCI_REGION=... OCI_AUTH_TYPE=API_KEY OCI_CONFIG_PROFILE=DEFAULT
+poetry run pytest tests/integration_tests/agents/test_deepagents_integration.py -v
+```
+
+Unit tests double as behavior specs —
+`test_empty_middleware_uses_lightweight_agent`,
+`test_backend_forces_deep_agent_path`,
+`test_custom_model_skips_compartment_requirement`, etc.

--- a/libs/oci/docs/deepagents/operations.md
+++ b/libs/oci/docs/deepagents/operations.md
@@ -110,6 +110,7 @@ debug output.
 | `Unclosed client session` warnings | Async model client never closed | `await agent._oci_llm.aclose()` |
 | Slow `get`/`delete` on ADB at scale | `metadata.id` index couldn't be created (check warning log) | Create the function-based index manually |
 | `ORA-00955` in logs | Index already exists | Benign — silently handled |
+| Deep path + Gemini model 400s: `Unknown name "exclusiveMinimum" at 'tools[0]...'` | `deepagents>=0.7` ships a built-in `grep` tool whose `max_count` field (`gt=0`) emits `exclusiveMinimum`, which Gemini's function-declaration API rejects (verified live 2026-08) | Use a non-Gemini model on the deep path (e.g. `meta.llama-3.3-70b-instruct` — verified working), pin `deepagents<0.7` (0.6.x has no such constraint), or use the lightweight path (`middleware=[]`) with Gemini |
 
 ## Testing
 

--- a/libs/oci/docs/deepagents/persistence.md
+++ b/libs/oci/docs/deepagents/persistence.md
@@ -1,0 +1,126 @@
+# Deep Agents on OCI — Persistence on Oracle
+
+Part of the [Deep Agents documentation](../../langchain_oci/agents/deepagents/README.md).
+See also: [Core guide](guide.md) · [Datastores & retrieval](datastores.md) · [Capabilities](capabilities.md) · [Operations](operations.md)
+
+The `[deepagents]` extra ships
+[`langgraph-oracledb`](https://pypi.org/project/langgraph-oracledb/) precisely
+so agent state can live in the same Oracle database as your vectors. Three
+independent knobs:
+
+| Knob | Class | Persists | Scope |
+|---|---|---|---|
+| `checkpointer=` | `OracleSaver` / `AsyncOracleSaver` | Full graph state: messages, todos, virtual files | Per `thread_id` — resume, replay, time-travel |
+| `store=` | `OracleStore` / `AsyncOracleStore` | Key/value namespaces (+ optional vector search) | Cross-thread, long-term |
+| `backend=` | `deepagents.backends.StoreBackend` | The deep agent's virtual filesystem, backed by the `store` | Files survive across threads |
+
+## Thread persistence with `OracleSaver`
+
+```python
+from langchain_oci import create_deepagents_agent
+from langgraph_oracledb.checkpoint.oracle import OracleSaver
+
+with OracleSaver.from_conn_string("USER/PASS@host:1521/FREEPDB1") as checkpointer:
+    checkpointer.setup()  # one-time: creates checkpoint tables + migrations
+
+    agent = create_deepagents_agent(
+        datastores={"research": my_store},
+        model_id="google.gemini-2.5-pro",
+        compartment_id="ocid1.compartment.oc1..example",
+        checkpointer=checkpointer,
+    )
+
+    cfg = {"configurable": {"thread_id": "research-42"}}
+    agent.invoke({"messages": [{"role": "user", "content": "Start a lit review on X"}]}, cfg)
+    # …later, same thread_id → full context, todos, and files restored:
+    agent.invoke({"messages": [{"role": "user", "content": "Continue where we left off"}]}, cfg)
+```
+
+For wallet-authenticated ADB, build the connection yourself and pass it:
+
+```python
+import oracledb
+from langgraph_oracledb.checkpoint.oracle import OracleSaver
+
+conn = oracledb.connect(
+    user="ADMIN",
+    password="***",
+    dsn="mydb_low",
+    config_dir="/path/to/wallet",
+    wallet_location="/path/to/wallet",
+    wallet_password="***",
+)
+checkpointer = OracleSaver(conn)
+checkpointer.setup()
+```
+
+`from_conn_string` also accepts `pool_config={"min_size": 1, "max_size": 10}`
+for pooled connections. Async graphs use
+`AsyncOracleSaver.from_conn_string(...)` with `await checkpointer.setup()`.
+
+**Inspecting checkpoints:**
+
+```python
+for checkpoint in checkpointer.list(cfg):
+    print(checkpoint.checkpoint["ts"], checkpoint.metadata)
+state = agent.get_state(cfg)                   # current messages / todos / files
+history = list(agent.get_state_history(cfg))   # time-travel
+```
+
+## Long-term memory with `OracleStore`
+
+```python
+from langgraph_oracledb.store.oracle import OracleStore
+
+with OracleStore.from_conn_string("USER/PASS@host:1521/FREEPDB1") as store:
+    store.setup()
+    agent = create_deepagents_agent(..., store=store)
+```
+
+The store is available to middleware/tools via LangGraph's runtime and supports
+namespaced key/value plus optional vector search — see the
+[`langgraph-oracledb` README](../../../langgraph-oracledb/README.md) for index
+configuration.
+
+## A durable virtual filesystem with `StoreBackend`
+
+By default the deep agent's files live in graph state (per-thread; persisted
+only if you set a checkpointer). To make files durable and shared across
+threads:
+
+```python
+from deepagents.backends import StoreBackend
+
+agent = create_deepagents_agent(
+    ...,
+    store=oracle_store,        # required by StoreBackend
+    backend=StoreBackend(),
+)
+```
+
+Now `write_file`/`read_file` operate on Oracle-backed storage: a report written
+in one thread is readable in the next. (`backend=` forces the deep path — see
+[Core guide](guide.md#the-two-build-paths).)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant A as Deep agent
+    participant C as OracleSaver
+    participant S as OracleStore
+
+    U->>A: invoke(thread_id=t1): "research X, save memo"
+    A->>A: plan → search → write_file("memo.md")
+    A->>S: memo.md (StoreBackend)
+    A->>C: checkpoint (messages, todos)
+    A-->>U: answer
+
+    Note over U,A: days later, new thread
+    U->>A: invoke(thread_id=t2): "update the memo"
+    A->>S: read_file("memo.md") ✓ still there
+    A->>C: new thread's checkpoints
+    A-->>U: updated memo
+```
+
+A runnable version of this page lives at
+[`samples/11-deepagents/persistence_oracle_example.py`](../../../../samples/11-deepagents/persistence_oracle_example.py).

--- a/libs/oci/docs/deepagents/persistence.md
+++ b/libs/oci/docs/deepagents/persistence.md
@@ -93,10 +93,15 @@ from deepagents.backends import StoreBackend
 
 agent = create_deepagents_agent(
     ...,
-    store=oracle_store,        # required by StoreBackend
-    backend=StoreBackend(),
+    store=oracle_store,        # StoreBackend reads/writes through this store
+    backend=StoreBackend(namespace=lambda rt: ("agent-files",)),
 )
 ```
+
+The `namespace` factory (required since deepagents 0.7) receives the LangGraph
+`Runtime` and returns the namespace tuple that scopes file storage — return a
+per-user tuple (e.g. `(rt.context.user_id, "files")`) for per-user isolation,
+or a constant for globally shared files.
 
 Now `write_file`/`read_file` operate on Oracle-backed storage: a report written
 in one thread is readable in the next. (`backend=` forces the deep path — see

--- a/libs/oci/langchain_oci/agents/deepagents/README.md
+++ b/libs/oci/langchain_oci/agents/deepagents/README.md
@@ -1,48 +1,104 @@
 # Deepagents Agent (langchain-oci)
 
-This module provides `create_deepagents_agent(...)` for multi-step research workflows on OCI.
+This module provides `create_deepagents_agent(...)` for multi-step research
+workflows on OCI. It wires an OCI GenAI chat model (or any LangChain chat
+model you bring) to auto-generated retrieval tools over Oracle Autonomous
+Database and OpenSearch vector stores, and — on the full path — to the
+`deepagents` harness: planning, a virtual filesystem, subagents, skills,
+memory, and human-in-the-loop controls.
 
-It supports:
-- OCI GenAI chat models for reasoning and synthesis
-- optional datastore-backed retrieval (`ADB`, `OpenSearch`)
-- optional custom tools
+## Documentation
 
-## Python Compatibility
+| Page | Covers |
+|---|---|
+| [Core guide](../../../docs/deepagents/guide.md) | Architecture, the two build paths, construction lifecycle, complete parameter reference, environment variables |
+| [Datastores & retrieval](../../../docs/deepagents/datastores.md) | `VectorDataStore` contract, ADB and OpenSearch adapters, custom stores, generated tools, query routing, hybrid search (RRF), embeddings |
+| [Persistence](../../../docs/deepagents/persistence.md) | Thread checkpoints (`OracleSaver`), long-term memory (`OracleStore`), durable virtual filesystem (`StoreBackend`) |
+| [Capabilities](../../../docs/deepagents/capabilities.md) | Built-in tools, subagents, skills, memory, human-in-the-loop, filesystem permissions, structured output, middleware |
+| [Operations](../../../docs/deepagents/operations.md) | Bring-your-own model, async & cleanup, logging, sharp edges, troubleshooting, testing |
 
-Deepagents support is provided via the optional extra:
-- `pip install langchain-oci[deepagents]`
+## Installation & compatibility
 
-Current compatibility for the `deepagents` extra is:
-- Python `>=3.11,<3.14` (driven by `deepagents` support bounds)
+```bash
+pip install -U "langchain-oci[deepagents]"
+```
+
+The `deepagents` extra installs:
+
+| Dependency | Pin | Why |
+|---|---|---|
+| `deepagents` | `>=0.6.1` (only on Python ≥3.11, <3.14) | The deep-agent harness (planning, filesystem, subagents) |
+| `langchain-oracledb` | `>=1.3.0` | `OracleVS` vector store, `OracleTextSearchRetriever`, `OracleTextSplitter` |
+| `langgraph-oracledb` | `>=1.0.1` | Oracle-backed checkpointers and stores for `checkpointer=` / `store=` |
+| `opensearch-py` | `>=2.4.0` | OpenSearch datastore backend |
+
+**Python matrix:**
+
+| Python | Lightweight path (`middleware=[]`) | Deep path (default) |
+|---|---|---|
+| 3.9 – 3.10 | ✅ works (no `deepagents` needed) | ❌ `RuntimeError` (deepagents requires ≥3.11) |
+| 3.11 – 3.13 | ✅ | ✅ |
+| 3.14 | ✅ | ⚠️ extra does not install `deepagents` (not yet tested upstream) |
+
+Only the pieces you use are imported: `oracledb`/`langchain-oracledb` only when
+an `ADB` store connects, `opensearch-py` only for `OpenSearch`, `deepagents`
+only on the deep path.
+
+## Quickstart
+
+```python
+from langchain_core.messages import HumanMessage
+from langchain_oci import create_deepagents_agent
+from langchain_oci.datastores import ADB
+
+agent = create_deepagents_agent(
+    datastores={
+        "research": ADB(
+            dsn="mydb_low",
+            user="ADMIN",
+            password="***",
+            wallet_location="~/wallets/mydb",
+            datastore_description="medical research papers, clinical trials",
+        ),
+    },
+    model_id="google.gemini-2.5-pro",
+    compartment_id="ocid1.compartment...",
+    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+    auth_type="API_KEY",
+    top_k=8,
+)
+
+result = agent.invoke(
+    {"messages": [HumanMessage(content="Summarize the evidence on leukocytosis treatment")]}
+)
+print(result["messages"][-1].content)
+```
+
+When `datastores=...` is provided, the agent gets three datastore tools
+automatically:
+
+- `stats` — sizes and per-store metadata
+- `search` — hybrid semantic + keyword retrieval with automatic store routing
+- `get_document` — fetch a full document by id
+
+Because this takes the deep path by default, the agent also gets the
+deepagents built-ins (filesystem tools and the `task` subagent tool). See the
+[Core guide](../../../docs/deepagents/guide.md) for the lightweight opt-out
+(`middleware=[]`) and the full parameter reference.
 
 ## Why This Is In Scope For `langchain-oci`
 
-This functionality is in scope for this SDK because it is an OCI-to-LangChain
-integration concern, not an unrelated application layer feature.
+This functionality is an OCI-to-LangChain integration concern, not an
+application-layer feature: agent helpers are first-class public API in
+`langchain_oci.agents`, the heavy dependencies are isolated in an optional
+extra, the datastore and deepagents surfaces are covered by unit and
+integration tests, and the implementation composes existing SDK primitives
+(OCI chat model, OCI embeddings, Oracle/OpenSearch datastores, LangChain
+tools) rather than introducing a separate product surface.
 
-Evidence from this repository:
-- Agent helpers are first-class public API in `langchain_oci.agents`
-  (`create_oci_agent`, `create_deepagents_agent`, datastore adapters).
-- The package explicitly declares deepagents as an optional integration extra
-  (`[project.optional-dependencies].deepagents` in `libs/oci/pyproject.toml`),
-  keeping core installs lean while supporting advanced workflows.
-- The datastore and deepagents surfaces are covered by unit and integration
-  tests under `libs/oci/tests/unit_tests/agents/` and
-  `libs/oci/tests/integration_tests/agents/`.
-- The implementation composes existing SDK primitives (OCI chat model,
-  OCI embeddings, OCI/OpenSearch datastores, LangChain tools) instead of
-  introducing a separate product surface.
-
-Scope boundary:
-- The SDK provides integration primitives and reference examples.
-- Dataset hosting/curation and domain-specific prompts remain user-owned.
-
-PR rationale (review-ready):
-This feature belongs here because `langchain-oci` is the OCI integration layer
-for LangChain. Deepagents support in this package wires OCI model/runtime
-capabilities to agent abstractions via reusable APIs (agent factory, datastore
-adapters, and tool generation), while keeping optional dependencies isolated in
-an extra. That is repository-scope integration work, not app-level logic.
+Scope boundary: the SDK provides integration primitives and reference
+examples. Dataset hosting/curation and domain-specific prompts remain
+user-owned.
 
 ## Data Provenance In This Repository
 
@@ -54,197 +110,55 @@ The deepagents examples use repository scripts to make provenance explicit:
 2. `libs/oci/scripts/upload_large_datasets.py` (optional)
    - uploads larger corpora (Wikipedia, C4, ArXiv) to OCI Object Storage
 3. `libs/oci/scripts/vectorize_datasets.py`
-   - reads objects from buckets
-   - generates embeddings
-   - writes vectors into ADB table `VECTOR_DOCUMENTS`
+   - reads objects from buckets, generates embeddings, writes vectors into the
+     ADB table `VECTOR_DOCUMENTS`
 
-Runtime examples then perform retrieval/synthesis over these indexed documents.
-For the Object Storage example, retrieval is done through agent tools
-(`list/read/search` on objects), not through SQL.
+Runtime examples then perform retrieval/synthesis over these indexed
+documents.
+
+## Samples
+
+| Sample | Shows |
+|---|---|
+| [`samples/11-deepagents/adb_multi_store_huggingface_example.py`](../../../../../samples/11-deepagents/adb_multi_store_huggingface_example.py) | Two ADB-backed stores: ingestion → multi-store research → markdown memo |
+| [`samples/11-deepagents/opensearch_multi_index_huggingface_example.py`](../../../../../samples/11-deepagents/opensearch_multi_index_huggingface_example.py) | Same flow on two OpenSearch indices |
+| [`samples/11-deepagents/local_docker_oracle_deepagents.ipynb`](../../../../../samples/11-deepagents/local_docker_oracle_deepagents.ipynb) | Local Docker Oracle + BYO Claude model, end-to-end |
+| [`samples/11-deepagents/persistence_oracle_example.py`](../../../../../samples/11-deepagents/persistence_oracle_example.py) | `OracleSaver` thread resume + checkpoint inspection |
 
 ## Common Questions
 
-1. Where does ADB data come from?
-- From your ingestion pipeline. In this repo: Hugging Face -> OCI Object Storage
-  -> ADB vectors using the scripts listed above.
+**Where does the data come from?** Your ingestion pipeline — the stores search
+what's already indexed. See Data Provenance above for the reference pipeline.
 
-2. Which embeddings model is used?
-- Default datastore embedding model is Cohere on OCI (`cohere.embed-v4.0`).
-- Examples in this repo now pass that model explicitly.
+**Do I need to implement a search class for ADB?** No. `ADB(...)` +
+`create_deepagents_agent(datastores=...)` is the canonical path; tools are
+generated automatically.
 
-3. Is there an additional ADB search class I must implement?
-- No, not for the canonical path. Use `ADB` + `create_deepagents_agent(...)`
-  with `datastores=...`; datastore tools are created automatically.
+**Can I use the tools without the deep agent?** Yes —
+`create_datastore_tools(...)` returns plain LangChain tools for any agent
+(e.g. `create_oci_agent`).
 
-4. At runtime, what do I need to provide?
-- Indexed documents in a datastore, OCI/auth config, and the user prompt/query.
+**Which chat models work best?** Any tool-calling model. On OCI GenAI,
+Gemini 2.5 Pro is the tuned default; raise `max_tokens` for long reports. Any
+provider works via `model=` — see
+[Operations](../../../docs/deepagents/operations.md#bring-your-own-model).
 
-## Datastore Descriptions And Routing (`datastore_description=...`)
+**How do I make the agent remember across sessions?**
+`checkpointer=OracleSaver(...)` + a stable `thread_id` for conversation state;
+`store=`/`backend=StoreBackend()` for durable files and long-term memory — see
+[Persistence](../../../docs/deepagents/persistence.md).
 
-`datastore_description` is datastore metadata used for auto-routing when you provide multiple
-stores.
-
-How it works:
-1. The SDK embeds each store description once at initialization (for example, "SRE runbooks, incidents").
-2. For each query, it embeds the query and compares similarity with description
-   embeddings using cosine similarity.
-3. The best-matching store is selected for the `search` (hybrid) tool.
-
-Guidance:
-- Keep descriptions short and content-focused (domain, document types, topics).
-- Use distinct descriptions across stores to reduce routing ambiguity.
-- With one datastore, description has no routing effect but still appears in tool/stats
-  descriptions.
-
-Examples of effective descriptions:
-- "incident reports, runbooks, system diagnostics, error logs"
-- "legal contracts, compliance documents, policy manuals"
-- "medical research papers, clinical trials, drug information"
-
-## What You Need
-
-1. OCI GenAI access:
-- `compartment_id`
-- `service_endpoint` (or `OCI_REGION`)
-- auth config (`auth_type`, `auth_profile`, credentials)
-
-2. For datastore-backed retrieval:
-- one or more `VectorDataStore` instances (`ADB`, `OpenSearch`, or custom)
-- indexed documents already loaded in the datastore
-
-3. A research prompt/query at runtime
-
-## Embeddings
-
-If you use datastores and do not pass `embedding_model=...`, the default is:
-- `cohere.embed-v4.0` via `OCIGenAIEmbeddings`
-
-You can override embeddings by passing a custom model:
-
-```python
-from langchain_oci import OCIGenAIEmbeddings
-
-embedding_model = OCIGenAIEmbeddings(
-    model_id="cohere.embed-v4.0",
-    compartment_id="ocid1.compartment...",
-    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
-    auth_type="API_KEY",
-)
-```
-
-Important:
-- use the same embedding model for indexing and query-time search
-- ensure embedding dimension matches your vector column definition
-- `ADB` uses `OracleVS` (`langchain-oracledb`) and expects OracleVS table
-  schema (`id/embedding/text/metadata`).
-
-## Example: ADB Datastore (Auto Tools)
-
-**Prerequisites:** `pip install langchain-oci langchain-oracledb`
-
-```python
-from langchain_core.messages import HumanMessage
-from langchain_oci import OCIGenAIEmbeddings
-from langchain_oci import create_deepagents_agent
-from langchain_oci.datastores import ADB
-
-# Requires langchain-oracledb for Oracle Database connectivity
-store = ADB(
-    dsn="mydb_low",
-    user="ADMIN",
-    password="***",
-    table_name="VECTOR_DOCUMENTS",
-    datastore_description="medical QA, legal clauses, web docs",
-)
-
-embedding_model = OCIGenAIEmbeddings(
-    model_id="cohere.embed-v4.0",
-    compartment_id="ocid1.compartment...",
-    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
-    auth_type="API_KEY",
-)
-
-agent = create_deepagents_agent(
-    datastores={"research": store},
-    embedding_model=embedding_model,  # explicit, same as default
-    model_id="google.gemini-2.5-pro",
-    compartment_id="ocid1.compartment...",
-    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
-    auth_type="API_KEY",
-    top_k=8,
-)
-
-result = agent.invoke(
-    {"messages": [HumanMessage(content="Research leukocytosis treatment evidence")]}
-)
-print(result["messages"][-1].content)
-```
-
-When `datastores=...` is provided, the agent gets three datastore tools:
-- `stats` — sizes and per-store metadata
-- `search` — `HybridSearchTool` (hybrid semantic + keyword retrieval)
-- `get_document` — fetch a full document by id
-
-## Example: ADB Datastore + Custom Embeddings
-
-```python
-from langchain_oci import OCIGenAIEmbeddings
-from langchain_oci import create_deepagents_agent
-from langchain_oci.datastores import ADB
-
-embedding_model = OCIGenAIEmbeddings(
-    model_id="cohere.embed-v4.0",
-    compartment_id="ocid1.compartment...",
-    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
-    auth_type="API_KEY",
-)
-
-agent = create_deepagents_agent(
-    datastores={"research": ADB(dsn="mydb_low", user="ADMIN", password="***")},
-    embedding_model=embedding_model,
-    compartment_id="ocid1.compartment...",
-    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
-)
-```
-
-## Example: Tool-Only Deepagents (No Datastores)
-
-```python
-from langchain_oci.agents import create_deepagents_agent
-
-agent = create_deepagents_agent(
-    tools=[...],  # your own LangChain tools
-    model_id="google.gemini-2.5-pro",
-    compartment_id="ocid1.compartment...",
-    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
-)
-```
-
-## Example: Bring Your Own Model
-
-By default the agent builds a `ChatOCIGenAI` from `model_id` and the OCI auth
-options. To drive it with any other LangChain chat model, pass a pre-built
-model via `model=...`. When set, `model_id` and the OCI inference auth options
-are ignored — the model owns its own connection.
-
-```python
-from langchain_anthropic import ChatAnthropic
-from langchain_oci.agents import create_deepagents_agent
-
-agent = create_deepagents_agent(
-    tools=[...],
-    model=ChatAnthropic(model="claude-opus-4-8"),
-)
-```
-
-This also works with a custom-configured `ChatOCIGenAI` (e.g. extra kwargs not
-exposed on the factory), a self-hosted vLLM endpoint via `ChatOpenAI`, etc. If
-you use OCI-backed datastores you may still need OCI auth for embeddings unless
-you pass your own `embedding_model`. The same `model=...` parameter is available
-on `create_oci_agent`.
+**Is Python 3.10 supported?** Only on the lightweight path (`middleware=[]`).
+The deep path needs 3.11+.
 
 ## Async Cleanup Note
 
 If your workflow keeps agents/models alive across many async calls, explicitly
 close the underlying model client when done to avoid unclosed HTTP session
-warnings.
+warnings:
+
+```python
+llm = getattr(agent, "_oci_llm", None)
+if llm is not None and hasattr(llm, "aclose"):
+    await llm.aclose()
+```

--- a/libs/oci/langchain_oci/agents/deepagents/agent.py
+++ b/libs/oci/langchain_oci/agents/deepagents/agent.py
@@ -201,15 +201,24 @@ def create_deepagents_agent(
         store: LangGraph store for long-term memory.
         backend: State backend for the deep agent (e.g., StoreBackend).
         cache: LangGraph cache for caching LLM calls.
-        interrupt_before: Node names to interrupt before (lightweight path).
-        interrupt_after: Node names to interrupt after (lightweight path).
-        interrupt_on: Mapping of tool names to interrupt configs.
+        interrupt_before: Node names to interrupt before (lightweight path
+            only; ignored on the deep path — use ``interrupt_on`` there).
+        interrupt_after: Node names to interrupt after (lightweight path
+            only; ignored on the deep path — use ``interrupt_on`` there).
+        interrupt_on: Mapping of tool names to interrupt configs for
+            human-in-the-loop approval. Deep path only; setting it forces
+            the deep path.
         debug: Enable debug mode.
         name: Name for the agent.
         temperature: Model temperature.
         max_tokens: Maximum output tokens (e.g., 65536 for Gemini 2.5 Pro).
         max_input_tokens: Ignored. Input limits are model-determined.
         **model_kwargs: Additional model kwargs.
+
+    Note:
+        Upstream ``deepagents.create_deep_agent`` parameters not listed here
+        (e.g. ``state_schema``) are not exposed by this factory. Full guides:
+        ``libs/oci/docs/deepagents/``.
 
     Returns:
         CompiledStateGraph: A compiled deepagents agent.

--- a/libs/oci/langchain_oci/datastores/vectorstores/adb.py
+++ b/libs/oci/langchain_oci/datastores/vectorstores/adb.py
@@ -132,7 +132,6 @@ class ADB(VectorDataStore):
 
     def _initialize_oraclevs_backend(self) -> None:
         try:
-            from langchain_community.vectorstores.utils import DistanceStrategy
             from langchain_oracledb.document_loaders.oracleai import (
                 OracleTextSplitter,
             )
@@ -142,6 +141,7 @@ class ADB(VectorDataStore):
             from langchain_oracledb.vectorstores.oraclevs import (
                 OracleVS,
             )
+            from langchain_oracledb.vectorstores.utils import DistanceStrategy
         except ImportError as e:
             raise ImportError(
                 "langchain-oracledb required for ADB datastore integration. "

--- a/samples/11-deepagents/README.md
+++ b/samples/11-deepagents/README.md
@@ -9,6 +9,8 @@ Included files:
 2. `adb_multi_store_huggingface_example.py`
 3. `opensearch_multi_index_huggingface_tutorial.md`
 4. `opensearch_multi_index_huggingface_example.py`
+5. `persistence_oracle_example.py`
+6. `local_docker_oracle_deepagents.ipynb`
 
 These samples show the full workflow:
 
@@ -124,3 +126,19 @@ Use these for the detailed explanation of each path:
 
 1. `samples/11-deepagents/adb_multi_store_huggingface_tutorial.md`
 2. `samples/11-deepagents/opensearch_multi_index_huggingface_tutorial.md`
+
+### 6. Persistence Sample
+
+`persistence_oracle_example.py` shows Oracle-backed thread persistence with
+`OracleSaver` from `langgraph-oracledb` (installed by the `[deepagents]`
+extra): two invokes on the same `thread_id` resume the conversation, then the
+stored checkpoints are listed. It needs either `ORACLE_CONN_STRING` or the
+`ADB_*` variables from step 3, plus the OCI settings from step 2:
+
+```bash
+PYTHONPATH=libs/oci python samples/11-deepagents/persistence_oracle_example.py \
+  --thread-id persistence-demo-01
+```
+
+Full persistence documentation (checkpoints, `OracleStore`, `StoreBackend`):
+`libs/oci/docs/deepagents/persistence.md`.

--- a/samples/11-deepagents/persistence_oracle_example.py
+++ b/samples/11-deepagents/persistence_oracle_example.py
@@ -1,0 +1,132 @@
+"""Deepagents persistence sample: Oracle-backed checkpoints with OracleSaver.
+
+Runs a deep agent twice on the same ``thread_id`` with an Oracle-backed
+checkpointer, proving that the second turn resumes with the first turn's
+conversation state, then lists the stored checkpoints.
+
+Connection is configured through environment variables, either as a plain
+connection string (local/container databases):
+
+    export ORACLE_CONN_STRING="USER/PASSWORD@localhost:1521/FREEPDB1"
+
+or as wallet-based ADB settings (same variables the other samples use):
+
+    export ADB_DSN="mydb_low"
+    export ADB_USER="ADMIN"
+    export ADB_PASSWORD="..."
+    export ADB_WALLET_LOCATION="$HOME/wallets/mydb"
+    export ADB_WALLET_PASSWORD="..."   # defaults to ADB_PASSWORD
+
+Model settings follow the other samples in this folder:
+
+    export OCI_COMPARTMENT_ID="ocid1.compartment..."
+    export OCI_REGION="us-chicago-1"
+    export OCI_AUTH_TYPE="API_KEY"
+    export OCI_AUTH_PROFILE="DEFAULT"
+    export OCI_DEEPAGENTS_MODEL="google.gemini-2.5-flash"
+
+Run from the repository root:
+
+    PYTHONPATH=libs/oci python samples/11-deepagents/persistence_oracle_example.py \
+      --thread-id persistence-demo-01
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any
+
+from langchain_core.messages import HumanMessage
+
+from langchain_oci import create_deepagents_agent
+
+
+def build_checkpointer() -> tuple[Any, Any]:
+    """Create an OracleSaver from environment configuration.
+
+    Returns (checkpointer, context_manager_or_None); the caller owns cleanup.
+    """
+    from langgraph_oracledb.checkpoint.oracle import OracleSaver
+
+    conn_string = os.environ.get("ORACLE_CONN_STRING")
+    if conn_string:
+        # from_conn_string is a context manager; keep the connection open for
+        # the whole demo by entering it manually and closing in main().
+        cm = OracleSaver.from_conn_string(conn_string)
+        checkpointer = cm.__enter__()
+        return checkpointer, cm
+
+    import oracledb
+
+    wallet = os.environ.get("ADB_WALLET_LOCATION")
+    wallet = os.path.expanduser(wallet) if wallet else None
+    password = os.environ["ADB_PASSWORD"]
+    conn = oracledb.connect(
+        user=os.environ.get("ADB_USER", "ADMIN"),
+        password=password,
+        dsn=os.environ["ADB_DSN"],
+        config_dir=wallet,
+        wallet_location=wallet,
+        wallet_password=os.environ.get("ADB_WALLET_PASSWORD", password),
+    )
+    return OracleSaver(conn), None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--thread-id", default="persistence-demo-01")
+    args = parser.parse_args()
+
+    checkpointer, cm = build_checkpointer()
+    try:
+        checkpointer.setup()  # idempotent: creates tables + migrations
+
+        agent = create_deepagents_agent(
+            model_id=os.environ.get("OCI_DEEPAGENTS_MODEL", "google.gemini-2.5-flash"),
+            compartment_id=os.environ.get("OCI_COMPARTMENT_ID"),
+            auth_type=os.environ.get("OCI_AUTH_TYPE", "API_KEY"),
+            auth_profile=os.environ.get("OCI_AUTH_PROFILE", "DEFAULT"),
+            checkpointer=checkpointer,
+        )
+
+        cfg = {"configurable": {"thread_id": args.thread_id}}
+
+        print(f"--- turn 1 (thread_id={args.thread_id}) ---")
+        result = agent.invoke(
+            {
+                "messages": [
+                    HumanMessage(
+                        content=(
+                            "Remember this fact for later: the launch codename "
+                            "is BLUE HERON. Reply with a short confirmation."
+                        )
+                    )
+                ]
+            },
+            cfg,
+        )
+        print(result["messages"][-1].content)
+
+        print("--- turn 2 (same thread, new invoke) ---")
+        result = agent.invoke(
+            {"messages": [HumanMessage(content="What is the launch codename?")]},
+            cfg,
+        )
+        print(result["messages"][-1].content)
+
+        print("--- stored checkpoints ---")
+        for i, checkpoint in enumerate(checkpointer.list(cfg)):
+            print(f"{i}: ts={checkpoint.checkpoint['ts']}")
+
+        state = agent.get_state(cfg)
+        print(f"--- current state: {len(state.values.get('messages', []))} messages ---")
+    finally:
+        if cm is not None:
+            cm.__exit__(None, None, None)
+        else:
+            checkpointer.conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Expands the deepagents documentation from a single module README into an exhaustive, structured guide set under `libs/oci/docs/deepagents/`, covering the entire `create_deepagents_agent` surface. Docs-only apart from two docstring clarifications; no behavior changes.

### New guide set

| Page | Covers |
|---|---|
| `docs/deepagents/guide.md` | Architecture, the two build paths (lightweight vs deep) and the exact decision rules, construction lifecycle (incl. factory-time network I/O), complete parameter reference, environment variables |
| `docs/deepagents/datastores.md` | `VectorDataStore` contract, ADB and OpenSearch adapter behavior contracts (chunk round-trip, `metadata.id` index, update semantics, normalization rules), custom stores, generated tools, query routing, hybrid search / RRF, embeddings |
| `docs/deepagents/persistence.md` | `OracleSaver`/`AsyncOracleSaver` checkpoints, `OracleStore`, durable virtual filesystem via `StoreBackend` — previously undocumented despite `langgraph-oracledb` being shipped by the `[deepagents]` extra for exactly this |
| `docs/deepagents/capabilities.md` | Built-in tools, subagents, skills, memory, human-in-the-loop (`interrupt_on`), filesystem permissions, structured output, middleware ordering; documents that upstream `state_schema` is not exposed |
| `docs/deepagents/operations.md` | BYO model, async usage & cleanup (`_oci_llm` / `aclose`), logging, sharp edges, troubleshooting matrix, testing |

Pages include mermaid architecture/sequence/class diagrams (rendered natively by GitHub).

### Other changes

- `langchain_oci/agents/deepagents/README.md` rewritten as overview + quickstart + doc index (content moved into the guide set, nothing dropped)
- New runnable sample `samples/11-deepagents/persistence_oracle_example.py` (OracleSaver thread resume + checkpoint listing) and samples README section for it
- Docstring clarifications in `agent.py`: `interrupt_before`/`interrupt_after` are lightweight-path only, `interrupt_on` is deep-path only, and a note that unexposed upstream params (e.g. `state_schema`) are not forwarded

### Verification

- Every behavioral claim was verified against source: `agent.py`, `agents/common.py`, `datastores/` (adapters, tools, selector, factory), `langgraph-oracledb`, and the upstream `deepagents` 0.7.5 wheel (pin is `>=0.6.1`)
- `ruff check` clean on the touched Python files; deepagents unit tests pass (`5 passed, 31 skipped` on a py3.14 venv where the deep path skips, as documented)
- All relative doc links checked against the repo layout

### Follow-up (not in this PR)

Extending `local_docker_oracle_deepagents.ipynb` with the persistence content (`OracleSaver`, checkpoint inspection, `StoreBackend`) so it matches the external docs page that references it — `docs/deepagents/persistence.md` in this PR provides the material for that.
