### PR TITLE
feat(langgraph-oracledb): containment matching for dict and list checkpoint metadata filters

### DIFF
--- a/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/base.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import random
 from collections.abc import Sequence
 from decimal import Decimal
@@ -462,7 +463,9 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
             # metadata {"nested": {"a": 1, "b": {"c": True}}}. Each dict is
             # flattened into per-leaf JSON-path predicates, matching the
             # LangGraph.js Oracle saver and PostgresSaver (`metadata @> filter`).
-            # Lists keep JSON_EQUAL exact-match (positional) semantics.
+            # Lists also use containment (issue #296): the stored value must be
+            # an array containing every filter element, regardless of order or
+            # duplicates, with dict/array elements matched recursively.
             filter_conditions = []
             param_counter = 0
 
@@ -471,6 +474,72 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
                 name = f"filter_key_{param_counter}"
                 param_counter += 1
                 return name
+
+            def _bound_path_variable(value: Any, passing: list[str]) -> str:
+                """Bind a value for use as a JSON path variable ($NAME)."""
+                param_name = _next_param()
+                variable = param_name.upper()
+                passing.append(f':{param_name} AS "{variable}"')
+                param_values[param_name] = value
+                return f"${variable}"
+
+            def _is_object_predicate(subject: str) -> str:
+                return " && ".join(
+                    f'!({subject}.type() == "{scalar}")'
+                    for scalar in ("array", "string", "number", "boolean", "null")
+                )
+
+            def _element_predicate(subject: str, value: Any, passing: list[str]) -> str:
+                """JSON-path predicate matching one array element by containment.
+
+                Mirrors the LangGraph.js Oracle saver's filter compiler so both
+                languages match the same rows: scalars compare by type and
+                value, dicts by recursive containment, arrays by nested
+                containment. String and numeric values are bound through the
+                PASSING clause; only our own literals reach the path text.
+                """
+                if value is None:
+                    return f'{subject}.type() == "null" && {subject} == null'
+                if isinstance(value, bool):
+                    literal = "true" if value else "false"
+                    return f'{subject}.type() == "boolean" && {subject} == {literal}'
+                if isinstance(value, (int, float)):
+                    if isinstance(value, float) and not math.isfinite(value):
+                        raise ValueError(
+                            "Metadata filter numbers inside lists must be finite."
+                        )
+                    variable = _bound_path_variable(value, passing)
+                    return f'{subject}.type() == "number" && {subject} == {variable}'
+                if isinstance(value, str):
+                    if value == "":
+                        return f'{subject}.type() == "string" && {subject} == ""'
+                    variable = _bound_path_variable(value, passing)
+                    return f'{subject}.type() == "string" && {subject} == {variable}'
+                if isinstance(value, list):
+                    predicates = [f'{subject}.type() == "array"']
+                    predicates.extend(
+                        f"exists({subject}[*]?"
+                        f"({_element_predicate('@', item, passing)}))"
+                        for item in value
+                    )
+                    return " && ".join(predicates)
+                if isinstance(value, dict):
+                    predicates = [] if subject == "@" else [f"exists({subject})"]
+                    predicates.append(_is_object_predicate(subject))
+                    for sub_key, sub_value in value.items():
+                        # SECURITY: member names become part of the JSON path
+                        # expression; validate exactly like top-level keys.
+                        self._validate_json_path_key(sub_key)
+                        predicates.append(
+                            _element_predicate(
+                                f'{subject}."{sub_key}"', sub_value, passing
+                            )
+                        )
+                    return " && ".join(predicates)
+                raise ValueError(
+                    "Metadata filter list elements must be JSON values, got "
+                    f"{type(value).__name__}."
+                )
 
             def _add_leaf_condition(path: str, value: Any) -> None:
                 """Append a predicate comparing one JSON path to a leaf value."""
@@ -497,12 +566,22 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
                     )
                     param_values[param_name] = value
                 elif isinstance(value, list):
-                    # Lists keep exact-match semantics (element order matters)
-                    param_name = _next_param()
+                    # Containment: the stored value must be an array holding
+                    # every filter element somewhere (order-insensitive),
+                    # matching the LangGraph.js Oracle saver and PostgresSaver.
                     filter_conditions.append(
-                        f"JSON_EQUAL(JSON_QUERY(metadata, '$.{path}'), :{param_name})"
+                        f"JSON_EXISTS(metadata, '$.{path}?(@.type() == \"array\")')"
                     )
-                    param_values[param_name] = json.dumps(value)
+                    for element in value:
+                        passing: list[str] = []
+                        predicate = _element_predicate("@", element, passing)
+                        passing_sql = (
+                            f" PASSING {', '.join(passing)}" if passing else ""
+                        )
+                        filter_conditions.append(
+                            f"JSON_EXISTS(metadata, "
+                            f"'$.{path}[*]?({predicate})'{passing_sql})"
+                        )
                 else:
                     # For string values, use direct comparison
                     param_name = _next_param()

--- a/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/base.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/base.py
@@ -457,44 +457,81 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
 
         # construct predicate for metadata filter
         if filter:
-            # Oracle JSON filtering - build individual conditions for each key-value pair
+            # Oracle JSON filtering. Dict values use recursive CONTAINMENT
+            # semantics: the filter {"nested": {"b": {"c": True}}} matches
+            # metadata {"nested": {"a": 1, "b": {"c": True}}}. Each dict is
+            # flattened into per-leaf JSON-path predicates, matching the
+            # LangGraph.js Oracle saver and PostgresSaver (`metadata @> filter`).
+            # Lists keep JSON_EQUAL exact-match (positional) semantics.
             filter_conditions = []
-            for i, (key, value) in enumerate(filter.items()):
-                # SECURITY: Validate key to prevent JSON path injection attacks
-                self._validate_json_path_key(key)
+            param_counter = 0
+
+            def _next_param() -> str:
+                nonlocal param_counter
+                name = f"filter_key_{param_counter}"
+                param_counter += 1
+                return name
+
+            def _add_leaf_condition(path: str, value: Any) -> None:
+                """Append a predicate comparing one JSON path to a leaf value."""
                 if value is None:
                     # Check for null values
-                    filter_conditions.append(f"JSON_VALUE(metadata, '$.{key}') IS NULL")
-                elif isinstance(value, (dict, list)):
-                    # For complex objects, use JSON_EQUAL for exact match
-                    param_name = f"filter_json_{i}"
                     filter_conditions.append(
-                        f"JSON_EQUAL(JSON_QUERY(metadata, '$.{key}'), :{param_name})"
+                        f"JSON_VALUE(metadata, '$.{path}') IS NULL"
+                    )
+                elif isinstance(value, bool):
+                    # Oracle has issues with boolean parameter binding, so use
+                    # literal comparison.
+                    # NOTE: Must check bool BEFORE int/float since bool is a
+                    # subclass of int
+                    bool_str = "true" if value else "false"
+                    filter_conditions.append(
+                        f"JSON_VALUE(metadata, '$.{path}') = '{bool_str}'"
+                    )
+                elif isinstance(value, (int, float)):
+                    # For numeric values, use JSON_VALUE with RETURNING NUMBER
+                    # for proper type comparison
+                    param_name = _next_param()
+                    filter_conditions.append(
+                        f"JSON_VALUE(metadata, '$.{path}' RETURNING NUMBER) = :{param_name}"
+                    )
+                    param_values[param_name] = value
+                elif isinstance(value, list):
+                    # Lists keep exact-match semantics (element order matters)
+                    param_name = _next_param()
+                    filter_conditions.append(
+                        f"JSON_EQUAL(JSON_QUERY(metadata, '$.{path}'), :{param_name})"
                     )
                     param_values[param_name] = json.dumps(value)
                 else:
