### PR TITLE
test(oci): refresh deepagents backend and xAI integration tests for the current APIs

### DIFF
--- a/libs/oci/poetry.lock
+++ b/libs/oci/poetry.lock
@@ -185,33 +185,34 @@ files = [
 
 [[package]]
 name = "anthropic"
-version = "0.97.0"
+version = "1.5.0"
 description = "The official Python library for the anthropic API"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "python_version >= \"3.11\" and python_version < \"3.14\" and extra == \"deepagents\""
 files = [
-    {file = "anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613"},
-    {file = "anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be"},
+    {file = "anthropic-1.5.0-py3-none-any.whl", hash = "sha256:d9ce04b29ad1f7025dda3e3bc478cde8d2924d2de5417d2d4a4bb0378ecbc2a6"},
+    {file = "anthropic-1.5.0.tar.gz", hash = "sha256:b25f87f5758861f25993383a5c9bf274eb6e0f1b010c84019ad91854cb4e1bc6"},
 ]
 
 [package.dependencies]
 anyio = ">=3.5.0,<5"
-distro = ">=1.7.0,<2"
 docstring-parser = ">=0.15,<1"
-httpx = ">=0.25.0,<1"
+httpx2 = ">=2.0.0,<3"
 jiter = ">=0.4.0,<1"
 pydantic = ">=1.9.0,<3"
-sniffio = "*"
+sniffio = ">=1,<2"
 typing-extensions = ">=4.14,<5"
 
 [package.extras]
-aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
-aws = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
-bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
-mcp = ["mcp (>=1.0) ; python_version >= \"3.10\""]
+aiohttp = ["aiohttp (>=3.10.0,<4)"]
+aws = ["boto3 (>=1.28.57,<2)", "botocore (>=1.31.57,<2)"]
+bedrock = ["boto3 (>=1.28.57,<2)", "botocore (>=1.31.57,<2)"]
+google-cloud = ["google-auth[requests] (>=2,<3)"]
+mcp = ["mcp (>=1.0,<3) ; python_version >= \"3.10\""]
 vertex = ["google-auth[requests] (>=2,<3)"]
+webhooks = ["standardwebhooks (>=1.0.1,<2)"]
 
 [[package]]
 name = "anyio"
@@ -261,15 +262,15 @@ files = [
 
 [[package]]
 name = "bracex"
-version = "2.6"
+version = "3.0.1"
 description = "Bash style brace expander."
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "python_version >= \"3.11\" and python_version < \"3.14\" and extra == \"deepagents\""
 files = [
-    {file = "bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952"},
-    {file = "bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7"},
+    {file = "bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c"},
+    {file = "bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4"},
 ]
 
 [[package]]
@@ -909,27 +910,30 @@ typing-inspect = ">=0.4.0,<1"
 
 [[package]]
 name = "deepagents"
-version = "0.6.2"
-description = "General purpose 'deep agent' with sub-agent spawning, todo list capabilities, and mock file system. Built on LangGraph."
+version = "0.7.13"
+description = "Production-ready, extensible agent harness with a built-in filesystem and context management, sub-agent delegation, skills, and long-term memory."
 optional = true
 python-versions = "<4.0,>=3.11"
 groups = ["main"]
 markers = "python_version >= \"3.11\" and python_version < \"3.14\" and extra == \"deepagents\""
 files = [
-    {file = "deepagents-0.6.2-py3-none-any.whl", hash = "sha256:202c42c06b5a7abb762dedba6a57073253096fa28effa6e156db280e10027322"},
-    {file = "deepagents-0.6.2.tar.gz", hash = "sha256:81bc6f69c6f54bd0b54ce929e8299003a604747404e7f9d208a66842c5fbf1f3"},
+    {file = "deepagents-0.7.13-py3-none-any.whl", hash = "sha256:d717ee8ee092a91c475a6124ed578d5e4154d54120769a1081bfe1aece87c248"},
+    {file = "deepagents-0.7.13.tar.gz", hash = "sha256:99fc1855b1387c1c6e6035ba3600edbd933f59c39a4863ef3a7d5a0272ea67ab"},
 ]
 
 [package.dependencies]
-langchain = ">=1.3.0,<2.0.0"
-langchain-anthropic = ">=1.4.3,<2.0.0"
-langchain-core = ">=1.4.0,<2.0.0"
-langchain-google-genai = ">=4.2.2,<5.0.0"
-langsmith = ">=0.8.3"
-wcmatch = "*"
+langchain = ">=1.3.18,<2.0.0"
+langchain-anthropic = ">=1.7.0,<2.0.0"
+langchain-core = ">=1.6.1,<2.0.0"
+langchain-google-genai = ">=4.3.7,<5.0.0"
+langsmith = ">=0.11.2"
+packaging = ">=23.2"
+wcmatch = ">=11.0"
 
 [package.extras]
-quickjs = ["langchain-quickjs"]
+aws = ["langchain-aws (>=1.7.4,<2.0.0)"]
+quickjs = ["langchain-quickjs (>=0.3.5)"]
+video = ["av (>=18.0.0,<19.0.0)", "pillow (>=12.3.0,<13.0.0)"]
 
 [[package]]
 name = "distro"
@@ -937,11 +941,12 @@ version = "1.9.0"
 description = "Distro - an OS platform information API"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "test"]
+groups = ["main", "test", "test-integration"]
 files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
     {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
 ]
+markers = {test-integration = "python_version >= \"3.10\""}
 
 [[package]]
 name = "docstring-parser"
@@ -1399,6 +1404,29 @@ socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
+name = "httpcore2"
+version = "2.3.0"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["main", "test", "test-integration"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "httpcore2-2.3.0-py3-none-any.whl", hash = "sha256:477e9e334f74e5240dcac002e890580f36a57d40ff0fb14cc9655731d23b8415"},
+    {file = "httpcore2-2.3.0.tar.gz", hash = "sha256:07327e251560960eea8e969d92d4c6a325feb13cca39e25340731336c3baf924"},
+]
+
+[package.dependencies]
+h11 = ">=0.16"
+truststore = ">=0.10"
+
+[package.extras]
+asyncio = ["anyio (>=4.5.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 description = "The next generation HTTP client."
@@ -1435,6 +1463,32 @@ files = [
     {file = "httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc"},
     {file = "httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"},
 ]
+
+[[package]]
+name = "httpx2"
+version = "2.3.0"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["main", "test", "test-integration"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "httpx2-2.3.0-py3-none-any.whl", hash = "sha256:6f393663bdf6dbe7fe90118e3eb5b2bd024a675cae0390ac08cec9198812d8b7"},
+    {file = "httpx2-2.3.0.tar.gz", hash = "sha256:227e7c41d95a76d4077a52640564132777215fc3394e07b66a3116c33d668fa9"},
+]
+
+[package.dependencies]
+anyio = "*"
+httpcore2 = "2.3.0"
+idna = "*"
+truststore = ">=0.10"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<15)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0) ; python_version <= \"3.13\""]
 
 [[package]]
 name = "idna"
