### PR TITLE
fix(js/langchain-oracledb): preserve sparse vector element format (FLOAT32/INT8) to prevent ORA-51812

### DIFF
--- a/libs/js/langchain-oracledb/src/tests/vectorstores.unit.test.ts
+++ b/libs/js/langchain-oracledb/src/tests/vectorstores.unit.test.ts
@@ -4,6 +4,8 @@ import type oracledb from "oracledb";
 import {
   DistanceStrategy,
   OracleVS,
+  VectorElementFormat,
+  VectorType,
   type OracleDBVSArgs,
   type Metadata,
 } from "../vectorstores.js";
@@ -77,5 +79,82 @@ describe("OracleVS SQL generation", () => {
       'SELECT /*+ VECTOR_INDEX_TRANSFORM("My Vector Table") */'
     );
     expect(sql).toContain(`FROM ${quoted}`);
+  });
+});
+
+describe("sparse vector element format (#297)", () => {
+  // The dense-input oracledb.SparseVector constructor stores values as
+  // Float64Array regardless of the typed array passed in, which made FLOAT32
+  // and INT8 sparse query vectors fail with ORA-51812. These tests pin the
+  // object-form construction that preserves the element format.
+  const makeStore = (format: VectorElementFormat) => {
+    const connection = {
+      execute: vi.fn(),
+      close: vi.fn(),
+    } as unknown as oracledb.Connection;
+    const embeddings = {
+      embedDocuments: vi.fn(),
+      embedQuery: vi.fn(),
+    } as unknown as EmbeddingsInterface;
+    return new OracleVS(embeddings, {
+      client: connection,
+      tableName: "SPARSE_FORMAT_TEST",
+      query: "probe",
+      vectorType: VectorType.SPARSE,
+      format,
+    });
+  };
+
+  const prepare = (store: OracleVS, vector: number[]) =>
+    (
+      store as unknown as {
+        prepareVectorForStorage(vector: number[]): {
+          values: Float32Array | Float64Array | Int8Array;
+          indices: Uint32Array | number[];
+          numDimensions: number;
+        };
+      }
+    ).prepareVectorForStorage(vector);
+
+  test("FLOAT32 sparse vectors keep Float32Array values", () => {
+    const sv = prepare(makeStore(VectorElementFormat.FLOAT32), [1, 0, 2, 0.5]);
+
+    expect(sv.values).toBeInstanceOf(Float32Array);
+    expect(Array.from(sv.indices)).toEqual([0, 2, 3]);
+    expect(Array.from(sv.values)).toEqual([1, 2, 0.5]);
+    expect(sv.numDimensions).toBe(4);
+  });
+
+  test("FLOAT64 sparse vectors keep Float64Array values", () => {
+    const sv = prepare(makeStore(VectorElementFormat.FLOAT64), [0, 1.25, 0]);
+
+    expect(sv.values).toBeInstanceOf(Float64Array);
+    expect(Array.from(sv.indices)).toEqual([1]);
+    expect(Array.from(sv.values)).toEqual([1.25]);
+    expect(sv.numDimensions).toBe(3);
+  });
+
+  test("INT8 sparse vectors keep Int8Array values and drop rounded zeros", () => {
+    const sv = prepare(makeStore(VectorElementFormat.INT8), [1.4, 0.3, -2, 0]);
+
+    expect(sv.values).toBeInstanceOf(Int8Array);
+    // 0.3 rounds to 0 and is dropped, matching the dense representation.
+    expect(Array.from(sv.indices)).toEqual([0, 2]);
+    expect(Array.from(sv.values)).toEqual([1, -2]);
+    expect(sv.numDimensions).toBe(4);
+  });
+
+  test("INT8 sparse vectors reject out-of-range values", () => {
+    expect(() => prepare(makeStore(VectorElementFormat.INT8), [1, 300, 0])).toThrow(
+      /INT8 sparse vector values/
+    );
+  });
+
+  test("all-zero sparse vectors produce empty indices and values", () => {
+    const sv = prepare(makeStore(VectorElementFormat.FLOAT32), [0, 0, 0]);
+
+    expect(Array.from(sv.indices)).toEqual([]);
+    expect(Array.from(sv.values)).toEqual([]);
+    expect(sv.numDimensions).toBe(3);
   });
 });

--- a/libs/js/langchain-oracledb/src/tests/vectorstores.unit.test.ts
+++ b/libs/js/langchain-oracledb/src/tests/vectorstores.unit.test.ts
@@ -150,6 +150,21 @@ describe("sparse vector element format (#297)", () => {
     );
   });
 