-                    # Check for simple values - preserve data types for proper comparison
-                    param_name = f"filter_key_{i}"
-                    if isinstance(value, bool):
-                        # For boolean values, use JSON_EXISTS to check for boolean values safely
-                        # Oracle has issues with boolean parameter binding, so use literal comparison
-                        # NOTE: Must check bool BEFORE int/float since bool is subclass of int
-                        bool_str = "true" if value else "false"
-                        filter_conditions.append(
-                            f"JSON_VALUE(metadata, '$.{key}') = '{bool_str}'"
-                        )
-                    elif isinstance(value, (int, float)):
-                        # For numeric values, use JSON_VALUE with RETURNING NUMBER for proper type comparison
-                        filter_conditions.append(
-                            f"JSON_VALUE(metadata, '$.{key}' RETURNING NUMBER) = :{param_name}"
-                        )
-                        param_values[param_name] = value
-                    else:
-                        # For string values, use direct comparison
-                        filter_conditions.append(
-                            f"JSON_VALUE(metadata, '$.{key}') = :{param_name}"
-                        )
-                        param_values[param_name] = value
+                    # For string values, use direct comparison
+                    param_name = _next_param()
+                    filter_conditions.append(
+                        f"JSON_VALUE(metadata, '$.{path}') = :{param_name}"
+                    )
+                    param_values[param_name] = value
+
+            def _expand_filter(path: str, value: Any) -> None:
+                """Flatten dict filters into per-path containment predicates."""
+                if isinstance(value, dict):
+                    if not value:
+                        # {} is contained in any object at this path: only
+                        # require that the path exists.
+                        filter_conditions.append(f"JSON_EXISTS(metadata, '$.{path}')")
+                        return
+                    for sub_key, sub_value in value.items():
+                        # SECURITY: nested keys become part of the JSON path
+                        # expression, so validate them exactly like top-level
+                        # keys to prevent JSON path injection attacks
+                        self._validate_json_path_key(sub_key)
+                        _expand_filter(f"{path}.{sub_key}", sub_value)
+                    return
+                _add_leaf_condition(path, value)
+
+            for key, value in filter.items():
+                # SECURITY: Validate key to prevent JSON path injection attacks
+                self._validate_json_path_key(key)
+                _expand_filter(key, value)
 
             if len(filter_conditions) > 0:
                 wheres.append("(" + " AND ".join(filter_conditions) + ")")

--- a/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/base.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/checkpoint/oracle/base.py
@@ -483,6 +483,16 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
                 param_values[param_name] = value
                 return f"${variable}"
 
+            def _json_path(segments: tuple[str, ...]) -> str:
+                """Render a JSON path whose member names are quoted literals.
+
+                ``("user", "a.b")`` becomes ``$."user"."a.b"`` so a filter key
+                containing a dot addresses a member literally named ``a.b``,
+                matching the LangGraph.js Oracle saver and PostgresSaver rather
+                than being reinterpreted as a nested ``a`` -> ``b`` path.
+                """
+                return "$" + "".join(f'."{segment}"' for segment in segments)
+
             def _is_object_predicate(subject: str) -> str:
                 return " && ".join(
                     f'!({subject}.type() == "{scalar}")'
@@ -541,13 +551,12 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
                     f"{type(value).__name__}."
                 )
 
-            def _add_leaf_condition(path: str, value: Any) -> None:
+            def _add_leaf_condition(segments: tuple[str, ...], value: Any) -> None:
                 """Append a predicate comparing one JSON path to a leaf value."""
+                path = _json_path(segments)
                 if value is None:
                     # Check for null values
-                    filter_conditions.append(
-                        f"JSON_VALUE(metadata, '$.{path}') IS NULL"
-                    )
+                    filter_conditions.append(f"JSON_VALUE(metadata, '{path}') IS NULL")
                 elif isinstance(value, bool):
                     # Oracle has issues with boolean parameter binding, so use
                     # literal comparison.
@@ -555,14 +564,16 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
                     # subclass of int
                     bool_str = "true" if value else "false"
                     filter_conditions.append(
-                        f"JSON_VALUE(metadata, '$.{path}') = '{bool_str}'"
+                        f"JSON_VALUE(metadata, '{path}') = '{bool_str}'"
                     )
                 elif isinstance(value, (int, float)):
+                    if isinstance(value, float) and not math.isfinite(value):
+                        raise ValueError("Metadata filter numbers must be finite.")
                     # For numeric values, use JSON_VALUE with RETURNING NUMBER
                     # for proper type comparison
                     param_name = _next_param()
                     filter_conditions.append(
-                        f"JSON_VALUE(metadata, '$.{path}' RETURNING NUMBER) = :{param_name}"
+                        f"JSON_VALUE(metadata, '{path}' RETURNING NUMBER) = :{param_name}"
                     )
                     param_values[param_name] = value
                 elif isinstance(value, list):
@@ -570,7 +581,7 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
                     # every filter element somewhere (order-insensitive),
                     # matching the LangGraph.js Oracle saver and PostgresSaver.
                     filter_conditions.append(
-                        f"JSON_EXISTS(metadata, '$.{path}?(@.type() == \"array\")')"
+                        f"JSON_EXISTS(metadata, '{path}?(@.type() == \"array\")')"
                     )
                     for element in value:
                         passing: list[str] = []
@@ -580,37 +591,39 @@ class BaseOracleSaver(BaseCheckpointSaver[str]):
                         )
                         filter_conditions.append(
                             f"JSON_EXISTS(metadata, "
-                            f"'$.{path}[*]?({predicate})'{passing_sql})"
+                            f"'{path}[*]?({predicate})'{passing_sql})"
                         )
                 else:
                     # For string values, use direct comparison
                     param_name = _next_param()
                     filter_conditions.append(
-                        f"JSON_VALUE(metadata, '$.{path}') = :{param_name}"
+                        f"JSON_VALUE(metadata, '{path}') = :{param_name}"
                     )
                     param_values[param_name] = value
 
-            def _expand_filter(path: str, value: Any) -> None:
+            def _expand_filter(segments: tuple[str, ...], value: Any) -> None:
                 """Flatten dict filters into per-path containment predicates."""
                 if isinstance(value, dict):
                     if not value:
                         # {} is contained in any object at this path: only
                         # require that the path exists.
-                        filter_conditions.append(f"JSON_EXISTS(metadata, '$.{path}')")
+                        filter_conditions.append(
+                            f"JSON_EXISTS(metadata, '{_json_path(segments)}')"
+                        )
                         return
                     for sub_key, sub_value in value.items():
                         # SECURITY: nested keys become part of the JSON path
                         # expression, so validate them exactly like top-level
                         # keys to prevent JSON path injection attacks
                         self._validate_json_path_key(sub_key)
-                        _expand_filter(f"{path}.{sub_key}", sub_value)
+                        _expand_filter((*segments, sub_key), sub_value)
                     return