@@ -1660,20 +1714,20 @@ xai = ["langchain-xai"]
 
 [[package]]
 name = "langchain"
-version = "1.3.1"
+version = "1.4.0"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
 markers = "python_version >= \"3.10\""
 files = [
-    {file = "langchain-1.3.1-py3-none-any.whl", hash = "sha256:154e9c30c90b391eba4315296f6bf6b6fac6b058ddea4cc771a10470968fe36f"},
-    {file = "langchain-1.3.1.tar.gz", hash = "sha256:bc283c220233230f48b8e50ab1fbf1b688bcb206d933fa448d40a9b143177f62"},
+    {file = "langchain-1.4.0-py3-none-any.whl", hash = "sha256:af1dc0161d30944a52ec7844d9bf890d0497b12ec0703069f3503b4003cbbac3"},
+    {file = "langchain-1.4.0.tar.gz", hash = "sha256:08da122a439f738f4c09a5158cfa3d2c1d8bea2d0bde7fbbf4aeb4d7f7fd9d80"},
 ]
 
 [package.dependencies]
-langchain-core = ">=1.4.0,<2.0.0"
-langgraph = ">=1.2.0,<1.3.0"
+langchain-core = ">=1.6.0,<2.0.0"
+langgraph = ">=1.2.11,<1.3.0"
 pydantic = ">=2.7.4,<3.0.0"
 
 [package.extras]
