### PR TITLE
fix(oci): Gemini rejects tool schemas with exclusiveMinimum/exclusiveMaximum (breaks deepagents>=0.7 default path)

### DIFF
--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -1099,13 +1099,76 @@ class OpenAIProvider(GenericProvider):
         return result
 
 
+def _to_gemini_compatible_schema(schema: Any) -> Any:
+    """Rewrite JSON-Schema numeric exclusive bounds for Gemini.
+
+    Google's function-declaration schema dialect rejects any request whose
+    tool parameters contain ``exclusiveMinimum`` / ``exclusiveMaximum``
+    (HTTP 400 ``Unknown name "exclusiveMinimum"``). Pydantic v2 emits the
+    numeric draft 2020-12 form for ``gt``/``lt`` constraints, so convert it
+    to the inclusive ``minimum`` / ``maximum`` bounds Gemini does accept.
+    The draft-4 boolean form is dropped (its paired inclusive bound already
+    stands on its own), and an explicit inclusive bound always wins over a
+    converted one.
+    """
+    if isinstance(schema, list):
+        return [_to_gemini_compatible_schema(item) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    converted: Dict[str, Any] = {}
+    for key, value in schema.items():
+        if key in ("exclusiveMinimum", "exclusiveMaximum"):
+            # bool is the draft-4 flag form; drop it. (bool before number:
+            # isinstance(True, int) is True.)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            inclusive = "minimum" if key == "exclusiveMinimum" else "maximum"
+            if inclusive not in schema:
+                converted[inclusive] = value
+            continue
+
+        # `properties` / `$defs` / `definitions` keys are user-defined field
+        # names, not JSON-Schema keywords — a field literally named
+        # "exclusiveMinimum" must survive. Recurse into each value only.
+        if key in ("properties", "$defs", "definitions") and isinstance(value, dict):
+            converted[key] = {
+                name: _to_gemini_compatible_schema(sub_schema)
+                for name, sub_schema in value.items()
+            }
+            continue
+
+        converted[key] = _to_gemini_compatible_schema(value)
+    return converted
+
+
 class GeminiProvider(GenericProvider):
     """Provider for Google Gemini models.
 
     Handles Gemini-specific parameter requirements:
     - max_output_tokens → max_tokens (Gemini SDK uses max_output_tokens,
       but OCI API expects max_tokens)
+    - tool parameter schemas are rewritten for Gemini's schema dialect
+      (``exclusiveMinimum``/``exclusiveMaximum`` → ``minimum``/``maximum``)
     """
+
+    def convert_to_oci_tool(
+        self,
+        tool: Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool],
+    ) -> Dict[str, Any]:
+        """Convert a tool and rewrite its schema for Gemini compatibility.
+
+        Gemini's function-calling API rejects whole requests when any tool
+        schema contains ``exclusiveMinimum``/``exclusiveMaximum`` (emitted by
+        Pydantic v2 for ``gt``/``lt`` field constraints — e.g. the built-in
+        ``grep`` tool of deepagents >= 0.7). Other OCI model families accept
+        these keywords, so the rewrite is scoped to this provider.
+        """
+        definition = super().convert_to_oci_tool(tool)
+        parameters = getattr(definition, "parameters", None)
+        if isinstance(parameters, dict):
+            definition.parameters = _to_gemini_compatible_schema(parameters)
+        return definition
 
     def normalize_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Normalize Gemini parameters with warnings for mapped keys."""

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -1164,7 +1164,10 @@ class GeminiProvider(GenericProvider):
         ``grep`` tool of deepagents >= 0.7). Other OCI model families accept
         these keywords, so the rewrite is scoped to this provider.
         """
-        definition = super().convert_to_oci_tool(tool)
+        # Annotated Any: the parent is typed Dict[str, Any] but actually
+        # returns the OCI SDK FunctionDefinition model, whose `parameters`
+        # attribute is what the rewrite targets.
+        definition: Any = super().convert_to_oci_tool(tool)
         parameters = getattr(definition, "parameters", None)
         if isinstance(parameters, dict):
             definition.parameters = _to_gemini_compatible_schema(parameters)

--- a/libs/oci/tests/unit_tests/chat_models/test_tool_schema_constraints.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_tool_schema_constraints.py
@@ -974,3 +974,98 @@ def test_cohere_full_mcp_combo():
     # output_format: resolved Optional, enum in desc
     assert params["output_format"].type == "str"
     assert "json" in params["output_format"].description