-                _add_leaf_condition(path, value)
+                _add_leaf_condition(segments, value)
 
             for key, value in filter.items():
                 # SECURITY: Validate key to prevent JSON path injection attacks
                 self._validate_json_path_key(key)
-                _expand_filter(key, value)
+                _expand_filter((key,), value)
 
             if len(filter_conditions) > 0:
                 wheres.append("(" + " AND ".join(filter_conditions) + ")")

--- a/libs/langgraph-oracledb/tests/test_search_where_key_combinations.py
+++ b/libs/langgraph-oracledb/tests/test_search_where_key_combinations.py
@@ -3,7 +3,6 @@
 """Oracle checkpoint search WHERE clause key coverage."""
 
 import itertools
-import json
 from contextlib import contextmanager
 
 import oracledb
@@ -110,6 +109,19 @@ def generate_key_parameter_combinations():
     ]
 
 
+def _assert_list_containment(where_clause, param_values, path, value) -> None:
+    """Assert containment predicates for list filter values (issue #296)."""
+    assert f"JSON_EXISTS(metadata, '$.{path}?(@.type() == \"array\")')" in where_clause
+    if value:
+        assert f"'$.{path}[*]?(" in where_clause
+    for element in value:
+        if isinstance(element, (dict, list)):
+            continue  # nested elements are covered by their bound leaf params
+        if element is None or isinstance(element, bool) or element == "":
+            continue  # rendered as path literals, not binds
+        assert element in param_values.values()
+
+
 def _assert_containment_paths(where_clause, param_values, path, value) -> None:
     """Assert flattened containment predicates for dict filter values."""
     if not value:
@@ -133,8 +145,7 @@ def _assert_containment_paths(where_clause, param_values, path, value) -> None:
             )
             assert sub_value in param_values.values()
         elif isinstance(sub_value, list):
-            assert f"JSON_EQUAL(JSON_QUERY(metadata, '$.{sub_path}')" in where_clause
-            assert json.dumps(sub_value) in param_values.values()
+            _assert_list_containment(where_clause, param_values, sub_path, sub_value)
         else:
             assert f"JSON_VALUE(metadata, '$.{sub_path}') =" in where_clause
             assert sub_value in param_values.values()
@@ -167,8 +178,7 @@ def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
                     f"JSON_VALUE(metadata, '$.{key}') = '{str(value).lower()}'"
                 ) in where_clause
             elif isinstance(value, list):
-                assert f"JSON_EQUAL(JSON_QUERY(metadata, '$.{key}')" in where_clause
-                assert json.dumps(value) in param_values.values()
+                _assert_list_containment(where_clause, param_values, key, value)
             elif isinstance(value, dict):
                 # dict filters match by containment: flattened per-leaf paths
                 _assert_containment_paths(where_clause, param_values, key, value)

--- a/libs/langgraph-oracledb/tests/test_search_where_key_combinations.py
+++ b/libs/langgraph-oracledb/tests/test_search_where_key_combinations.py
@@ -110,6 +110,36 @@ def generate_key_parameter_combinations():
     ]
 
 
+def _assert_containment_paths(where_clause, param_values, path, value) -> None:
+    """Assert flattened containment predicates for dict filter values."""
+    if not value:
+        assert f"JSON_EXISTS(metadata, '$.{path}')" in where_clause
+        return
+    for sub_key, sub_value in value.items():
+        sub_path = f"{path}.{sub_key}"
+        if isinstance(sub_value, dict):
+            _assert_containment_paths(where_clause, param_values, sub_path, sub_value)
+        elif sub_value is None:
+            assert f"JSON_VALUE(metadata, '$.{sub_path}') IS NULL" in where_clause
+        elif isinstance(sub_value, bool):
+            bool_str = "true" if sub_value else "false"
+            assert (
+                f"JSON_VALUE(metadata, '$.{sub_path}') = '{bool_str}'" in where_clause
+            )
+        elif isinstance(sub_value, int | float):
+            assert (
+                f"JSON_VALUE(metadata, '$.{sub_path}' RETURNING NUMBER) ="
+                in where_clause
+            )
+            assert sub_value in param_values.values()
+        elif isinstance(sub_value, list):
+            assert f"JSON_EQUAL(JSON_QUERY(metadata, '$.{sub_path}')" in where_clause
+            assert json.dumps(sub_value) in param_values.values()
+        else:
+            assert f"JSON_VALUE(metadata, '$.{sub_path}') =" in where_clause
+            assert sub_value in param_values.values()
+
+
 def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
     where_clause, param_values = saver._search_where(config, filter_dict, before)
 
@@ -136,9 +166,12 @@ def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
                 assert (
                     f"JSON_VALUE(metadata, '$.{key}') = '{str(value).lower()}'"
                 ) in where_clause
-            elif isinstance(value, dict | list):
+            elif isinstance(value, list):
                 assert f"JSON_EQUAL(JSON_QUERY(metadata, '$.{key}')" in where_clause
                 assert json.dumps(value) in param_values.values()