@@ -1688,6 +1742,8 @@ google-genai = ["langchain-google-genai"]
 google-vertexai = ["langchain-google-vertexai"]
 groq = ["langchain-groq"]
 huggingface = ["langchain-huggingface"]
+mcp = ["fastmcp (>=4.0.1,<5.0.0)"]
+meta = ["langchain-meta"]
 mistralai = ["langchain-mistralai"]
 ollama = ["langchain-ollama"]
 openai = ["langchain-openai"]
@@ -1697,20 +1753,20 @@ xai = ["langchain-xai"]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.3"
+version = "1.7.2"
 description = "Integration package connecting Claude (Anthropic) APIs and LangChain"
 optional = true
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
 markers = "python_version >= \"3.11\" and python_version < \"3.14\" and extra == \"deepagents\""
 files = [
-    {file = "langchain_anthropic-1.4.3-py3-none-any.whl", hash = "sha256:65466e0f2f95909a009708f2958e917dfdbfab79c612b4484a30866a85e1f291"},
-    {file = "langchain_anthropic-1.4.3.tar.gz", hash = "sha256:f8a2442463c0629b1b3110eaeaa56fdbdc87df2a802f8c7f5ecf611eb4874ec8"},
+    {file = "langchain_anthropic-1.7.2-py3-none-any.whl", hash = "sha256:9d114c3766f57bbffe8e84093efe396306520c51587263b96d00c055d3bb8370"},
+    {file = "langchain_anthropic-1.7.2.tar.gz", hash = "sha256:0d39665211b3b40421de8be621536c4e32149500d20a75ee4338cac4ae97db19"},
 ]
 
 [package.dependencies]
-anthropic = ">=0.96.0,<1.0.0"
-langchain-core = ">=1.3.2,<2.0.0"
+anthropic = ">=0.120.0,<2.0.0"
+langchain-core = ">=1.6.2,<2.0.0"
 pydantic = ">=2.7.4,<3.0.0"
 
 [[package]]
@@ -1833,20 +1889,21 @@ typing-extensions = ">=4.7.0,<5.0.0"
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0"
+version = "1.6.2"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main", "test", "test-integration"]
 markers = "python_version >= \"3.10\""
 files = [
-    {file = "langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c"},
-    {file = "langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f"},
+    {file = "langchain_core-1.6.2-py3-none-any.whl", hash = "sha256:21e6c7cf097c68b777fd69ea00864f09bd9ca76ac73e3e3fa14e1ee366eb4711"},
+    {file = "langchain_core-1.6.2.tar.gz", hash = "sha256:1ec6d3a98f7c8cdbb5bb0deff86e7ca37e16bf4f8f49f022d10723656c62352d"},
 ]
 
 [package.dependencies]
+httpx = ">=0.23.0,<1.0.0"
 jsonpatch = ">=1.33.0,<2.0.0"
-langchain-protocol = ">=0.0.14"
+langchain-protocol = ">=0.0.17"
 langsmith = ">=0.3.45,<1.0.0"
 packaging = ">=23.2.0"
 pydantic = ">=2.7.4,<3.0.0"
