### PR TITLE
feat(oci): expose token log probabilities in ChatOCIGenAI

### DIFF
--- a/libs/oci/README.md
+++ b/libs/oci/README.md
@@ -366,6 +366,35 @@ llm_with_tools = llm.bind_tools(
 <sub>**Note:** Parallel tool calling is only supported for Llama 4+ models. Llama 3.x (including 3.3) and Cohere models will raise an error if this parameter is used.</sub>
 
 
+### 7. Token Log Probabilities
+
+Generic-API models (Meta Llama, OpenAI, and others that return them) can
+report per-token log probabilities. Pass the same `logprobs` / `top_logprobs`
+model kwargs `ChatOpenAI` uses; they map to the OCI request's `log_probs`
+(`top_logprobs=N` returns the N most likely tokens per position, `logprobs=True`
+alone returns one). The result is on `response_metadata["logprobs"]` with
+`tokens`, `token_logprobs`, `top_logprobs` (list of `{token: logprob}` dicts)
+and `text_offset`:
+
+```python
+from langchain_oci import ChatOCIGenAI
+
+llm = ChatOCIGenAI(
+    model_id="meta.llama-3.3-70b-instruct",
+    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+    compartment_id="MY_COMPARTMENT_ID",
+    model_kwargs={"logprobs": True, "top_logprobs": 2},
+)
+response = llm.invoke("Say hi")
+print(response.response_metadata["logprobs"]["top_logprobs"][0])
+# {'Hi': -0.02, 'Hello': -3.9}
+```
+
+Notes: log probabilities are returned for `invoke`/`ainvoke` only (the service
+does not include them in streaming events); some models do not produce them
+(xAI Grok returns none), in which case the key is simply absent; Cohere models
+have no log-probability option and raise a `ValueError` if you request them.
+
 ## Deepagents + Datastores (Integration Points)
 
 The deepagents integration in `langchain-oci` is built around datastore adapters (`ADB`, `OpenSearch`) and auto-generated tools (`stats`, hybrid `search`, `get_document`).

--- a/libs/oci/langchain_oci/chat_models/async_mixin.py
+++ b/libs/oci/langchain_oci/chat_models/async_mixin.py
@@ -18,6 +18,7 @@ from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, Tool
 from langchain_core.messages.ai import UsageMetadata
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 
+from langchain_oci.chat_models.providers.generic import normalize_logprobs
 from langchain_oci.common.async_support import OCIAsyncClient, OCIAsyncRequestError
 from langchain_oci.common.param_compat import (
     PARAM_RETRY_ATTEMPTS,
@@ -319,6 +320,12 @@ class ChatOCIGenAIAsyncMixin:
             "finish_reason": chat_response.get("finishReason"),
         }
 
+        # Token log probabilities (Generic API; requested via logprobs/top_logprobs)
+        choices = chat_response.get("choices") or []
+        if choices and isinstance(choices[0], dict):
+            logprobs = normalize_logprobs(choices[0].get("logprobs"))
+            if logprobs is not None:
+                info["logprobs"] = logprobs
         # Cohere-specific fields
         if "documents" in chat_response:
             info["documents"] = chat_response["documents"]

--- a/libs/oci/langchain_oci/chat_models/providers/cohere.py
+++ b/libs/oci/langchain_oci/chat_models/providers/cohere.py
@@ -78,8 +78,26 @@ class CohereProvider(Provider):
         self.chat_api_format_v2 = None
 
     def normalize_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """Normalize parameters. Returns params unchanged for Cohere."""
-        return params
+        """Normalize parameters for Cohere.
+
+        Cohere chat requests on OCI Generative AI have no log-probability
+        option, so ``logprobs`` / ``top_logprobs`` / ``log_probs`` raise a
+        clear error instead of being silently dropped. ``logprobs=False`` is
+        accepted and removed.
+        """
+        result = dict(params)
+        requested = {
+            key: result.pop(key)
+            for key in ("logprobs", "top_logprobs", "log_probs")
+            if key in result
+        }
+        if any(v for v in requested.values()):
+            raise ValueError(
+                "Cohere models on OCI Generative AI do not support logprobs; "
+                "remove logprobs/top_logprobs or use a Generic-API model "
+                "(e.g. meta.llama-*, openai.*, xai.*)."
+            )
+        return result
 
     def _load_v2_classes(self) -> None:
         """Lazy load Cohere V2 API classes for vision support.

--- a/libs/oci/langchain_oci/chat_models/providers/generic.py
+++ b/libs/oci/langchain_oci/chat_models/providers/generic.py
@@ -109,6 +109,78 @@ def _should_allow_more_tool_calls(
     return True
 
 
+def normalize_logprobs_params(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Map LangChain-style ``logprobs`` / ``top_logprobs`` to OCI ``log_probs``.
+
+    ``ChatOpenAI`` and ``ChatOCIModelDeployment*`` accept ``logprobs`` (bool)
+    and ``top_logprobs`` (int). The OCI Generic chat request has a single
+    integer, ``log_probs``: the number of most-likely tokens to return per
+    position, alongside the chosen token's log probability. The mapping is:
+
+    - ``top_logprobs=N`` -> ``log_probs=N`` (requires ``logprobs`` not False)
+    - ``logprobs=True`` (no ``top_logprobs``) -> ``log_probs=1``
+    - ``logprobs=False`` / ``None`` -> nothing is sent
+
+    An explicit ``log_probs`` passes through untouched.
+    """
+    result = dict(params)
+    logprobs = result.pop("logprobs", None)
+    top_logprobs = result.pop("top_logprobs", None)
+    if top_logprobs is not None:
+        if logprobs is False:
+            raise ValueError("top_logprobs was set but logprobs is False.")
+        result.setdefault("log_probs", int(top_logprobs))
+    elif logprobs:
+        result.setdefault("log_probs", 1)
+    return result
+
+
+def normalize_logprobs(raw: Any) -> Optional[Dict[str, Any]]:
+    """Normalise OCI logprobs (SDK ``Logprobs`` object or JSON dict) to one dict.
+
+    Returns ``{"tokens", "token_logprobs", "top_logprobs", "text_offset"}``
+    with snake_case keys and numeric values, or ``None`` when absent. The
+    JSON form (async transport, streaming) uses camelCase keys and encodes
+    ``topLogprobs`` values as strings; both are converted.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        tokens = raw.get("tokens")
+        token_logprobs = raw.get("token_logprobs", raw.get("tokenLogprobs"))
+        top_logprobs = raw.get("top_logprobs", raw.get("topLogprobs"))
+        text_offset = raw.get("text_offset", raw.get("textOffset"))
+    else:
+        tokens = getattr(raw, "tokens", None)
+        token_logprobs = getattr(raw, "token_logprobs", None)
+        top_logprobs = getattr(raw, "top_logprobs", None)
+        text_offset = getattr(raw, "text_offset", None)
+    if tokens is None and token_logprobs is None and top_logprobs is None:
+        return None
+
+    def _num(value: Any) -> Any:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return value
+
+    return {
+        "tokens": list(tokens) if tokens is not None else None,
+        "token_logprobs": (
+            [_num(v) for v in token_logprobs] if token_logprobs is not None else None
+        ),
+        "top_logprobs": (
+            [
+                {str(k): _num(v) for k, v in (entry or {}).items()}
+                for entry in top_logprobs
+            ]
+            if top_logprobs is not None
+            else None
+        ),
+        "text_offset": list(text_offset) if text_offset is not None else None,
+    }
+
+
 class GenericProvider(Provider):
     """Provider for models using generic API spec."""
 
@@ -119,7 +191,7 @@ class GenericProvider(Provider):
 
         Subclasses can override for provider-specific transformations.
         """
-        return params
+        return normalize_logprobs_params(params)
 
     @property
     def supports_tool_choice(self) -> bool:
@@ -326,11 +398,25 @@ class GenericProvider(Provider):
                 response.data.chat_response.usage.total_tokens
             )
 