+            elif isinstance(value, dict):
+                # dict filters match by containment: flattened per-leaf paths
+                _assert_containment_paths(where_clause, param_values, key, value)
             elif isinstance(value, int | float):
                 assert (
                     f"JSON_VALUE(metadata, '$.{key}' RETURNING NUMBER) ="

--- a/libs/langgraph-oracledb/tests/test_search_where_key_combinations.py
+++ b/libs/langgraph-oracledb/tests/test_search_where_key_combinations.py
@@ -14,6 +14,11 @@ from tests.conftest import DEFAULT_CONNECTION_INFO, skip_if_no_oracle
 _connection_pool = None
 
 
+def _jp(dotted: str) -> str:
+    """Expected quoted JSON path for a dotted test key: a.b -> $."a"."b"."""
+    return "$" + "".join(f'."{seg}"' for seg in dotted.split("."))
+
+
 def get_connection_pool():
     """Get or create a connection pool for real execution checks."""
     global _connection_pool
@@ -111,9 +116,11 @@ def generate_key_parameter_combinations():
 
 def _assert_list_containment(where_clause, param_values, path, value) -> None:
     """Assert containment predicates for list filter values (issue #296)."""
-    assert f"JSON_EXISTS(metadata, '$.{path}?(@.type() == \"array\")')" in where_clause
+    assert (
+        f"JSON_EXISTS(metadata, '{_jp(path)}?(@.type() == \"array\")')" in where_clause
+    )
     if value:
-        assert f"'$.{path}[*]?(" in where_clause
+        assert f"'{_jp(path)}[*]?(" in where_clause
     for element in value:
         if isinstance(element, (dict, list)):
             continue  # nested elements are covered by their bound leaf params
@@ -125,29 +132,30 @@ def _assert_list_containment(where_clause, param_values, path, value) -> None:
 def _assert_containment_paths(where_clause, param_values, path, value) -> None:
     """Assert flattened containment predicates for dict filter values."""
     if not value:
-        assert f"JSON_EXISTS(metadata, '$.{path}')" in where_clause
+        assert f"JSON_EXISTS(metadata, '{_jp(path)}')" in where_clause
         return
     for sub_key, sub_value in value.items():
         sub_path = f"{path}.{sub_key}"
         if isinstance(sub_value, dict):
             _assert_containment_paths(where_clause, param_values, sub_path, sub_value)
         elif sub_value is None:
-            assert f"JSON_VALUE(metadata, '$.{sub_path}') IS NULL" in where_clause
+            assert f"JSON_VALUE(metadata, '{_jp(sub_path)}') IS NULL" in where_clause
         elif isinstance(sub_value, bool):
             bool_str = "true" if sub_value else "false"
             assert (
-                f"JSON_VALUE(metadata, '$.{sub_path}') = '{bool_str}'" in where_clause
+                f"JSON_VALUE(metadata, '{_jp(sub_path)}') = '{bool_str}'"
+                in where_clause
             )
         elif isinstance(sub_value, int | float):
             assert (
-                f"JSON_VALUE(metadata, '$.{sub_path}' RETURNING NUMBER) ="
+                f"JSON_VALUE(metadata, '{_jp(sub_path)}' RETURNING NUMBER) ="
                 in where_clause
             )
             assert sub_value in param_values.values()
         elif isinstance(sub_value, list):
             _assert_list_containment(where_clause, param_values, sub_path, sub_value)
         else:
-            assert f"JSON_VALUE(metadata, '$.{sub_path}') =" in where_clause
+            assert f"JSON_VALUE(metadata, '{_jp(sub_path)}') =" in where_clause
             assert sub_value in param_values.values()
 
 
@@ -172,10 +180,10 @@ def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
     if filter_dict:
         for key, value in filter_dict.items():
             if value is None:
-                assert f"JSON_VALUE(metadata, '$.{key}') IS NULL" in where_clause
+                assert f"JSON_VALUE(metadata, '{_jp(key)}') IS NULL" in where_clause
             elif isinstance(value, bool):
                 assert (
-                    f"JSON_VALUE(metadata, '$.{key}') = '{str(value).lower()}'"
+                    f"JSON_VALUE(metadata, '{_jp(key)}') = '{str(value).lower()}'"
                 ) in where_clause
             elif isinstance(value, list):
                 _assert_list_containment(where_clause, param_values, key, value)
@@ -184,12 +192,12 @@ def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
                 _assert_containment_paths(where_clause, param_values, key, value)
             elif isinstance(value, int | float):
                 assert (
-                    f"JSON_VALUE(metadata, '$.{key}' RETURNING NUMBER) ="
+                    f"JSON_VALUE(metadata, '{_jp(key)}' RETURNING NUMBER) ="
                     in where_clause
                 )
                 assert value in param_values.values()
             else:
-                assert f"JSON_VALUE(metadata, '$.{key}') =" in where_clause
+                assert f"JSON_VALUE(metadata, '{_jp(key)}') =" in where_clause
                 assert value in param_values.values()
 
     if before:

--- a/libs/langgraph-oracledb/tests/test_search_where_nested_containment.py
+++ b/libs/langgraph-oracledb/tests/test_search_where_nested_containment.py
@@ -1,12 +1,13 @@
 # type: ignore
 
-"""Nested-path containment matching for dict metadata filters (issue #290).
+"""Containment matching for checkpoint metadata filters (issues #290, #296).
 
 Dict filter values match by recursive containment — the filter
 {"nested": {"b": {"c": True}}} matches metadata
-{"nested": {"a": 1, "b": {"c": True}}} — aligning the Python saver with the
-LangGraph.js Oracle saver and PostgresSaver (`metadata @> filter`). Lists
-keep JSON_EQUAL exact-match (positional) semantics.
+{"nested": {"a": 1, "b": {"c": True}}} — and list values match any stored
+array containing every filter element regardless of order or duplicates,
+aligning the Python saver with the LangGraph.js Oracle saver and
+PostgresSaver (`metadata @> filter`).
 """
 
 import pytest
@@ -47,10 +48,42 @@ def test_nested_leaf_types_use_typed_predicates() -> None:
     assert "run-1" in params.values()
 
 
-def test_lists_keep_exact_match_semantics() -> None:
+def test_lists_use_containment_semantics() -> None:
     where, params = _where({"tags": [1, 2], "nested": {"items": ["a"]}})
-    assert "JSON_EQUAL(JSON_QUERY(metadata, '$.tags')" in where
-    assert "JSON_EQUAL(JSON_QUERY(metadata, '$.nested.items')" in where
+    assert "JSON_EQUAL" not in where
+    assert "JSON_EXISTS(metadata, '$.tags?(@.type() == \"array\")')" in where
+    assert '\'$.tags[*]?(@.type() == "number" && @ == $FILTER_KEY_' in where
+    assert "JSON_EXISTS(metadata, '$.nested.items?(@.type() == \"array\")')" in where
+    assert '\'$.nested.items[*]?(@.type() == "string" && @ == $FILTER_KEY_' in where
+    assert 1 in params.values()
+    assert 2 in params.values()
+    assert "a" in params.values()
+
+
+def test_list_literal_elements_render_without_binds() -> None:
+    where, params = _where({"flags": [True, None, ""]})
+    assert '@.type() == "boolean" && @ == true' in where
+    assert '@.type() == "null" && @ == null' in where
+    assert '@.type() == "string" && @ == ""' in where
+    assert params == {}
+
+
+def test_list_dict_elements_compile_to_recursive_containment() -> None:
+    where, params = _where({"events": [{"kind": "start", "attempt": 1}]})
+    assert '@."kind"' in where
+    assert '@."attempt"' in where
+    assert "start" in params.values()
+    assert 1 in params.values()
+
+
+def test_list_dict_element_keys_are_validated_against_path_injection() -> None:
+    with pytest.raises(ValueError, match="Illegal metadata key"):
+        _where({"events": [{"bad'key": 1}]})
+
+
+def test_list_non_finite_numbers_are_rejected() -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        _where({"values": [float("inf")]})
 
 
 def test_empty_dict_requires_path_existence() -> None:
@@ -152,17 +185,47 @@ def test_nested_filter_combined_with_scalar(saver_name: str, test_data) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool"])
-def test_list_values_still_require_exact_match(saver_name: str, test_data) -> None:
+def test_list_values_match_by_containment(saver_name: str, test_data) -> None:
+    """Issue #296: align list filters with LangGraph.js and PostgresSaver."""
     with _sync_saver(saver_name) as saver:
         _put_checkpoints(
             saver,
-            "thread-list-exact",
-            [{"tags": [1, 2, 3]}, {"tags": [1, 2]}],
+            "thread-list-containment",
+            [{"tags": [1, 2, 3]}, {"tags": [1, 2]}, {"tags": "not-an-array"}],
         )
 
-        results = list(saver.list(None, filter={"tags": [1, 2]}))
-        assert len(results) == 1
-        assert results[0].metadata["tags"] == [1, 2]
+        # Subset and order-insensitive matches include both array rows.
+        assert len(list(saver.list(None, filter={"tags": [1, 2]}))) == 2
+        assert len(list(saver.list(None, filter={"tags": [2, 1]}))) == 2
+        assert len(list(saver.list(None, filter={"tags": [1]}))) == 2
+        # Elements absent from the stored arrays match nothing.
+        assert len(list(saver.list(None, filter={"tags": [4]}))) == 0
+        assert len(list(saver.list(None, filter={"tags": [1, 4]}))) == 0
+        # An empty list matches any stored array, but never a scalar.
+        assert len(list(saver.list(None, filter={"tags": []}))) == 2
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
+def test_list_containment_matches_typed_elements(saver_name: str, test_data) -> None:
+    with _sync_saver(saver_name) as saver:
+        _put_checkpoints(
+            saver,
+            "thread-list-typed",
+            [
+                {"mixed": ["a", 2, True, None, {"kind": "start", "attempt": 1}]},
+                {"mixed": ["b", 3, False]},
+            ],
+        )
+
+        assert len(list(saver.list(None, filter={"mixed": ["a"]}))) == 1
+        assert len(list(saver.list(None, filter={"mixed": [2]}))) == 1
+        assert len(list(saver.list(None, filter={"mixed": [True]}))) == 1
+        assert len(list(saver.list(None, filter={"mixed": [None]}))) == 1
+        # Dict elements match by recursive containment, not exact equality.
+        assert len(list(saver.list(None, filter={"mixed": [{"kind": "start"}]}))) == 1
+        assert len(list(saver.list(None, filter={"mixed": [{"kind": "stop"}]}))) == 0
+        # The boolean True must not match the number 2 or the string "a".
+        assert len(list(saver.list(None, filter={"mixed": [False]}))) == 1
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool"])

--- a/libs/langgraph-oracledb/tests/test_search_where_nested_containment.py
+++ b/libs/langgraph-oracledb/tests/test_search_where_nested_containment.py
@@ -1,0 +1,191 @@
+# type: ignore
+
+"""Nested-path containment matching for dict metadata filters (issue #290).
+
+Dict filter values match by recursive containment — the filter
+{"nested": {"b": {"c": True}}} matches metadata
+{"nested": {"a": 1, "b": {"c": True}}} — aligning the Python saver with the
+LangGraph.js Oracle saver and PostgresSaver (`metadata @> filter`). Lists
+keep JSON_EQUAL exact-match (positional) semantics.
+"""
+
+import pytest
+from langgraph.checkpoint.base import (
+    empty_checkpoint,
+)
+
+from langgraph_oracledb.checkpoint.oracle.sync import OracleSaver
+from tests.conftest_checkpointer import (
+    _async_saver,
+    _sync_saver,
+)
+
+# ---------------------------------------------------------------------------
+# SQL generation (no database required)
+# ---------------------------------------------------------------------------
+
+
+def _where(filter_):
+    saver = OracleSaver(conn=None)
+    return saver._search_where(None, filter_)
+
+
+def test_nested_dict_flattens_to_json_paths() -> None:
+    where, params = _where({"nested": {"b": {"c": True}}})
+    assert "JSON_VALUE(metadata, '$.nested.b.c') = 'true'" in where
+    assert "JSON_EQUAL" not in where
+
+
+def test_nested_leaf_types_use_typed_predicates() -> None:
+    where, params = _where(
+        {"level": {"depth": 3}, "meta": {"name": "run-1"}, "gone": {"x": None}}
+    )
+    assert "JSON_VALUE(metadata, '$.level.depth' RETURNING NUMBER)" in where
+    assert "JSON_VALUE(metadata, '$.meta.name') = :" in where
+    assert "JSON_VALUE(metadata, '$.gone.x') IS NULL" in where
+    assert 3 in params.values()
+    assert "run-1" in params.values()
+
+
+def test_lists_keep_exact_match_semantics() -> None:
+    where, params = _where({"tags": [1, 2], "nested": {"items": ["a"]}})
+    assert "JSON_EQUAL(JSON_QUERY(metadata, '$.tags')" in where
+    assert "JSON_EQUAL(JSON_QUERY(metadata, '$.nested.items')" in where
+
+
+def test_empty_dict_requires_path_existence() -> None:
+    where, _ = _where({"empty": {}})
+    assert "JSON_EXISTS(metadata, '$.empty')" in where
+
+
+def test_nested_keys_are_validated_against_path_injection() -> None:
+    with pytest.raises(ValueError, match="Illegal metadata key"):
+        _where({"nested": {"bad'key": 1}})
+
+
+def test_scalar_filters_unchanged() -> None:
+    where, params = _where({"source": "loop", "step": 2, "active": True})
+    assert "JSON_VALUE(metadata, '$.source') = :" in where
+    assert "JSON_VALUE(metadata, '$.step' RETURNING NUMBER) = :" in where
+    assert "JSON_VALUE(metadata, '$.active') = 'true'" in where
+
+
+# ---------------------------------------------------------------------------
+# End-to-end against Oracle
+# ---------------------------------------------------------------------------
+
+
+def _put_checkpoints(saver, thread_id, metadatas):
+    """Store one checkpoint per metadata dict on the given thread."""
+    config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    for metadata in metadatas:
+        checkpoint = empty_checkpoint()
+        cfg = {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+        saver.put(cfg, checkpoint, metadata, {})
+    return config
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
+def test_partial_nested_filter_matches_containing_metadata(
+    saver_name: str, test_data
+) -> None:
+    """The exact scenario from issue #290."""
+    with _sync_saver(saver_name) as saver:
+        _put_checkpoints(
+            saver,
+            "thread-containment",
+            [
+                {"nested": {"a": 1, "b": {"c": True}}, "kind": "match"},
+                {"nested": {"a": 1, "b": {"c": False}}, "kind": "no-match"},
+                {"nested": {"a": 1}, "kind": "missing-path"},
+            ],
+        )
+
+        results = list(saver.list(None, filter={"nested": {"b": {"c": True}}}))
+        assert len(results) == 1
+        assert results[0].metadata["kind"] == "match"
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
+def test_exact_dict_filter_still_matches_equal_metadata(
+    saver_name: str, test_data
+) -> None:
+    """Exact filters are contained in equal metadata: old behavior preserved."""
+    with _sync_saver(saver_name) as saver:
+        complex_dict = {"nested": {"key": "value", "count": 5}}
+        _put_checkpoints(
+            saver,
+            "thread-exact-still-works",
+            [{"config": complex_dict}, {"config": {"other": True}}],
+        )
+
+        results = list(saver.list(None, filter={"config": complex_dict}))
+        assert len(results) == 1
+        assert results[0].metadata["config"] == complex_dict
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
+def test_nested_filter_combined_with_scalar(saver_name: str, test_data) -> None:
+    with _sync_saver(saver_name) as saver:
+        _put_checkpoints(
+            saver,
+            "thread-combined",
+            [
+                {"source": "loop", "run": {"phase": "b", "attempt": 2}},
+                {"source": "loop", "run": {"phase": "a", "attempt": 2}},
+                {"source": "input", "run": {"phase": "b", "attempt": 2}},
+            ],
+        )
+
+        results = list(
+            saver.list(None, filter={"source": "loop", "run": {"phase": "b"}})
+        )
+        assert len(results) == 1
+        assert results[0].metadata["run"]["phase"] == "b"
+        assert results[0].metadata["source"] == "loop"
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
+def test_list_values_still_require_exact_match(saver_name: str, test_data) -> None:
+    with _sync_saver(saver_name) as saver:
+        _put_checkpoints(
+            saver,
+            "thread-list-exact",
+            [{"tags": [1, 2, 3]}, {"tags": [1, 2]}],
+        )
+
+        results = list(saver.list(None, filter={"tags": [1, 2]}))
+        assert len(results) == 1
+        assert results[0].metadata["tags"] == [1, 2]
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool"])
+async def test_async_partial_nested_filter(saver_name: str, test_data) -> None:
+    """AsyncOracleSaver shares _search_where: containment works there too."""
+    async with _async_saver(saver_name) as saver:
+        thread_id = "thread-containment-async"
+        for metadata in [
+            {"nested": {"a": 1, "b": {"c": True}}, "kind": "match"},
+            {"nested": {"b": {"c": False}}, "kind": "no-match"},
+        ]:
+            checkpoint = empty_checkpoint()
+            cfg = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "checkpoint_ns": "",
+                    "checkpoint_id": checkpoint["id"],
+                }
+            }
+            await saver.aput(cfg, checkpoint, metadata, {})
+
+        results = [
+            c async for c in saver.alist(None, filter={"nested": {"b": {"c": True}}})
+        ]
+        assert len(results) == 1
+        assert results[0].metadata["kind"] == "match"

--- a/libs/langgraph-oracledb/tests/test_search_where_nested_containment.py
+++ b/libs/langgraph-oracledb/tests/test_search_where_nested_containment.py
@@ -33,7 +33,7 @@ def _where(filter_):
 
 def test_nested_dict_flattens_to_json_paths() -> None:
     where, params = _where({"nested": {"b": {"c": True}}})
-    assert "JSON_VALUE(metadata, '$.nested.b.c') = 'true'" in where
+    assert 'JSON_VALUE(metadata, \'$."nested"."b"."c"\') = \'true\'' in where
     assert "JSON_EQUAL" not in where
 
 
@@ -41,9 +41,9 @@ def test_nested_leaf_types_use_typed_predicates() -> None:
     where, params = _where(
         {"level": {"depth": 3}, "meta": {"name": "run-1"}, "gone": {"x": None}}
     )
-    assert "JSON_VALUE(metadata, '$.level.depth' RETURNING NUMBER)" in where
-    assert "JSON_VALUE(metadata, '$.meta.name') = :" in where
-    assert "JSON_VALUE(metadata, '$.gone.x') IS NULL" in where
+    assert 'JSON_VALUE(metadata, \'$."level"."depth"\' RETURNING NUMBER)' in where
+    assert 'JSON_VALUE(metadata, \'$."meta"."name"\') = :' in where
+    assert 'JSON_VALUE(metadata, \'$."gone"."x"\') IS NULL' in where
     assert 3 in params.values()
     assert "run-1" in params.values()
 
@@ -51,10 +51,12 @@ def test_nested_leaf_types_use_typed_predicates() -> None:
 def test_lists_use_containment_semantics() -> None:
     where, params = _where({"tags": [1, 2], "nested": {"items": ["a"]}})
     assert "JSON_EQUAL" not in where
-    assert "JSON_EXISTS(metadata, '$.tags?(@.type() == \"array\")')" in where
-    assert '\'$.tags[*]?(@.type() == "number" && @ == $FILTER_KEY_' in where
-    assert "JSON_EXISTS(metadata, '$.nested.items?(@.type() == \"array\")')" in where
-    assert '\'$.nested.items[*]?(@.type() == "string" && @ == $FILTER_KEY_' in where
+    assert 'JSON_EXISTS(metadata, \'$."tags"?(@.type() == "array")\')' in where
+    assert '\'$."tags"[*]?(@.type() == "number" && @ == $FILTER_KEY_' in where
+    assert (
+        'JSON_EXISTS(metadata, \'$."nested"."items"?(@.type() == "array")\')' in where
+    )
+    assert '\'$."nested"."items"[*]?(@.type() == "string" && @ == $FILTER_KEY_' in where
     assert 1 in params.values()
     assert 2 in params.values()
     assert "a" in params.values()
@@ -88,7 +90,7 @@ def test_list_non_finite_numbers_are_rejected() -> None:
 
 def test_empty_dict_requires_path_existence() -> None:
     where, _ = _where({"empty": {}})
-    assert "JSON_EXISTS(metadata, '$.empty')" in where
+    assert "JSON_EXISTS(metadata, '$.\"empty\"')" in where
 
 
 def test_nested_keys_are_validated_against_path_injection() -> None:
@@ -96,11 +98,35 @@ def test_nested_keys_are_validated_against_path_injection() -> None:
         _where({"nested": {"bad'key": 1}})
 
 
+def test_dotted_keys_are_literal_member_names() -> None:
+    """A key containing a dot addresses a member literally named ``a.b``.
+
+    Every path segment is rendered as a quoted member name, so dotted keys are
+    not reinterpreted as nested paths -- at the top level, inside nested dicts,
+    and inside list elements alike. This matches the LangGraph.js Oracle saver
+    and PostgresSaver.
+    """
+    where, params = _where({"a.b": 1, "user": {"x.y": "v", "tags": [{"k.k": 2}]}})
+    assert "JSON_VALUE(metadata, '$.\"a.b\"' RETURNING NUMBER) = :" in where
+    assert 'JSON_VALUE(metadata, \'$."user"."x.y"\') = :' in where
+    assert '@."k.k"' in where
+    assert "'$.a.b'" not in where and "$.user.x.y" not in where
+    assert 1 in params.values() and "v" in params.values() and 2 in params.values()
+
+
+def test_top_level_non_finite_numbers_are_rejected() -> None:
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError, match="must be finite"):
+            _where({"score": bad})
+        with pytest.raises(ValueError, match="must be finite"):
+            _where({"nested": {"score": bad}})
+
+
 def test_scalar_filters_unchanged() -> None:
     where, params = _where({"source": "loop", "step": 2, "active": True})
