### PR TITLE
fix(oci): skip the `[DONE]` SSE sentinel in sync streaming (ChatOCIGenAI, OCIGenAI)

### DIFF
--- a/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/chat_models/oci_generative_ai.py
@@ -110,6 +110,18 @@ def _build_chat_completions_headers(compartment_id: str) -> Dict[str, str]:
     return {COMPARTMENT_ID_HEADER: compartment_id}
 
 
+def _is_sse_sentinel(data: Optional[str]) -> bool:
+    """Return True for SSE frames that carry no JSON payload.
+
+    The OCI GenAI streaming endpoint emits a terminal ``data: [DONE]`` frame
+    for some models (seen live on ``meta.llama-3.3-70b-instruct`` and
+    ``meta.llama-4-maverick-17b-128e-instruct-fp8`` in September 2026).
+    Empty frames are treated the same way so keep-alives never reach
+    ``json.loads``.
+    """
+    return data is None or data.strip() in ("", "[DONE]")
+
+
 class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
     """ChatOCIGenAI chat model integration.
 
@@ -890,6 +902,12 @@ class ChatOCIGenAI(ChatOCIGenAIAsyncMixin, BaseChatModel, OCIGenAIBase):
                 reset()
 
         for event in response.data.events():
+            # OCI GenAI terminates some chat streams (observed on Meta Llama
+            # models) with an OpenAI-style ``data: [DONE]`` sentinel that is
+            # not JSON. Skip it (and empty keep-alive frames) instead of
+            # failing the whole stream with a JSONDecodeError.
+            if _is_sse_sentinel(event.data):
+                continue
             event_data = json.loads(event.data)
 
             if not self._provider.is_chat_stream_end(event_data):

--- a/libs/oci/langchain_oci/llms/oci_generative_ai.py
+++ b/libs/oci/langchain_oci/llms/oci_generative_ai.py
@@ -357,6 +357,10 @@ class OCIGenAI(LLM, OCIGenAIBase):
         response = self.client.generate_text(invocation_obj)
 
         for event in response.data.events():
+            # Skip the non-JSON ``data: [DONE]`` terminal frame / empty frames
+            # (see ChatOCIGenAI._stream) instead of raising JSONDecodeError.
+            if event.data is None or event.data.strip() in ("", "[DONE]"):
+                continue
             json_load = json.loads(event.data)
             if "text" in json_load:
                 event_data_text = json_load["text"]

--- a/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_oci_generative_ai.py
@@ -2442,3 +2442,35 @@ class TestGeminiModelIdRouting:
         # No flattening: 1 Human + 1 AI (with 2 tool_calls) + 2 Tool = 4
         oci_msgs = result["messages"]
         assert len(oci_msgs) == 4
+
+
+class TestStreamDoneSentinel:
+    """The sync stream must tolerate the ``data: [DONE]`` terminal SSE frame.
+
+    OCI GenAI started closing Meta Llama chat streams with an OpenAI-style
+    ``[DONE]`` frame. ``json.loads("[DONE]")`` raises, which turned every
+    ``ChatOCIGenAI.stream()`` call on those models into a JSONDecodeError
+    after the last real chunk. The async transport already skipped the
+    sentinel; this pins the same behaviour for the sync path.
+    """
+
+    @staticmethod
+    def _stream_with_trailing(trailing: list) -> list:
+        oci_client = MagicMock()
+        llm = ChatOCIGenAI(model_id="meta.llama-3.3-70b-instruct", client=oci_client)
+        mock_stream_response = MagicMock()
+        mock_stream_response.data.events.return_value = _make_generic_stream_events(
+            text_parts=["Hel", "lo"]
+        ) + [MagicMock(data=data) for data in trailing]
+        oci_client.chat.return_value = mock_stream_response
+        return list(llm.stream([HumanMessage(content="hi")]))
+
+    def test_stream_skips_done_sentinel(self) -> None:
+        chunks = self._stream_with_trailing(["[DONE]"])
+        assert _merge_stream(chunks).content == "Hello"
+
+    def test_sentinel_and_empty_frames_add_no_chunks(self) -> None:
+        baseline = self._stream_with_trailing([])
+        with_noise = self._stream_with_trailing(["", "  [DONE]\n", None])
+        assert len(with_noise) == len(baseline)
+        assert _merge_stream(with_noise).content == "Hello"

--- a/libs/oci/tests/unit_tests/llms/test_stream_done_sentinel.py
+++ b/libs/oci/tests/unit_tests/llms/test_stream_done_sentinel.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""OCIGenAI.stream() must skip the non-JSON ``data: [DONE]`` SSE frame."""
+
+import json
+from unittest.mock import MagicMock
+
+from langchain_oci.llms.oci_generative_ai import OCIGenAI
+
+
+def test_llm_stream_skips_done_sentinel() -> None:
+    oci_client = MagicMock()
+    llm = OCIGenAI(model_id="cohere.command", client=oci_client)
+    response = MagicMock()
+    response.data.events.return_value = [
+        MagicMock(data=json.dumps({"text": "Hel"})),
+        MagicMock(data=json.dumps({"text": "lo"})),
+        MagicMock(data=""),
+        MagicMock(data="[DONE]"),
+    ]
+    oci_client.generate_text.return_value = response
+
+    chunks = list(llm.stream("hi"))
+
+    assert "".join(c for c in chunks) == "Hello"