+        # Token log probabilities, when requested via logprobs/top_logprobs.
+        if choices:
+            logprobs = normalize_logprobs(getattr(choices[0], "logprobs", None))
+            if logprobs is not None:
+                generation_info["logprobs"] = logprobs
         return generation_info
 
     def chat_stream_generation_info(self, event_data: Dict) -> Dict[str, Any]:
-        """Extract generation metadata from Meta chat stream event."""
-        return {"finish_reason": event_data["finishReason"]}
+        """Extract generation metadata from a Generic chat stream event.
+
+        The service does not currently include log probabilities in streaming
+        events even when ``log_probs`` is requested; if it ever does, they are
+        surfaced under ``logprobs`` in the same normalised shape as invoke.
+        """
+        info: Dict[str, Any] = {"finish_reason": event_data["finishReason"]}
+        logprobs = normalize_logprobs(event_data.get("logprobs"))
+        if logprobs is not None:
+            info["logprobs"] = logprobs
+        return info
 
     def chat_stream_to_reasoning(self, event_data: Dict) -> str:
         """Extract incremental reasoning text from a Generic stream event.
@@ -1096,7 +1182,7 @@ class OpenAIProvider(GenericProvider):
         elif "max_tokens" in result and "max_completion_tokens" in result:
             # Both provided - prefer the OpenAI-native key and drop the legacy one
             result.pop("max_tokens")
-        return result
+        return super().normalize_params(result)
 
 
 def _to_gemini_compatible_schema(schema: Any) -> Any:

--- a/libs/oci/tests/unit_tests/chat_models/test_logprobs.py
+++ b/libs/oci/tests/unit_tests/chat_models/test_logprobs.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""logprobs / top_logprobs support in ChatOCIGenAI (issue #265)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from langchain_oci.chat_models.oci_generative_ai import ChatOCIGenAI
+from langchain_oci.chat_models.providers.cohere import CohereProvider
+from langchain_oci.chat_models.providers.generic import (
+    GenericProvider,
+    OpenAIProvider,
+    normalize_logprobs,
+    normalize_logprobs_params,
+)
+
+
+class TestNormalizeLogprobsParams:
+    def test_logprobs_true_requests_one_top_token(self) -> None:
+        assert normalize_logprobs_params({"logprobs": True}) == {"log_probs": 1}
+
+    def test_top_logprobs_sets_count(self) -> None:
+        assert normalize_logprobs_params({"logprobs": True, "top_logprobs": 3}) == {
+            "log_probs": 3
+        }
+        assert normalize_logprobs_params({"top_logprobs": 2}) == {"log_probs": 2}
+
+    def test_false_or_absent_sends_nothing(self) -> None:
+        assert normalize_logprobs_params({"logprobs": False, "max_tokens": 5}) == {
+            "max_tokens": 5
+        }
+        assert normalize_logprobs_params({"max_tokens": 5}) == {"max_tokens": 5}
+
+    def test_top_logprobs_with_logprobs_false_is_an_error(self) -> None:
+        with pytest.raises(ValueError, match="top_logprobs"):
+            normalize_logprobs_params({"logprobs": False, "top_logprobs": 2})
+
+    def test_explicit_log_probs_passes_through(self) -> None:
+        assert normalize_logprobs_params({"log_probs": 4, "logprobs": True}) == {
+            "log_probs": 4
+        }
+
+    def test_generic_and_openai_providers_apply_mapping(self) -> None:
+        assert GenericProvider().normalize_params({"logprobs": True}) == {
+            "log_probs": 1
+        }
+        assert OpenAIProvider().normalize_params(
+            {"max_tokens": 9, "logprobs": True, "top_logprobs": 2}
+        ) == {"max_completion_tokens": 9, "log_probs": 2}
+
+    def test_cohere_rejects_logprobs_clearly(self) -> None:
+        with pytest.raises(ValueError, match="Cohere .* do not support logprobs"):
+            CohereProvider().normalize_params({"logprobs": True})
+        with pytest.raises(ValueError, match="Cohere"):
+            CohereProvider().normalize_params({"log_probs": 2})
+        # logprobs=False is a no-op, not an error
+        assert CohereProvider().normalize_params({"logprobs": False, "k": 1}) == {
+            "k": 1
+        }
+
+
+class TestNormalizeLogprobs:
+    def test_sdk_object(self) -> None:
+        raw = SimpleNamespace(
+            tokens=["Hi", "!"],
+            token_logprobs=[-0.02, -0.03],
+            top_logprobs=[{"Hi": "-0.02", "Hello": "-3.9"}, {"!": "-0.03"}],
+            text_offset=[0, 2],
+        )
+        assert normalize_logprobs(raw) == {
+            "tokens": ["Hi", "!"],
+            "token_logprobs": [-0.02, -0.03],
+            "top_logprobs": [{"Hi": -0.02, "Hello": -3.9}, {"!": -0.03}],
+            "text_offset": [0, 2],
+        }
+
+    def test_camel_case_json(self) -> None:
+        raw = {
+            "tokens": ["Hi"],
+            "tokenLogprobs": [-0.5],
+            "topLogprobs": [{"Hi": "-0.5", "Hey": "-2.0"}],
+            "textOffset": [0],
+        }
+        out = normalize_logprobs(raw)
+        assert out is not None
+        assert out["token_logprobs"] == [-0.5]
+        assert out["top_logprobs"] == [{"Hi": -0.5, "Hey": -2.0}]
+        assert out["text_offset"] == [0]
+
+    def test_absent(self) -> None:
+        assert normalize_logprobs(None) is None
+        assert normalize_logprobs({}) is None
+        assert normalize_logprobs(SimpleNamespace()) is None
+
+
+def _llm() -> ChatOCIGenAI:
+    return ChatOCIGenAI(model_id="meta.llama-3.3-70b-instruct", client=MagicMock())
+
+
+class TestGenerationInfo:
+    def test_sync_response_surfaces_logprobs(self) -> None:
+        provider = GenericProvider()
+        choice = SimpleNamespace(
+            finish_reason="stop",
+            message=SimpleNamespace(reasoning_content=None),
+            logprobs=SimpleNamespace(
+                tokens=["a"],
+                token_logprobs=[-0.1],
+                top_logprobs=[{"a": "-0.1"}],
+                text_offset=[0],
+            ),
+        )
+        response = SimpleNamespace(
+            data=SimpleNamespace(
+                chat_response=SimpleNamespace(
+                    choices=[choice], time_created="t", usage=None
+                )
+            )
+        )
+        info = provider.chat_generation_info(response)
+        assert info["logprobs"]["tokens"] == ["a"]
+        assert info["logprobs"]["top_logprobs"] == [{"a": -0.1}]
+
+    def test_sync_response_without_logprobs_is_unchanged(self) -> None:
+        provider = GenericProvider()
+        choice = SimpleNamespace(finish_reason="stop", message=None, logprobs=None)
+        response = SimpleNamespace(
+            data=SimpleNamespace(
+                chat_response=SimpleNamespace(
+                    choices=[choice], time_created="t", usage=None
+                )
+            )
+        )
+        assert "logprobs" not in provider.chat_generation_info(response)
+
+    def test_stream_event_without_logprobs(self) -> None:
+        assert GenericProvider().chat_stream_generation_info(
+            {"finishReason": "stop"}
+        ) == {"finish_reason": "stop"}
+
+    def test_stream_event_with_logprobs_is_normalised(self) -> None:
+        info = GenericProvider().chat_stream_generation_info(
+            {
+                "finishReason": "stop",
+                "logprobs": {"tokens": ["x"], "tokenLogprobs": [-1]},
+            }
+        )
+        assert info["logprobs"]["token_logprobs"] == [-1.0]
+
+    def test_async_dict_response_surfaces_logprobs(self) -> None:
+        llm = _llm()
+        info = llm._extract_generation_info(
+            {
+                "chatResponse": {
+                    "finishReason": "stop",
+                    "choices": [
+                        {
+                            "message": {"content": [{"type": "TEXT", "text": "hi"}]},
+                            "logprobs": {
+                                "tokens": ["hi"],
+                                "tokenLogprobs": [-0.2],
+                                "topLogprobs": [{"hi": "-0.2"}],
+                            },
+                        }
+                    ],
+                }
+            }
+        )
+        assert info["logprobs"] == {
+            "tokens": ["hi"],
+            "token_logprobs": [-0.2],
+            "top_logprobs": [{"hi": -0.2}],
+            "text_offset": None,
+        }
+
+    def test_request_carries_log_probs(self) -> None:
+        llm = ChatOCIGenAI(
+            model_id="meta.llama-3.3-70b-instruct",
+            client=MagicMock(),
+            model_kwargs={"logprobs": True, "top_logprobs": 2},
+        )
+        request = llm._prepare_request(
+            [HumanMessage(content="hi")],
+            stop=None,
+            stream=False,
+        )
+        assert request.chat_request.log_probs == 2


### PR DESCRIPTION
Closes #265.

## What

`ChatOCIGenAI` now accepts the `logprobs` / `top_logprobs` model kwargs that `ChatOpenAI` and `ChatOCIModelDeployment*` already use, and returns the result on `response_metadata["logprobs"]`.

- **Request.** `top_logprobs=N` → OCI `log_probs=N`; `logprobs=True` alone → `log_probs=1`; `False`/absent → nothing sent; an explicit OCI `log_probs` passes through. Applied by `GenericProvider.normalize_params`; `OpenAIProvider` keeps it alongside its `max_tokens` rewrite.
- **Response.** `choice.logprobs` is normalised to `{"tokens", "token_logprobs", "top_logprobs", "text_offset"}` with float probabilities, from both the sync SDK object and the async JSON path (camelCase keys, string-encoded probabilities).
- **Cohere.** No log-probability option exists on Cohere requests, so `logprobs`/`top_logprobs`/`log_probs` raise a clear `ValueError` rather than being dropped silently; `logprobs=False` is a no-op.
- **Streaming.** Events are checked for `logprobs` and would be surfaced in the same shape, but the service does not include them in streaming events today. Documented in the README (new section 7).

## Verification

Live against OCI GenAI (us-chicago-1):

| Model | invoke | ainvoke | astream |
|---|---|---|---|
| meta.llama-3.3-70b-instruct | tokens + top-2 alternatives | same | works, no logprobs in events |
| openai.gpt-4o | tokens + top-2 alternatives | same | works, no logprobs in events |
| xai.grok-4.20 | service returns none, key absent | same | works |
| cohere.command-a-03-2025 | `ValueError` as designed | | |

Also: no `logprobs` key when not requested; explicit `log_probs=1` passthrough returns one alternative per token.

Unit: 16 new tests in `tests/unit_tests/chat_models/test_logprobs.py` (mapping, Cohere error, normalisation of SDK object and camelCase JSON, sync/async/stream generation info, request carries `log_probs`); full libs/oci unit suite 518 passed / 47 skipped; ruff, format and mypy clean.