-    assert "JSON_VALUE(metadata, '$.source') = :" in where
-    assert "JSON_VALUE(metadata, '$.step' RETURNING NUMBER) = :" in where
-    assert "JSON_VALUE(metadata, '$.active') = 'true'" in where
+    assert "JSON_VALUE(metadata, '$.\"source\"') = :" in where
+    assert "JSON_VALUE(metadata, '$.\"step\"' RETURNING NUMBER) = :" in where
+    assert "JSON_VALUE(metadata, '$.\"active\"') = 'true'" in where
 
 
 # ---------------------------------------------------------------------------

--- a/libs/langgraph-oracledb/tests/test_search_where_parameter_combinations.py
+++ b/libs/langgraph-oracledb/tests/test_search_where_parameter_combinations.py
@@ -3,7 +3,6 @@
 """Oracle checkpoint search WHERE clause parameter coverage."""
 
 import itertools
-import json
 from contextlib import contextmanager
 
 import oracledb
@@ -103,10 +102,10 @@ def generate_parameter_combinations():
         {"mixed": "active", "count": 1, "enabled": False},
         {"complex_dict": {"nested": {"deep": {"value": 123}}}},
         {"dict": {"key": "val"}, "list": [1, 2]},
+        {"list_key": [1, 2, "three"]},
+        {"complex_list": [{"item": 1}, {"item": 2}, [3, 4]]},
         # {"float_key": 3.14},
         # {"bool_false": False},
