### PR TITLE
chore: bump langchain-oracledb to 1.6.0

### DIFF
--- a/libs/oracledb/pyproject.toml
+++ b/libs/oracledb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-oracledb"
-version = "1.5.0"
+version = "1.6.0"
 description = "An integration package connecting Oracle Database and LangChain"
 readme = "README.md"
 license = "UPL-1.0"


### PR DESCRIPTION
Version bump for release:

* **langchain-oracledb 1.5.0 → 1.6.0**: exact-match OracleCache (#282), OracleByteStore/OracleDocStore (#283), nested metadata filters in OracleVS (#280)

Note: this PR originally also bumped langgraph-oracledb to 1.0.2, but that bump landed on main via #295 (which pairs it with the Decimal index-param fix for #294), so it was dropped here on rebase. If #293 (containment matching for checkpoint metadata filters) merges before the langgraph-oracledb release is cut, consider bumping to 1.1.0 in that context since it changes filter-matching behavior.