### PR TITLE
fix(langgraph-oracledb): coerce Decimal index params before comparison

### DIFF
--- a/libs/langgraph-oracledb/langgraph_oracledb/store/oracle/base.py
+++ b/libs/langgraph-oracledb/langgraph_oracledb/store/oracle/base.py
@@ -11,6 +11,7 @@ import threading
 from collections import defaultdict
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
+from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -349,8 +350,29 @@ def _detect_dimensions(config) -> int:
     return config["dims"]
 
 
+def _coerce_decimals(obj: Any) -> Any:
+    """Recursively convert ``decimal.Decimal`` values to ``int``/``float``.
+
+    Oracle's native JSON type deserializes every number as ``Decimal``, which
+    ``json.dumps`` cannot encode. The checkpoint saver has the same helper for
+    the same reason; see ``BaseOracleSaver._coerce_decimals``.
+    """
+    if isinstance(obj, Decimal):
+        return int(obj) if obj == obj.to_integral_value() else float(obj)
+    if isinstance(obj, dict):
+        return {k: _coerce_decimals(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_coerce_decimals(v) for v in obj]
+    return obj
+
+
 def _normalize_existing_index_params(existing_params: Any) -> dict[str, Any]:
-    """Normalize persisted store config params into a plain dict."""
+    """Normalize persisted store config params into a plain dict.
+
+    The result must be JSON-serializable: callers compare configurations by
+    ``json.dumps``-ing this dict, and numbers read back from the ``index_params``
+    JSON column arrive as ``Decimal``.
+    """
     if hasattr(existing_params, "read"):
         existing_params = existing_params.read()
 
@@ -358,7 +380,7 @@ def _normalize_existing_index_params(existing_params: Any) -> dict[str, Any]:
         existing_params = existing_params.decode()
 
     if isinstance(existing_params, Mapping):
-        return dict(existing_params)
+        return _coerce_decimals(dict(existing_params))
 
     if isinstance(existing_params, str):
         try:
@@ -373,7 +395,7 @@ def _normalize_existing_index_params(existing_params: Any) -> dict[str, Any]:
                 "Stored index configuration must decode to a JSON object. "
                 "Use a different table_suffix or drop existing tables."
             )
-        return dict(parsed)
+        return _coerce_decimals(dict(parsed))
 
     raise ValueError(
         "Stored index configuration has an unsupported format. "

--- a/libs/langgraph-oracledb/pyproject.toml
+++ b/libs/langgraph-oracledb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-oracledb"
-version = "1.0.1"
+version = "1.0.2"
 description = "An integration package connecting Oracle Database and LangGraph"
 readme = "README.md"
 license = "UPL-1.0"

--- a/libs/langgraph-oracledb/tests/test_store_config_isolation.py
+++ b/libs/langgraph-oracledb/tests/test_store_config_isolation.py
@@ -1,6 +1,8 @@
 """Test configuration isolation and table suffix functionality."""
 
+import json
 from contextlib import asynccontextmanager, contextmanager
+from decimal import Decimal
 from unittest.mock import Mock
 from uuid import uuid4
 
@@ -11,6 +13,7 @@ from langgraph_oracledb.store.oracle.base import (
     OracleStore,
     _generate_suffix,
     _get_parameters_clause,
+    _normalize_existing_index_params,
 )
 
 
@@ -671,3 +674,57 @@ def test_non_vector_store_suffix():
         store2.teardown()
         with conn.cursor() as cur:
             cur.execute("drop table if exists STORE_CONFIGS purge")
+
+
+class TestNormalizeExistingIndexParams:
+    """The normalized params are json.dumps()-ed by _validate_configuration.
+
+    Oracle's JSON type returns every number as Decimal, so anything left in the
+    result that json cannot encode makes setup() fail on the second run.
+    """
+
+    def test_coerces_decimals_from_a_mapping(self):
+        params = _normalize_existing_index_params(
+            {
+                "type": "ivf",
+                "neighbor_partitions": Decimal("1"),
+                "accuracy": Decimal("90"),
+            }
+        )
+
+        assert params == {
+            "type": "ivf",
+            "neighbor_partitions": 1,
+            "accuracy": 90,
+        }
+        assert isinstance(params["neighbor_partitions"], int)
+        # The caller does exactly this, and it must not raise.
+        assert json.dumps(params, sort_keys=True)
+
+    def test_coerces_decimals_from_a_json_string(self):
+        params = _normalize_existing_index_params(
+            '{"type": "hnsw", "neighbors": 16, "efconstruction": 200}'
+        )
+
+        assert params == {"type": "hnsw", "neighbors": 16, "efconstruction": 200}
+        assert json.dumps(params, sort_keys=True)
+
+    def test_coerces_nested_and_non_integral_decimals(self):
+        params = _normalize_existing_index_params(
+            {"nested": {"values": [Decimal("2"), Decimal("2.5")]}}
+        )
+
+        assert params == {"nested": {"values": [2, 2.5]}}
+        assert isinstance(params["nested"]["values"][0], int)
+        assert isinstance(params["nested"]["values"][1], float)
+        assert json.dumps(params, sort_keys=True)
+
+    def test_still_rejects_unusable_values(self):
+        with pytest.raises(ValueError, match="not valid JSON"):
+            _normalize_existing_index_params("{not json")
+
+        with pytest.raises(ValueError, match="must decode to a JSON object"):
+            _normalize_existing_index_params("[1, 2]")
+
+        with pytest.raises(ValueError, match="unsupported format"):
+            _normalize_existing_index_params(object())


### PR DESCRIPTION
OracleStore.setup() raised "TypeError: Object of type Decimal is not JSON serializable" whenever it re-validated a registered index configuration that contained a numeric index_type parameter, making the store unusable after the first run.

STORE_CONFIGS.index_params is an Oracle JSON column, so python-oracledb returns its numbers as Decimal. _validate_configuration compares configurations by json.dumps()-ing the normalized dict, and json has no encoder for Decimal.

_normalize_existing_index_params now coerces Decimal to int/float, which fixes both OracleStore and AsyncOracleStore since they share the helper. The same coercion already exists on the checkpoint side (BaseOracleSaver._coerce_decimals) for exactly this reason.

Triggered by an explicit table_suffix plus any numeric index_type value (neighbors, efconstruction, neighbor_partitions, samples_per_partition, min_vectors_per_partition) on the second setup(). Configurations without a numeric index_type parameter were unaffected, which is why defaults never hit it.

Fixes #294 