-        # {"list_key": [1, 2, "three"]},
-        # {"complex_list": [{"item": 1}, {"item": 2}, [3, 4]]},
         # {"empty_string": ""},
         # {"zero_int": 0},
         # {"zero_float": 0.0},
@@ -154,6 +153,19 @@ def _count_leaf_params(value) -> int:
         return 0
     if isinstance(value, dict):
         return sum(_count_leaf_params(v) for v in value.values())
+    if isinstance(value, list):
+        return sum(_count_list_element_params(v) for v in value)
+    return 1
+
+
+def _count_list_element_params(value) -> int:
+    """Bind count for one list element under containment (issue #296)."""
+    if value is None or isinstance(value, bool) or value == "":
+        return 0
+    if isinstance(value, dict):
+        return sum(_count_list_element_params(v) for v in value.values())
+    if isinstance(value, list):
+        return sum(_count_list_element_params(v) for v in value)
     return 1
 
 
@@ -161,6 +173,19 @@ def _expected_filter_param_count(filter_dict) -> int:
     if not filter_dict:
         return 0
     return sum(_count_leaf_params(value) for value in filter_dict.values())
+
+
+def _assert_list_containment(where_clause, param_values, path, value) -> None:
+    """Assert containment predicates for list filter values (issue #296)."""
+    assert f"JSON_EXISTS(metadata, '$.{path}?(@.type() == \"array\")')" in where_clause
+    if value:
+        assert f"'$.{path}[*]?(" in where_clause
+    for element in value:
+        if isinstance(element, (dict, list)):
+            continue  # nested elements are covered by their bound leaf params
+        if element is None or isinstance(element, bool) or element == "":
+            continue  # rendered as path literals, not binds
+        assert element in param_values.values()
 
 
 def _assert_containment_paths(where_clause, param_values, path, value) -> None:
@@ -186,8 +211,7 @@ def _assert_containment_paths(where_clause, param_values, path, value) -> None:
             )
             assert sub_value in param_values.values()
         elif isinstance(sub_value, list):
-            assert f"JSON_EQUAL(JSON_QUERY(metadata, '$.{sub_path}')" in where_clause
-            assert json.dumps(sub_value) in param_values.values()
+            _assert_list_containment(where_clause, param_values, sub_path, sub_value)
         else:
             assert f"JSON_VALUE(metadata, '$.{sub_path}') =" in where_clause
             assert sub_value in param_values.values()
@@ -233,8 +257,7 @@ def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
                 bool_str = "true" if value else "false"
                 assert f"JSON_VALUE(metadata, '$.{key}') = '{bool_str}'" in where_clause
             elif isinstance(value, list):
-                assert f"JSON_EQUAL(JSON_QUERY(metadata, '$.{key}')" in where_clause
-                assert json.dumps(value) in param_values.values()
+                _assert_list_containment(where_clause, param_values, key, value)
             elif isinstance(value, dict):
                 # dict filters match by containment: flattened per-leaf paths
                 _assert_containment_paths(where_clause, param_values, key, value)

--- a/libs/langgraph-oracledb/tests/test_search_where_parameter_combinations.py
+++ b/libs/langgraph-oracledb/tests/test_search_where_parameter_combinations.py
@@ -101,10 +101,11 @@ def generate_parameter_combinations():
         {"null_key": None},
         {"dict_key": {"nested": "value"}},
         {"mixed": "active", "count": 1, "enabled": False},
+        {"complex_dict": {"nested": {"deep": {"value": 123}}}},
+        {"dict": {"key": "val"}, "list": [1, 2]},
         # {"float_key": 3.14},
         # {"bool_false": False},
         # {"list_key": [1, 2, "three"]},
-        # {"complex_dict": {"nested": {"deep": {"value": 123}}}},
         # {"complex_list": [{"item": 1}, {"item": 2}, [3, 4]]},
         # {"empty_string": ""},
         # {"zero_int": 0},
@@ -147,15 +148,49 @@ def generate_parameter_combinations():
     ]
 
 
+def _count_leaf_params(value) -> int:
+    """Bind-parameter count for one filter value under containment flattening."""
+    if value is None or isinstance(value, bool):
+        return 0
+    if isinstance(value, dict):
+        return sum(_count_leaf_params(v) for v in value.values())
+    return 1
+
+
 def _expected_filter_param_count(filter_dict) -> int:
     if not filter_dict:
         return 0
-    count = 0
-    for value in filter_dict.values():
-        if value is None or isinstance(value, bool):
-            continue
-        count += 1
-    return count
+    return sum(_count_leaf_params(value) for value in filter_dict.values())
+
+
+def _assert_containment_paths(where_clause, param_values, path, value) -> None:
+    """Assert flattened containment predicates for dict filter values."""
+    if not value:
+        assert f"JSON_EXISTS(metadata, '$.{path}')" in where_clause
+        return
+    for sub_key, sub_value in value.items():
+        sub_path = f"{path}.{sub_key}"
+        if isinstance(sub_value, dict):
+            _assert_containment_paths(where_clause, param_values, sub_path, sub_value)
+        elif sub_value is None:
+            assert f"JSON_VALUE(metadata, '$.{sub_path}') IS NULL" in where_clause
+        elif isinstance(sub_value, bool):
+            bool_str = "true" if sub_value else "false"
+            assert (
+                f"JSON_VALUE(metadata, '$.{sub_path}') = '{bool_str}'" in where_clause
+            )
+        elif isinstance(sub_value, int | float):
+            assert (
+                f"JSON_VALUE(metadata, '$.{sub_path}' RETURNING NUMBER) ="
+                in where_clause
+            )
+            assert sub_value in param_values.values()
+        elif isinstance(sub_value, list):
+            assert f"JSON_EQUAL(JSON_QUERY(metadata, '$.{sub_path}')" in where_clause
+            assert json.dumps(sub_value) in param_values.values()
+        else:
+            assert f"JSON_VALUE(metadata, '$.{sub_path}') =" in where_clause
+            assert sub_value in param_values.values()
 
 
 def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
@@ -197,9 +232,12 @@ def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
             elif isinstance(value, bool):
                 bool_str = "true" if value else "false"
                 assert f"JSON_VALUE(metadata, '$.{key}') = '{bool_str}'" in where_clause
-            elif isinstance(value, dict | list):
+            elif isinstance(value, list):
                 assert f"JSON_EQUAL(JSON_QUERY(metadata, '$.{key}')" in where_clause
                 assert json.dumps(value) in param_values.values()