@@ -1857,21 +1914,21 @@ uuid-utils = ">=0.12.0,<1.0"
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.2.2"
+version = "4.3.7"
 description = "An integration package connecting Google's genai package and LangChain"
 optional = true
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
 markers = "python_version >= \"3.11\" and python_version < \"3.14\" and extra == \"deepagents\""
 files = [
-    {file = "langchain_google_genai-4.2.2-py3-none-any.whl", hash = "sha256:c8d09aac0304d26f1c2483e41a350f15587af1fbe034c39a304e1e17a3b743f3"},
-    {file = "langchain_google_genai-4.2.2.tar.gz", hash = "sha256:5fc774bf41d1dc1c1a5ba8d7b9f2017dfa77e30653c9b44d2dfbaf0e877e7388"},
+    {file = "langchain_google_genai-4.3.7-py3-none-any.whl", hash = "sha256:8d4b1aa8f2c2e17b8e790d34a7e9a7b8e7d13e9a00175679d17647c235104bf9"},
+    {file = "langchain_google_genai-4.3.7.tar.gz", hash = "sha256:8a57f936b1fbde52776fdde6673fdabd99cfa5cbbb122a926f1cff0ba00f6bc6"},
 ]
 
 [package.dependencies]
 filetype = ">=1.2.0,<2.0.0"
-google-genai = ">=1.65.0,<2.0.0"
-langchain-core = ">=1.2.29,<2.0.0"
+google-genai = ">=1.65.0,<3.0.0"
+langchain-core = ">=1.6.1,<2.0.0"
 pydantic = ">=2.0.0,<3.0.0"
 
 [[package]]
@@ -1935,19 +1992,19 @@ pydantic = ">=2,<3"
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.15"
+version = "0.0.19"
 description = "Python bindings for the LangChain agent streaming protocol"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main", "test", "test-integration"]
 markers = "python_version >= \"3.10\""
 files = [
-    {file = "langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79"},
-    {file = "langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade"},
+    {file = "langchain_protocol-0.0.19-py3-none-any.whl", hash = "sha256:4cdf879a492a35980fd859ae792d3c65458ccaae504e183c9a10d7eac1f0720f"},
+    {file = "langchain_protocol-0.0.19.tar.gz", hash = "sha256:79d90a1425122ac87e8052e2ec054fbd09c3edbf341bdfb6397112a495c7bf8c"},
 ]
 
 [package.dependencies]
-typing-extensions = ">=4.7.0,<5.0.0"
+typing-extensions = ">=4.13.0,<5.0.0"
 
 [[package]]
 name = "langchain-tests"
@@ -2055,22 +2112,22 @@ xxhash = ">=3.5.0"
 
 [[package]]
 name = "langgraph"
-version = "1.2.0"
+version = "1.2.11"
 description = "Building stateful, multi-actor applications with LLMs"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "test", "test-integration"]
 markers = "python_version >= \"3.10\""
 files = [
-    {file = "langgraph-1.2.0-py3-none-any.whl", hash = "sha256:03fd5895a8d4b70db1ff63ebc3bacead29dd20cd794a8b1a483e7ec9018f7a65"},
-    {file = "langgraph-1.2.0.tar.gz", hash = "sha256:4a9baaf62afc5d5f63144a50095140a34b9aa9b7cea695d25326d564775348e7"},
+    {file = "langgraph-1.2.11-py3-none-any.whl", hash = "sha256:8bab70de7b2d00b5300fb289bcf38d8b241400f3184c1e95e8ce706fb0e8686b"},
+    {file = "langgraph-1.2.11.tar.gz", hash = "sha256:9ecfe11e50d338b34b15cf4d8a442642de103e8ae6971320efba84e4542eb363"},
 ]
 
 [package.dependencies]
-langchain-core = ">=1.4.0,<2"
+langchain-core = ">=1.4.7,<2"
 langgraph-checkpoint = ">=4.1.0,<5.0.0"
 langgraph-prebuilt = ">=1.1.0,<1.2.0"
-langgraph-sdk = ">=0.3.0,<0.4.0"
+langgraph-sdk = ">=0.4.2,<0.5.0"
 pydantic = ">=2.7.4"
 xxhash = ">=3.5.0"
 
