### PR TITLE
fix(oci): pin openai below 3

### DIFF
--- a/libs/oci/poetry.lock
+++ b/libs/oci/poetry.lock
@@ -5601,4 +5601,4 @@ deepagents = ["deepagents", "langchain-oracledb", "langgraph-oracledb", "opensea
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "9aebd96c8d65d23baf65a40c26d2bc17cf75bf1d54b412ba04afc32fb5a557b6"
+content-hash = "f0e93ee35d6b83cb620926fc9ebc0c645f577084b0611c86e051580cfebad2d1"

--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -13,7 +13,9 @@ dependencies = [
     "oci>=2.173.0",
     "pydantic>=2,<3",
     "aiohttp>=3.12.14",
-    "openai>=2.6.1",
+    # openai 3.x changes how a custom httpx auth is accepted; oci-openai's
+    # OciSessionAuth is rejected with TypeError: Invalid "auth" argument.
+    "openai>=2.6.1,<3",
     "oci-openai>=1.0.0",
     "langchain-openai>=0.3.35,<1.0.0; python_version < '3.10'",
     "langchain-openai>=1.1.0,<2.0.0; python_version >= '3.10'",


### PR DESCRIPTION
## Problem

`libs/oci` allows `openai>=2.6.1` with no upper bound. openai 3.x changed how a custom httpx `auth` object is accepted, and rejects oci-openai's `OciSessionAuth` with `TypeError: Invalid "auth" argument`. A fresh `pip install langchain-oci` today resolves openai 3.x, so the Responses API path (`ChatOCIGenAI(use_responses_api=True)`, `ChatOCIOpenAI`) is broken for new installs while CI, which runs the lock, stays green.

## Fix

Pin `openai>=2.6.1,<3` and regenerate the lock. Nothing else changes.

## Verification

- openai 3.13.0: 21 of the 26 Responses API unit tests fail with the TypeError above.
- With the pin (openai 2.x): full `libs/oci` unit suite 502 passed, 47 skipped.
- `poetry check --lock` clean.

The pin can be lifted once oci-openai supports the openai 3.x auth contract.