### PR DESCRIPTION
## Problem

OCI GenAI now closes chat streams for **Meta Llama** models with an OpenAI-style terminal frame:

```
data: [DONE]
```

`ChatOCIGenAI._stream` (and `OCIGenAI._stream` for the completion LLM) call `json.loads(event.data)` on every SSE frame, so every sync `.stream()` call on those models raises after the last real chunk:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 2 (char 1)   # e.doc == '[DONE]'
```

Reproduced on `main` with nothing more than `ChatOCIGenAI(model_id="meta.llama-3.3-70b-instruct", ...).stream("Say hello")`. Same for `meta.llama-4-maverick-17b-128e-instruct-fp8`. Cohere, Gemini, OpenAI and xAI streams do not carry the sentinel and are unaffected. `.astream()` already worked because the async transport skips `[DONE]` (`common/async_support.py`), as does `_stream_responses_api`.

## Fix

- `ChatOCIGenAI._stream`: skip frames whose payload is empty or `[DONE]` before `json.loads` (small `_is_sse_sentinel` helper).
- `OCIGenAI._stream` (completion LLM): same guard.
- Behaviour is otherwise unchanged; no new chunks are emitted for the skipped frames.

## Tests

- `tests/unit_tests/chat_models/test_oci_generative_ai.py::TestStreamDoneSentinel` — stream with a trailing `[DONE]`, and with empty / padded / `None` frames, yields the same chunks as a clean stream.
- `tests/unit_tests/llms/test_stream_done_sentinel.py` — same for `OCIGenAI.stream()`.
- Full `libs/oci` unit suite: 505 passed, 47 skipped. `ruff check`, `ruff format --diff`, `mypy` clean.

## Live verification (OCI GenAI, us-chicago-1)

| Model | `.stream()` on main | with this PR |
|---|---|---|
| meta.llama-3.3-70b-instruct | JSONDecodeError on `[DONE]` | OK |
| meta.llama-4-maverick-17b-128e-instruct-fp8 | JSONDecodeError on `[DONE]` | OK |
| cohere.command-a-03-2025, google.gemini-2.5-flash, openai.gpt-4o, openai.gpt-5, xai.grok-4.20 | OK | OK |

This is also what was making the langchain-tests conformance suite in #277 red: with this guard applied, that suite goes from 10 failed / 27 passed to 37 passed / 11 skipped / 2 xfailed / 0 failed against the live service.