+
+
+# ---------------------------------------------------------------------------
+# GeminiProvider: exclusive-bounds rewrite
+# (Google's function-declaration API rejects exclusiveMinimum/exclusiveMaximum
+#  with HTTP 400; other OCI model families accept them — see GeminiProvider.)
+# ---------------------------------------------------------------------------
+
+
+def _gemini_props(tool_obj):
+    """Run GeminiProvider.convert_to_oci_tool and return the properties dict."""
+    from langchain_oci.chat_models.providers.generic import GeminiProvider
+
+    result = GeminiProvider().convert_to_oci_tool(tool_obj)
+    return result.parameters.get("properties", {})  # type: ignore[attr-defined]
+
+
+@pytest.mark.requires("oci")
+def test_gemini_exclusive_bounds_become_inclusive():
+    """Pydantic gt/lt must be rewritten to minimum/maximum for Gemini."""
+    p = _gemini_props(exclusive_range_tool)
+    assert "exclusiveMinimum" not in p["score"]
+    assert "exclusiveMaximum" not in p["score"]
+    assert p["score"]["minimum"] == 0
+    assert p["score"]["maximum"] == 1.0
+
+
+@pytest.mark.requires("oci")
+def test_gemini_optional_gt_constraint_rewritten():
+    """Optional[int] with gt=0 (the deepagents>=0.7 grep max_count shape)."""
+
+    @tool
+    def grep_like_tool(
+        pattern: str,
+        max_count: Optional[int] = Field(default=None, gt=0, description="Max matches"),
+    ) -> str:
+        """Search for a pattern."""
+        return pattern
+
+    p = _gemini_props(grep_like_tool)
+    assert "exclusiveMinimum" not in str(p), p
+    assert p["max_count"]["minimum"] == 0
+    assert p["max_count"]["type"] == "integer"
+
+
+@pytest.mark.requires("oci")
+def test_gemini_explicit_inclusive_bound_wins():
+    """An explicit minimum next to a draft-4 boolean flag must survive as-is."""
+    from langchain_oci.chat_models.providers.generic import (
+        _to_gemini_compatible_schema,
+    )
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "n": {
+                "type": "integer",
+                "minimum": 5,
+                "exclusiveMinimum": True,  # draft-4 flag form: dropped
+            },
+            "m": {
+                "type": "number",
+                "maximum": 9,
+                "exclusiveMaximum": 3,  # explicit inclusive bound wins
+            },
+        },
+    }
+    out = _to_gemini_compatible_schema(schema)
+    assert out["properties"]["n"] == {"type": "integer", "minimum": 5}
+    assert out["properties"]["m"] == {"type": "number", "maximum": 9}
+
+
+@pytest.mark.requires("oci")
+def test_gemini_user_field_named_exclusive_minimum_survives():
+    """properties keys are user-defined names, never JSON-Schema keywords."""
+    from langchain_oci.chat_models.providers.generic import (
+        _to_gemini_compatible_schema,
+    )
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "exclusiveMinimum": {"type": "string", "description": "odd name"},
+        },
+    }
+    out = _to_gemini_compatible_schema(schema)
+    assert out["properties"]["exclusiveMinimum"]["type"] == "string"
+
+
+@pytest.mark.requires("oci")
+def test_generic_provider_still_preserves_exclusive_bounds():
+    """Non-Gemini providers keep the richer constraint keywords (issue #103)."""
+    p = _props(exclusive_range_tool)
+    assert p["score"]["exclusiveMinimum"] == 0
+    assert p["score"]["exclusiveMaximum"] == 1.0


### PR DESCRIPTION
## Problem

Google's function-declaration API rejects any chat request whose tool parameter schemas contain `exclusiveMinimum` / `exclusiveMaximum`:

```
400 — Invalid JSON payload received. Unknown name "exclusiveMinimum" at 'tools[0].function_declarations[6].parameters.properties[4].value'
```

Pydantic v2 emits exactly that keyword for `gt=` / `lt=` field constraints, so **any tool with such a constraint breaks every `google.*` model on OCI GenAI**. The highest-impact case: `deepagents>=0.7` ships a built-in `grep` tool with `max_count: Optional[int] = Field(gt=0)`, which makes `create_deepagents_agent(...)` — whose default model is Gemini — fail on its very first model call. Discovered during end-to-end verification of the deepagents documentation (#289).

## Fix

`GeminiProvider.convert_to_oci_tool` now post-processes the converted tool definition:

- numeric (draft 2020-12) `exclusiveMinimum`/`exclusiveMaximum` → the inclusive `minimum`/`maximum` bounds Gemini accepts
- draft-4 boolean flag form is dropped (its paired inclusive bound stands on its own)
- an explicit inclusive bound always wins over a converted one
- `properties`/`$defs`/`definitions` keys are exempt from keyword matching, so a user field literally named `exclusiveMinimum` survives

Scoped to `GeminiProvider` only: Meta/OpenAI/xAI models on OCI accept these keywords (verified live), and `test_12_exclusive_native` (issue #103) intentionally asserts they're preserved for `GenericProvider` — that behavior is unchanged and now covered by an explicit regression test.

## Verification

- **E2E before/after** against OCI GenAI (us-chicago-1): the failing deep-agent call on `google.gemini-2.5-flash` (deepagents 0.7.5) now completes — built-in `write_file` runs and the file lands in graph state.
- **Unit:** 5 new tests (rewrite, the exact deepagents `grep` shape, draft-4/explicit-bound precedence, user-field-named-keyword survival, GenericProvider preservation). Full `tests/unit_tests/chat_models/` suite: **325 passed, 7 skipped**.

## Related

- #289 documents this as a known issue with workarounds; once this merges, that note can be softened to "fixed in <next release>".