@@ -2179,20 +2236,23 @@ orjson = ">=3.10.1"
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.3.6"
+version = "0.4.4"
 description = "SDK for interacting with LangGraph API"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "test", "test-integration"]
 markers = "python_version >= \"3.10\""
 files = [
-    {file = "langgraph_sdk-0.3.6-py3-none-any.whl", hash = "sha256:7df2fd552ad7262d0baf8e1f849dce1d62186e76dcdd36db9dc5bdfa5c3fc20f"},
-    {file = "langgraph_sdk-0.3.6.tar.gz", hash = "sha256:7650f607f89c1586db5bee391b1a8754cbe1fc83b721ff2f1450f8906e790bd7"},
+    {file = "langgraph_sdk-0.4.4-py3-none-any.whl", hash = "sha256:39afe416c91742925e6f8a93715f566d499b36e1b636b804a4ffe3190e4f4e64"},
+    {file = "langgraph_sdk-0.4.4.tar.gz", hash = "sha256:4e651ffa09de695681579396375377bdde23bedbc8e35b070e615cbd5af7da8b"},
 ]
 
 [package.dependencies]
 httpx = ">=0.25.2"
-orjson = ">=3.10.1"
+langchain-core = ">=1.4.0,<2"
+langchain-protocol = ">=0.0.15"
+orjson = ">=3.11.5"
+websockets = ">=14,<17"
 
 [[package]]
 name = "langsmith"
@@ -2226,36 +2286,45 @@ vcr = ["vcrpy (>=7.0.0)"]
 
 [[package]]
 name = "langsmith"
-version = "0.8.5"
+version = "0.12.4"
 description = "Client library to connect to the LangSmith Observability and Evaluation Platform."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "test", "test-integration"]
 markers = "python_version >= \"3.10\""
 files = [
-    {file = "langsmith-0.8.5-py3-none-any.whl", hash = "sha256:efc779f9d450dcaf9d97bc8894f4926276509d6e730e05289af9a64debce06ae"},
-    {file = "langsmith-0.8.5.tar.gz", hash = "sha256:3615243d99c12f4047f13042bdc05a373dce232d106a6511b3ca7b48c5af1c2c"},
+    {file = "langsmith-0.12.4-py3-none-any.whl", hash = "sha256:b2edaa49baeec0c7347a84ca0f755039dcff9e9e52f0b9dc26423ec2a98a4dab"},
+    {file = "langsmith-0.12.4.tar.gz", hash = "sha256:f486435323eeb0c525087cc694f0b7cd92e255f340db08db643204c789f4f1c4"},
 ]
 
 [package.dependencies]
-httpx = ">=0.23.0,<1"
+anyio = ">=3.5.0"
+distro = ">=1.7.0"
+httpx2 = ">=2,<3"
 orjson = {version = ">=3.9.14", markers = "platform_python_implementation != \"PyPy\""}
 packaging = ">=23.2"
 pydantic = ">=2,<3"
 requests = ">=2.0.0"
 requests-toolbelt = ">=1.0.0"
+sniffio = ">=1.1"
+typing-extensions = ">=4.0.0"
 uuid-utils = ">=0.12.0,<1.0"
+websockets = ">=15.0"
 xxhash = ">=3.0.0"
 zstandard = ">=0.23.0"
 
 [package.extras]
 claude-agent-sdk = ["claude-agent-sdk (>=0.1.0) ; python_version >= \"3.10\""]
+gemini-live = ["google-genai (>=1.75)"]
 google-adk = ["google-adk (>=1.0.0)", "wrapt (>=1.16.0)"]
+google-adk-live = ["google-adk (>=2.3.0)"]
 langsmith-pyo3 = ["langsmith-pyo3 (>=0.1.0rc2)"]
+livekit = ["cachetools (>=5.0.0)", "livekit-agents (>=1.6)", "opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http (>=1.30.0)", "opentelemetry-sdk (>=1.30.0)"]
 openai-agents = ["openai-agents (>=0.0.3)"]
+openai-realtime = ["openai (>=1.50)", "openai-agents (>=0.0.3)"]
 otel = ["opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http (>=1.30.0)", "opentelemetry-sdk (>=1.30.0)"]
+pipecat = ["cachetools (>=5.0.0)", "opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http (>=1.30.0)", "opentelemetry-sdk (>=1.30.0)", "pipecat-ai (>=1.0) ; python_version >= \"3.11\""]
 pytest = ["pytest (>=7.0.0)", "rich (>=13.9.4)", "vcrpy (>=7.0.0)"]
