### PR TITLE
docs(js): session-auth switch for the RAG sample; structured-output naming note

### DIFF
--- a/libs/js/langchain-oracledb/samples/rag_pipeline/README.md
+++ b/libs/js/langchain-oracledb/samples/rag_pipeline/README.md
@@ -18,6 +18,7 @@ Here are the environment variables to be set:
 | `OCI_ENDPOINT` | OCI Generative AI inference endpoint | `https://inference.generativeai.us-phoenix-1.oci.oraclecloud.com` |
 | `OCI_CONFIG_FILE` | Path to the OCI configuration file used by `ConfigFileAuthenticationDetailsProvider` | `~/.oci/config` |
 | `OCI_CONFIG_PROFILE` | OCI configuration profile used for authentication | `DEFAULT` |
+| `OCI_AUTH_TYPE` | `ConfigFile` for API-key auth from the config file, or `Session` for a profile with a `security_token_file` (created by `oci session authenticate`) | `ConfigFile` |
 | `OCI_MAX_TOKENS` | Maximum number of tokens the model may generate | `1000` |
 | `RESET_VECTOR_STORE` | `true` rebuilds the vector table from `DOCUMENTS_FOLDER`; `false` reuses the existing table without re-ingesting | `true` |
 

--- a/libs/js/langchain-oracledb/samples/rag_pipeline/oracle-rag-full-pipeline.ts
+++ b/libs/js/langchain-oracledb/samples/rag_pipeline/oracle-rag-full-pipeline.ts
@@ -27,6 +27,7 @@ type OciChatConfig = {
   endpoint: string;
   configFile: string;
   profile: string;
+  authType: OciGenAiNewClientAuthType;
 };
 
 type RagConfig = {
@@ -45,12 +46,30 @@ function resolvePath(filePath: string): string {
   return path.resolve(filePath);
 }
 
+/**
+ * Map OCI_AUTH_TYPE to the langchain-oci auth type. "ConfigFile" (default) is
+ * API-key auth from the config file; "Session" uses the profile's
+ * security_token_file (e.g. a profile created by `oci session authenticate`).
+ */
+function resolveAuthType(value: string | undefined): OciGenAiNewClientAuthType {
+  const normalized = (value ?? "ConfigFile").trim().toLowerCase();
+  if (normalized === "configfile" || normalized === "config_file") {
+    return OciGenAiNewClientAuthType.ConfigFile;
+  }
+  if (normalized === "session" || normalized === "security_token") {
+    return OciGenAiNewClientAuthType.Session;
+  }
+  throw new Error(
+    `Unsupported OCI_AUTH_TYPE "${value}". Use "ConfigFile" or "Session".`,
+  );
+}
+
 function getOciClient(config: OciChatConfig): OciGenAiGenericChat {
   return new OciGenAiGenericChat({
     compartmentId: config.compartmentId,
     onDemandModelId: config.modelId,
     newClientParams: {
-      authType: OciGenAiNewClientAuthType.ConfigFile,
+      authType: config.authType,
       serviceEndpoint: config.endpoint,
       authParams: {
         clientConfigFilePath: resolvePath(config.configFile),
@@ -361,6 +380,7 @@ async function runCompleteRagPipeline() {
       "https://inference.generativeai.us-phoenix-1.oci.oraclecloud.com",
     configFile: process.env.OCI_CONFIG_FILE || "~/.oci/config",
     profile: process.env.OCI_CONFIG_PROFILE || "DEFAULT",
+    authType: resolveAuthType(process.env.OCI_AUTH_TYPE),
   };
 
   const ragConfig: RagConfig = {

--- a/libs/js/oci/README.md
+++ b/libs/js/oci/README.md
@@ -372,6 +372,17 @@ Use structured output when the application needs model responses that conform to
 function calling. LangChain `jsonMode`, `jsonSchema`, and `strict`
 structured-output options are not implemented by this adapter.
 
+Structured output is implemented by binding one function named after the
+schema (or `extract` when the schema has no name) and forcing the model to
+call it. If your schema has a top-level field literally called `name`, pass an
+explicit function name so smaller models do not confuse the two:
+
+```ts
+const structuredModel = model.withStructuredOutput(personSchema, {
+  name: "extract_person",
+});
+```
+
 ## Embeddings
 
 `OciGenAiEmbeddings` provides text embeddings through OCI's `embedText` API.


### PR DESCRIPTION
Two small follow-ups from the #301 and #303 reviews.

**RAG sample: `OCI_AUTH_TYPE`.** The sample hardcoded `OciGenAiNewClientAuthType.ConfigFile`, so it could only run with API-key credentials. A new `OCI_AUTH_TYPE` env var (`ConfigFile`, the default, or `Session`) selects the auth type, which lets the sample run with a profile created by `oci session authenticate`. Unknown values fail fast with a clear error. README table updated.

**libs/js/oci README: structured output naming.** `withStructuredOutput` binds a function named after the schema, or `extract` when the schema has no name. When the schema has a top-level field literally called `name`, Llama 3.3 was observed filling that field with the function name; GPT-4o was not. The README now recommends passing an explicit `name` in that case.

Verification: the sample type-checks and runs end to end with `OCI_AUTH_TYPE=Session` against Oracle AI Database 26ai Free and OCI GenAI (ingestion, IVF index, retrieval, cited answer from `xai.grok-4.20`); an invalid `OCI_AUTH_TYPE` is rejected with the intended message; `pnpm format:check` passes for the README.