+            elif isinstance(value, dict):
+                # dict filters match by containment: flattened per-leaf paths
+                _assert_containment_paths(where_clause, param_values, key, value)
             elif isinstance(value, int | float):
                 assert (
                     f"JSON_VALUE(metadata, '$.{key}' RETURNING NUMBER) ="

--- a/libs/langgraph-oracledb/tests/test_search_where_parameter_combinations.py
+++ b/libs/langgraph-oracledb/tests/test_search_where_parameter_combinations.py
@@ -14,6 +14,11 @@ from tests.conftest import DEFAULT_CONNECTION_INFO, skip_if_no_oracle
 _connection_pool = None
 
 
+def _jp(dotted: str) -> str:
+    """Expected quoted JSON path for a dotted test key: a.b -> $."a"."b"."""
+    return "$" + "".join(f'."{seg}"' for seg in dotted.split("."))
+
+
 def get_connection_pool():
     """Get or create a connection pool for real execution checks."""
     global _connection_pool
@@ -177,9 +182,11 @@ def _expected_filter_param_count(filter_dict) -> int:
 
 def _assert_list_containment(where_clause, param_values, path, value) -> None:
     """Assert containment predicates for list filter values (issue #296)."""
-    assert f"JSON_EXISTS(metadata, '$.{path}?(@.type() == \"array\")')" in where_clause
+    assert (
+        f"JSON_EXISTS(metadata, '{_jp(path)}?(@.type() == \"array\")')" in where_clause
+    )
     if value:
-        assert f"'$.{path}[*]?(" in where_clause
+        assert f"'{_jp(path)}[*]?(" in where_clause
     for element in value:
         if isinstance(element, (dict, list)):
             continue  # nested elements are covered by their bound leaf params
@@ -191,29 +198,30 @@ def _assert_list_containment(where_clause, param_values, path, value) -> None:
 def _assert_containment_paths(where_clause, param_values, path, value) -> None:
     """Assert flattened containment predicates for dict filter values."""
     if not value:
-        assert f"JSON_EXISTS(metadata, '$.{path}')" in where_clause
+        assert f"JSON_EXISTS(metadata, '{_jp(path)}')" in where_clause
         return
     for sub_key, sub_value in value.items():
         sub_path = f"{path}.{sub_key}"
         if isinstance(sub_value, dict):
             _assert_containment_paths(where_clause, param_values, sub_path, sub_value)
         elif sub_value is None:
-            assert f"JSON_VALUE(metadata, '$.{sub_path}') IS NULL" in where_clause
+            assert f"JSON_VALUE(metadata, '{_jp(sub_path)}') IS NULL" in where_clause
         elif isinstance(sub_value, bool):
             bool_str = "true" if sub_value else "false"
             assert (
-                f"JSON_VALUE(metadata, '$.{sub_path}') = '{bool_str}'" in where_clause
+                f"JSON_VALUE(metadata, '{_jp(sub_path)}') = '{bool_str}'"
+                in where_clause
             )
         elif isinstance(sub_value, int | float):
             assert (
-                f"JSON_VALUE(metadata, '$.{sub_path}' RETURNING NUMBER) ="
+                f"JSON_VALUE(metadata, '{_jp(sub_path)}' RETURNING NUMBER) ="
                 in where_clause
             )
             assert sub_value in param_values.values()
         elif isinstance(sub_value, list):
             _assert_list_containment(where_clause, param_values, sub_path, sub_value)
         else:
-            assert f"JSON_VALUE(metadata, '$.{sub_path}') =" in where_clause
+            assert f"JSON_VALUE(metadata, '{_jp(sub_path)}') =" in where_clause
             assert sub_value in param_values.values()
 
 
@@ -252,10 +260,12 @@ def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
 
         for key, value in filter_dict.items():
             if value is None:
-                assert f"JSON_VALUE(metadata, '$.{key}') IS NULL" in where_clause
+                assert f"JSON_VALUE(metadata, '{_jp(key)}') IS NULL" in where_clause
             elif isinstance(value, bool):
                 bool_str = "true" if value else "false"
-                assert f"JSON_VALUE(metadata, '$.{key}') = '{bool_str}'" in where_clause
+                assert (
+                    f"JSON_VALUE(metadata, '{_jp(key)}') = '{bool_str}'" in where_clause
+                )
             elif isinstance(value, list):
                 _assert_list_containment(where_clause, param_values, key, value)
             elif isinstance(value, dict):
@@ -263,12 +273,12 @@ def _assert_search_where_shape(saver, config, filter_dict, before) -> None:
                 _assert_containment_paths(where_clause, param_values, key, value)
             elif isinstance(value, int | float):
                 assert (
-                    f"JSON_VALUE(metadata, '$.{key}' RETURNING NUMBER) ="
+                    f"JSON_VALUE(metadata, '{_jp(key)}' RETURNING NUMBER) ="
                     in where_clause
                 )
                 assert value in param_values.values()
             else:
-                assert f"JSON_VALUE(metadata, '$.{key}') =" in where_clause
+                assert f"JSON_VALUE(metadata, '{_jp(key)}') =" in where_clause
                 assert value in param_values.values()
 
     if before:


### PR DESCRIPTION
## Summary

Closes #290 — the follow-up @fileames raised on #280.
Closes #296 — list-filter divergence from the LangGraph.js Oracle saver, found while reviewing langchain-ai/langgraphjs#2660.

Metadata filters in `list()`/`alist()` previously required **exact** `JSON_EQUAL` matches: dict filters didn't match metadata containing extra keys, and list filters required exact positional equality. Both diverged from the LangGraph.js Oracle saver and from `PostgresSaver`'s containment semantics (`metadata @> filter`).

## Changes

### Dict containment (#290)

`_search_where()` flattens dict filter values into per-leaf JSON-path predicates — the same nested-path approach #280 applied to OracleVS:

```sql
JSON_VALUE(metadata, '$.nested.b.c') = 'true'
```

- recurses through arbitrarily deep dicts; **every nested key** is validated with the same JSON-path-injection check as top-level keys
- leaf typing preserved: `RETURNING NUMBER` for numerics, literal `'true'`/`'false'` for booleans, `IS NULL` for nulls, bind params for strings
- `{}` asserts path existence via `JSON_EXISTS`
- sync (`OracleSaver`) and async (`AsyncOracleSaver`) share the implementation

### List containment (#296)

List filter values now match any stored array that **contains every filter element**, regardless of order or duplicates — the semantics the JS saver and `PostgresSaver` already use. The stored value must be an array (scalars never match), and elements compare by JSON type:

```sql
JSON_EXISTS(metadata, '$.tags?(@.type() == "array")')
JSON_EXISTS(metadata, '$.tags[*]?(@.type() == "string" && @ == $FILTER_KEY_0)'
            PASSING :filter_key_0 AS "FILTER_KEY_0")
```

- string/number elements are bound through the `PASSING` clause; only our own literals (`true`, `false`, `null`, `""`) reach the path text
- dict elements match by recursive containment, array elements by nested containment; nested member names go through the same injection validation
- `[]` matches any stored array at the path
- verified live against the JS saver on shared tables: for metadata `{"tags": ["a","b"]}`, the filters `["a","b"]` / `["b","a"]` / `["a"]` now return identical results from both languages (previously Python returned 1/0/0 vs JS 1/1/1), and a seven-case typed-element matrix (dict containment, dict miss, `null`, `true`/`false` discrimination, numbers, absent nested arrays) agrees exactly

Backward compatibility: an exact-match filter is trivially contained in equal metadata, so every previously-matching filter still matches — the change only widens matching, it never narrows it.

## Tests

- `tests/test_search_where_nested_containment.py`: SQL-generation assertions (no DB) + live sync/async containment tests — dict scenarios from #290 plus list containment (order-insensitivity, subsets, non-matching elements, empty-list, typed elements incl. dict-in-list), injection checks for nested dict keys and dict-in-list member names, non-finite number rejection
- `test_search_where_key_combinations.py` / `test_search_where_parameter_combinations.py` updated to the containment contract; previously-disabled complex list cases (`[1, 2, "three"]`, `[{"item": 1}, {"item": 2}, [3, 4]]`) re-enabled
- Full package suite verified against a local Oracle 26ai Free container (per-file, see note), all green

Note: this package has no repo CI job, so the verification above was run locally. On a resource-constrained container (default `processes=200`) the suite must be run file-by-file or with pauses — running all files back-to-back exhausts DB processes and fails spuriously with `ORA-12516`.