-sandbox = ["websockets (>=15.0)"]
 strands-agents = ["opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http (>=1.30.0)", "opentelemetry-sdk (>=1.30.0)", "strands-agents (>=0.1.0)", "strands-agents-tools (>=0.2.0)"]
 vcr = ["vcrpy (>=7.0.0)"]
 
@@ -4758,6 +4827,19 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+description = "Verify certificates using native system trust stores"
+optional = false
+python-versions = ">=3.10"
+groups = ["main", "test", "test-integration"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
+]
+
+[[package]]
 name = "types-requests"
 version = "2.31.0.6"
 description = "Typing stubs for requests"
@@ -4981,28 +5063,28 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "wcmatch"
-version = "10.1"
+version = "11.0.1"
 description = "Wildcard/glob file name matcher."
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "python_version >= \"3.11\" and python_version < \"3.14\" and extra == \"deepagents\""
 files = [
-    {file = "wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a"},
-    {file = "wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af"},
+    {file = "wcmatch-11.0.1-py3-none-any.whl", hash = "sha256:fd149ecddb9f0a88ea780017d6dde17c994e494e7f7303d4e3c9d6251f978f4b"},
+    {file = "wcmatch-11.0.1.tar.gz", hash = "sha256:1ea2b4fa678b8ca268253798d5963935df39132d47c3e241c0a0732224005e7d"},
 ]
 
 [package.dependencies]
-bracex = ">=2.1.1"
+bracex = ">=3.0"
 
 [[package]]
 name = "websockets"
 version = "16.0"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
-optional = true
+optional = false
 python-versions = ">=3.10"