+  test("INT8 sparse vectors reject non-finite values", () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      expect(() => prepare(makeStore(VectorElementFormat.INT8), [1, bad, 0])).toThrow(
+        /INT8 sparse vector values must be finite/
+      );
+    }
+  });
+
+  test("sparse indices are passed as a Uint32Array", () => {
+    const sv = prepare(makeStore(VectorElementFormat.FLOAT32), [0, 3, 0, 4]);
+
+    expect(sv.indices).toBeInstanceOf(Uint32Array);
+    expect(Array.from(sv.indices)).toEqual([1, 3]);
+  });
+
   test("all-zero sparse vectors produce empty indices and values", () => {
     const sv = prepare(makeStore(VectorElementFormat.FLOAT32), [0, 0, 0]);
 

--- a/libs/js/langchain-oracledb/src/vectorstores.ts
+++ b/libs/js/langchain-oracledb/src/vectorstores.ts
@@ -709,24 +709,55 @@ export class OracleVS extends VectorStore {
         throwError(ErrorCode.VECTOR_INVALID_VALUE, "Sparse vectors must supply full-dimension arrays for conversion.");
       }
 
-      let sparseInput: number[] | Float32Array | Float64Array | Int8Array = vector;
+      // The dense-input SparseVector constructor stores its values as a
+      // Float64Array regardless of the typed array passed in, so FLOAT32 and
+      // INT8 query vectors reach the database as FLOAT64 and VECTOR_DISTANCE()
+      // fails with ORA-51812 against a non-FLOAT64 sparse column. The
+      // object-form constructor preserves the values' typed array, so build
+      // the nonzero indices/values explicitly and use that form.
+      const indices: number[] = [];
+      const nonzero: number[] = [];
       if (format === VectorElementFormat.INT8) {
-        const clamped = new Int8Array(vector.length);
         for (let i = 0; i < vector.length; i += 1) {
           const rounded = Math.round(vector[i]);
           if (rounded < -128 || rounded > 127) {
             throwError(ErrorCode.VECTOR_INVALID_VALUE, "INT8 sparse vector values must be within [-128, 127].");
           }
-          clamped[i] = rounded;
+          if (rounded !== 0) {
+            indices.push(i);
+            nonzero.push(rounded);
+          }
         }
-        sparseInput = clamped;
-      } else if (format === VectorElementFormat.FLOAT64) {
-        sparseInput = new Float64Array(vector);
       } else if (format === VectorElementFormat.FLOAT32) {
-        sparseInput = new Float32Array(vector);
+        for (let i = 0; i < vector.length; i += 1) {
+          if (Math.fround(vector[i]) !== 0) {
+            indices.push(i);
+            nonzero.push(vector[i]);
+          }
+        }
+      } else {
+        for (let i = 0; i < vector.length; i += 1) {
+          if (vector[i] !== 0) {
+            indices.push(i);
+            nonzero.push(vector[i]);
+          }
+        }
       }
 
-      return new oracledb.SparseVector(sparseInput);
+      let values: Float32Array | Float64Array | Int8Array;
+      if (format === VectorElementFormat.INT8) {
+        values = new Int8Array(nonzero);
+      } else if (format === VectorElementFormat.FLOAT64) {
+        values = new Float64Array(nonzero);
+      } else {
+        values = new Float32Array(nonzero);
+      }
+
+      return new oracledb.SparseVector({
+        values,
+        indices,
+        numDimensions: vector.length,
+      });
     }
 
     if (vector.length !== dimension) {

--- a/libs/js/langchain-oracledb/src/vectorstores.ts
+++ b/libs/js/langchain-oracledb/src/vectorstores.ts
@@ -719,9 +719,13 @@ export class OracleVS extends VectorStore {
       const nonzero: number[] = [];
       if (format === VectorElementFormat.INT8) {
         for (let i = 0; i < vector.length; i += 1) {
-          const rounded = Math.round(vector[i]);
-          if (rounded < -128 || rounded > 127) {
-            throwError(ErrorCode.VECTOR_INVALID_VALUE, "INT8 sparse vector values must be within [-128, 127].");
+          const value = vector[i];
+          const rounded = Math.round(value);
+          if (!Number.isFinite(value) || rounded < -128 || rounded > 127) {
+            throwError(
+              ErrorCode.VECTOR_INVALID_VALUE,
+              "INT8 sparse vector values must be finite and within [-128, 127].",
+            );
           }
           if (rounded !== 0) {
             indices.push(i);
@@ -755,7 +759,7 @@ export class OracleVS extends VectorStore {
 
       return new oracledb.SparseVector({
         values,
-        indices,
+        indices: new Uint32Array(indices),
         numDimensions: vector.length,
       });
     }


### PR DESCRIPTION
Fixes #297

## Problem

With `vectorType: SPARSE` and `format: FLOAT32`, similarity search fails with `ORA-51812: ... encountered dimension formats (FLOAT32, FLOAT64)`. Root cause (verified against node-oracledb 7.0.1): the dense-input `oracledb.SparseVector` constructor stores its `values` as a `Float64Array` **regardless of the typed array passed in**, so the query vector reaches `VECTOR_DISTANCE()` as FLOAT64 while the column is FLOAT32:

```js
new oracledb.SparseVector(new Float32Array([1, 0, 2, 0.5])).values.constructor.name  // "Float64Array"
new oracledb.SparseVector(new Int8Array([1, 0, 2, 0])).values.constructor.name       // "Float64Array" — INT8 sparse was equally broken
```

## Fix

`prepareVectorForStorage()` now extracts the nonzero `indices`/`values` into the correctly-typed array and uses the object-form constructor, which preserves the element format:

```js
new oracledb.SparseVector({ values: new Float32Array(...), indices, numDimensions })
```

Semantics preserved from the previous dense construction: INT8 values are rounded and range-checked before zero-dropping (a value rounding to 0 is dropped, as the dense path produced), and FLOAT32 uses `Math.fround` for the zero test so values that underflow to 0 in float32 are dropped as before.

## Testing

- **Live repro** on Oracle Database 23ai Free (node-oracledb 7.0.1, Thin): before the fix, the issue's exact scenario fails with ORA-51812 on a `VECTOR(5, FLOAT32, SPARSE)` column; with the fix, both the issue's FLOAT32 scenario and the INT8 variant run `initialize → addVectors → similaritySearchByVectorReturningEmbeddings` successfully end-to-end.
- **Unit tests**: new `sparse vector element format (#297)` describe block pins the values' typed array per format (FLOAT32/FLOAT64/INT8), indices/numDimensions correctness, INT8 range validation, rounded-zero dropping, and the all-zero vector edge case. `vitest run src/tests/vectorstores.unit.test.ts`: 8 passed, type check clean.
- `pnpm lint` and `pnpm build` clean.

Note: this package has no CI coverage in this repo — the results above are from a local run.