-groups = ["main"]
-markers = "python_version >= \"3.11\" and python_version < \"3.14\" and extra == \"deepagents\""
+groups = ["main", "test", "test-integration"]
+markers = "python_version >= \"3.10\""
 files = [
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a"},
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0"},
@@ -5601,4 +5683,4 @@ deepagents = ["deepagents", "langchain-oracledb", "langgraph-oracledb", "opensea
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "9aebd96c8d65d23baf65a40c26d2bc17cf75bf1d54b412ba04afc32fb5a557b6"
+content-hash = "eba39a890edfdce3aa3f63bad37e22b5421f66658e98456e16257a4ff6f0ac7d"

--- a/libs/oci/pyproject.toml
+++ b/libs/oci/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
 # Deepagents agent with all datastores
 deepagents = [
     # deepagents requires Python 3.11+; Python 3.14 not yet tested
-    "deepagents>=0.6.1; python_version >= '3.11' and python_version < '3.14'",
+    # 0.7 removed backend factories: pass StateBackend()/StoreBackend(...) instances
+    "deepagents>=0.7.0; python_version >= '3.11' and python_version < '3.14'",
     # 1.3.0 ships chunk_text/extract_doc_id and the OracleVS.add_documents
     # text_splitter kwarg used by the ADB chunk_on_write path.
     "langchain-oracledb>=1.3.0",

--- a/libs/oci/tests/integration_tests/agents/test_deepagents_integration.py
+++ b/libs/oci/tests/integration_tests/agents/test_deepagents_integration.py
@@ -943,7 +943,7 @@ class TestDeepAgentBackend:
 
         agent = create_deepagents_agent(
             tools=[search_knowledge_base],
-            backend=StateBackend,
+            backend=StateBackend(),
             **_make_oci_kwargs(),
         )
         try:
@@ -966,7 +966,7 @@ class TestDeepAgentBackend:
         store = InMemoryStore()
         agent = create_deepagents_agent(
             tools=[search_knowledge_base],
-            backend=lambda rt: StoreBackend(rt),
+            backend=StoreBackend(namespace=lambda rt: ("agent-files",)),
             store=store,
             checkpointer=MemorySaver(),
             **_make_oci_kwargs(),
@@ -982,15 +982,16 @@ class TestDeepAgentBackend:
         finally:
             _cleanup_agent(agent)
 
-    def test_backend_factory_lambda(self) -> None:
-        """Test backend as a lambda factory (common user pattern)."""
+    def test_composite_backend_explicit(self) -> None:
+        """Test a CompositeBackend instance (deepagents>=0.7 removed factories)."""
+        from deepagents.backends import CompositeBackend
         from deepagents.backends.state import StateBackend
 
         from langchain_oci import create_deepagents_agent
 
         agent = create_deepagents_agent(
             tools=[search_knowledge_base],
-            backend=lambda rt: StateBackend(rt),
+            backend=CompositeBackend(default=StateBackend(), routes={}),
             **_make_oci_kwargs(),
         )
         try:
@@ -1266,7 +1267,7 @@ class TestDeepAgentAllParamsCombined:
         store = InMemoryStore()
         agent = create_deepagents_agent(
             tools=[search_knowledge_base, get_statistics],
-            backend=lambda rt: StoreBackend(rt),
+            backend=StoreBackend(namespace=lambda rt: ("agent-files",)),
             store=store,
             cache=InMemoryCache(),
             checkpointer=MemorySaver(),

--- a/libs/oci/tests/integration_tests/agents/test_deepagents_integration.py
+++ b/libs/oci/tests/integration_tests/agents/test_deepagents_integration.py
@@ -221,8 +221,13 @@ class TestDeepAgentCompatibilityIntegration:
 
         schema = agent.output_schema
 
-        assert "messages" in schema.model_fields
-        assert "structured_response" in schema.model_fields
+        # `output_schema` is typed as a pydantic v2 *or* v1 model class in
+        # recent langgraph; read the field names in a version-agnostic way.
+        fields = getattr(schema, "model_fields", None) or getattr(
+            schema, "__fields__", {}
+        )
+        assert "messages" in fields
+        assert "structured_response" in fields
 
     @pytest.mark.xfail(
         reason=(

--- a/libs/oci/tests/integration_tests/agents/test_react_integration.py
+++ b/libs/oci/tests/integration_tests/agents/test_react_integration.py
@@ -261,7 +261,7 @@ class TestOCIReactAgentIntegration:
         "meta.llama-4-scout-17b-16e-instruct",
         "meta.llama-3.3-70b-instruct",
         "cohere.command-a-03-2025",
-        "xai.grok-3-mini-fast",
+        "xai.grok-4.20",
         "google.gemini-2.5-flash-lite",
     ],
 )
@@ -314,7 +314,7 @@ def test_multi_model_tool_calling(model_id: str) -> None:
         "meta.llama-4-scout-17b-16e-instruct",
         "meta.llama-3.3-70b-instruct",
         "cohere.command-a-03-2025",
-        "xai.grok-3-mini-fast",
+        "xai.grok-4.20",
         "google.gemini-2.5-flash-lite",
     ],
 )


### PR DESCRIPTION
Two groups of integration tests on `main` fail for reasons unrelated to the code under test, which makes every live run look worse than it is.

**deepagents 0.7 removed backend factories.** `TestDeepAgentBackend` (3 tests) and `TestDeepAgentAllParamsCombined` still pass the `StateBackend` class or `lambda rt: StoreBackend(rt)` factories and fail with `TypeError: backend must be an initialized backend instance. Backend factories were removed in deepagents 0.7`. They now pass `StateBackend()`, `StoreBackend(namespace=...)`, and an explicit `CompositeBackend` in place of the factory-lambda case. The `deepagents` extra floor moves from 0.6.1 to 0.7.0 to match what the tests and the docs (#289) describe; lock regenerated.

**`xai.grok-3-mini-fast` is no longer served on-demand** (404 from the service, model still listed in the catalog), so `test_multi_model_tool_calling` and `test_multi_model_support` carried a guaranteed failure. Replaced with `xai.grok-4.20`, which is served.

Verification: all six affected tests pass live against OCI GenAI (us-chicago-1) with deepagents 0.7.13; `ruff check` and `ruff format` clean.
